### PR TITLE
Use postgres for persistence in local and deployment environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ sonar-project.properties
 
 #Helm
 **/Chart.lock
+
+# local environment settings
+.env

--- a/README.md
+++ b/README.md
@@ -121,6 +121,19 @@ e.g. `values-dev.yaml`.
 There is also a `docker-compose.yml` that can be used to run a local instance of the template in docker and also an
 instance of HMPPS Auth (required if your service calls out to other services using a token).
 
+The docker-compose configuration defines a local postgres instance used for persistence. Before running services locally,
+define a `.env` file containing the password for the default `postgres` user:
+
+__.env__
+```properties
+POSTGRES_PASSWORD=your_local_dev_password
+```
+
+note this file is also loaded within the Spring boot `application-dev.yml` file so the password does not need to be repeated
+there.
+
+Run services with:
+
 ```bash
 docker compose pull && docker compose up
 ```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,8 +16,7 @@ dependencies {
 
   implementation("org.jetbrains.kotlin:kotlin-reflect")
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
-  runtimeOnly("com.h2database:h2")
-  // runtimeOnly("org.postgresql:postgresql")
+  runtimeOnly("org.postgresql:postgresql")
   implementation("com.googlecode.libphonenumber:libphonenumber:9.0.7")
 
   developmentOnly("org.springframework.boot:spring-boot-devtools")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,5 +29,21 @@ services:
       - SPRING_PROFILES_ACTIVE=dev
       - APPLICATION_AUTHENTICATION_UI_ALLOWLIST=0.0.0.0/0
 
+  postgres:
+    image: postgres:17.5
+    restart: always
+    networks:
+      - hmpps
+    container_name: postgres
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
 networks:
   hmpps:
+
+volumes:
+  pgdata:

--- a/helm_deploy/hmpps-esupervision-api/values.yaml
+++ b/helm_deploy/hmpps-esupervision-api/values.yaml
@@ -30,6 +30,13 @@ generic-service:
     hmpps-esupervision-api-application-insights:
       APPLICATIONINSIGHTS_CONNECTION_STRING: "APPLICATIONINSIGHTS_CONNECTION_STRING"
 
+    # postgres connection settings
+    hmpps-esupervision-rds-settings:
+      POSTGRES_ENDPOINT: "rds_instance_endpoint"
+      POSTGRES_USERNAME: "database_username"
+      POSTGRES_PASSWORD: "database_password"
+      POSTGRES_DATABASE: "database_name"
+
   allowlist:
     groups:
       - internal

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -2,11 +2,13 @@ hmpps-auth:
   url: "http://localhost:8090/auth"
 
 spring:
+  config:
+    import: "optional:file:.env[.properties]"
   datasource:
-    url: jdbc:h2:mem:esupervision;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
+    url: jdbc:postgresql://localhost:5432/postgres
+    driver-class-name: org.postgresql.Driver
+    username: postgres
+    password: ${POSTGRES_PASSWORD}
     hikari:
       maximum-pool-size: 10
       minimum-idle: 5
@@ -14,7 +16,7 @@ spring:
       connection-timeout: 30000
       pool-name: HikariPool-esupervision
   jpa:
-    database-platform: org.hibernate.dialect.H2Dialect
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
     show-sql: true
     hibernate:
       ddl-auto: update
@@ -22,10 +24,6 @@ spring:
       hibernate:
         format_sql: true
         use_sql_comments: true
-        dialect: org.hibernate.dialect.H2Dialect
+        dialect: org.hibernate.dialect.PostgreSQLDialect
         hbm2ddl:
           auto: update
-  h2:
-    console:
-      enabled: true
-      path: /h2-console

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,6 +24,31 @@ spring:
           hmpps-auth:
             token-uri: ${hmpps-auth.url}/oauth/token
 
+  datasource:
+    url: jdbc:postgresql://${POSTGRES_ENDPOINT}/${POSTGRES_DATABASE}
+    driver-class-name: org.postgresql.Driver
+    username: ${POSTGRES_USERNAME}
+    password: ${POSTGRES_PASSWORD}
+    hikari:
+      maximum-pool-size: 10
+      minimum-idle: 5
+      idle-timeout: 60000
+      connection-timeout: 30000
+      pool-name: HikariPool-esupervision
+
+  jpa:
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    show-sql: true
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+        use_sql_comments: true
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        hbm2ddl:
+          auto: update
+
 server:
   port: 8080
   servlet:


### PR DESCRIPTION
Add postgres container to docker-compose.yml and update dev config to use it.
Update service helm deployment to load RDS setting into the environment and configure the default application.yml file to connect to the configured database.
