### PR TITLE
Photo uploads using pre-signed S3 URLs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,9 @@ dependencies {
   implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
 
+  api("software.amazon.awssdk:s3")
+  implementation("software.amazon.awssdk:s3:2.31.63")
+
   implementation("org.jetbrains.kotlin:kotlin-reflect")
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   runtimeOnly("org.postgresql:postgresql")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:8080/auth/health"]
     environment:
       - SERVER_PORT=8080
-      - SPRING_PROFILES_ACTIVE=local
+      - SPRING_PROFILES_ACTIVE=dev,local
       - APPLICATION_AUTHENTICATION_UI_ALLOWLIST=0.0.0.0/0
 
   postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,19 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
 
+  localstack:
+    # LocalStack configuration: https://docs.localstack.cloud/references/configuration/
+    image: docker.io/localstack/localstack:4.5
+    container_name: localstack
+    ports:
+      - "127.0.0.1:4566:4566"            # LocalStack Gateway
+      - "127.0.0.1:4510-4559:4510-4559"  # external services port range
+    environment:
+      - DEBUG=${DEBUG:-0}
+    volumes:
+      - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+
 networks:
   hmpps:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:8080/auth/health"]
     environment:
       - SERVER_PORT=8080
-      - SPRING_PROFILES_ACTIVE=dev
+      - SPRING_PROFILES_ACTIVE=local
       - APPLICATION_AUTHENTICATION_UI_ALLOWLIST=0.0.0.0/0
 
   postgres:

--- a/docs/http/full-invite-flow.http
+++ b/docs/http/full-invite-flow.http
@@ -1,5 +1,4 @@
 ### Practitioner invites people to the app
-
 POST http://localhost:8080/offender_invites/
 Content-Type: application/json
 Authorization: Bearer {{hmpps_auth.pp}}
@@ -27,6 +26,7 @@ if (response.status === 200) {
 }
 %}
 
+
 ### Practitioner looks at status of created invites
 GET http://localhost:8080/offender_invites
 Authorization: Bearer {{hmpps_auth.pp}}
@@ -38,8 +38,9 @@ if (response.status == 200) {
 }
  %}
 
+
 ### Request upload location for the offender
-POST http://localhost:8080/offender_invites/upload_location?uuid={{invite.uuid}}&content-type=image/png
+POST http://localhost:8080/offender_invites/{{invite.uuid}}/upload_location?content-type=image/png
 Authorization: Bearer {{hmpps_auth.pop}}
 
 > {%
@@ -49,6 +50,7 @@ if (response.status === 200) {
 }
 %}
 
+
 ### "Attach" photo to the invite
 PUT {{invitePhotoUploadUrl}}
 Content-Type: image/png
@@ -57,14 +59,10 @@ Content-Type: image/png
 
 
 ### Offender confirms the invite
-POST http://localhost:8080/offender_invites/confirm
+POST http://localhost:8080/offender_invites/{{invite.uuid}}/confirm
 Authorization: Bearer {{hmpps_auth.pop}}
 Content-Type: multipart/form-data; boundary=WebAppBoundary
 
---WebAppBoundary
-Content-Disposition: form-data; name="inviteUuid"
-
-{{invite.uuid}}
 --WebAppBoundary
 Content-Disposition: form-data; name="info.firstName"
 
@@ -87,12 +85,14 @@ Content-Disposition: form-data: name="photoContentType"
 image/png
 --WebAppBoundary--
 
+
 ### Practitioner sees invite status on the dashboard
 GET http://localhost:8080/offender_invites
 Authorization: Bearer {{hmpps_auth.pp}}
 
+
 ### Practitioner approves invite -> offender record added
-POST http://localhost:8080/offender_invites/approve?uuid={{invite.uuid}}
+POST http://localhost:8080/offender_invites/{{invite.uuid}}/approve
 Authorization: Bearer {{hmpps_auth.pp}}
 
 

--- a/docs/http/full-invite-flow.http
+++ b/docs/http/full-invite-flow.http
@@ -38,6 +38,24 @@ if (response.status == 200) {
 }
  %}
 
+### Request upload location for the offender
+POST http://localhost:8080/offender_invites/upload_location?uuid={{invite.uuid}}&content-type=image/png
+Authorization: Bearer {{hmpps_auth.pop}}
+
+> {%
+if (response.status === 200) {
+    const uploadUrl = response.body["url"]
+    client.global.set("invitePhotoUploadUrl", uploadUrl)
+}
+%}
+
+### "Attach" photo to the invite
+PUT {{invitePhotoUploadUrl}}
+Content-Type: image/png
+
+< ./guy.png
+
+
 ### Offender confirms the invite
 POST http://localhost:8080/offender_invites/confirm
 Authorization: Bearer {{hmpps_auth.pop}}
@@ -64,10 +82,9 @@ Content-Disposition: form-data; name="info.email"
 
 barry@example.com
 --WebAppBoundary
-Content-Disposition: form-data; name="image"; filename="guy.png"
-Content-Type: image/png
+Content-Disposition: form-data: name="photoContentType"
 
-< ./guy.png
+image/png
 --WebAppBoundary--
 
 ### Practitioner sees invite status on the dashboard

--- a/docs/http/full-invite-flow.http
+++ b/docs/http/full-invite-flow.http
@@ -27,7 +27,7 @@ if (response.status === 200) {
 }
 %}
 
-###
+### Practitioner looks at status of created invites
 GET http://localhost:8080/offender_invites
 Authorization: Bearer {{hmpps_auth.pp}}
 Content-Type: application/json
@@ -64,7 +64,7 @@ Content-Disposition: form-data; name="info.email"
 
 barry@example.com
 --WebAppBoundary
-Content-Disposition: form-data; name="image"; filename="test.png"
+Content-Disposition: form-data; name="image"; filename="guy.png"
 Content-Type: image/png
 
 < ./guy.png

--- a/docs/interactions.md
+++ b/docs/interactions.md
@@ -31,10 +31,16 @@ sequenceDiagram
     participant Offender
     participant Frontend
     participant Backend
+    participant S3
         
     Offender->>Frontend: Open invite URL
     Frontend->>Backend: Validate invite URL
     Backend-->>Frontend: Invite valid
+    Frontend->>Backend: Get Photo Upload URL
+    Backend-->>Frontend: Return pre-signed URL
+    Frontend-->>Offender: Display photo upload UI
+    Offender->>Frontend: Upload photo
+    Frontend->>S3: Upload photo to pre-signed URL
     Frontend-->>Offender: Display registration form
     Offender->>Frontend: Fill registration form
     Frontend->>Backend: Submit registration data

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/AwsConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/AwsConfig.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.presigner.S3Presigner
+
+@Configuration
+@Profile("!test & !local")
+class AwsConfig {
+
+  @Value("\${aws.region-name}")
+  lateinit var region: String
+
+  @Bean
+  fun s3Client(): S3Client = S3Client.builder()
+    .region(Region.of(region))
+    .build()
+
+  @Bean
+  fun s3Presigner(): S3Presigner = S3Presigner.builder()
+    .region(Region.of(region))
+    .build()
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/LocalAwsConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/LocalAwsConfig.kt
@@ -14,7 +14,7 @@ import software.amazon.awssdk.services.s3.presigner.S3Presigner
 import java.net.URI
 
 @Configuration
-@Profile("local")
+@Profile("local | test")
 class LocalAwsConfig {
   @Value("\${aws.region-name}")
   lateinit var region: String

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/LocalAwsConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/LocalAwsConfig.kt
@@ -9,6 +9,8 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.S3Configuration
+import software.amazon.awssdk.services.s3.presigner.S3Presigner
 import java.net.URI
 
 @Configuration
@@ -30,6 +32,16 @@ class LocalAwsConfig {
       .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("any", "any")))
       .build()
   }
+
+  @Bean
+  fun s3Presigner(): S3Presigner = S3Presigner.builder()
+    .serviceConfiguration(
+      S3Configuration.builder()
+        .pathStyleAccessEnabled(true).build())
+    .endpointOverride(URI.create(endpointUrl))
+    .region(Region.of(region))
+    .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("any", "any")))
+    .build()
 
   companion object {
     val LOG = LoggerFactory.getLogger(this::class.java)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/LocalAwsConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/LocalAwsConfig.kt
@@ -14,7 +14,7 @@ import software.amazon.awssdk.services.s3.presigner.S3Presigner
 import java.net.URI
 
 @Configuration
-@Profile("dev")
+@Profile("local")
 class LocalAwsConfig {
   @Value("\${aws.region-name}")
   lateinit var region: String

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/LocalAwsConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/LocalAwsConfig.kt
@@ -37,7 +37,8 @@ class LocalAwsConfig {
   fun s3Presigner(): S3Presigner = S3Presigner.builder()
     .serviceConfiguration(
       S3Configuration.builder()
-        .pathStyleAccessEnabled(true).build())
+        .pathStyleAccessEnabled(true).build(),
+    )
     .endpointOverride(URI.create(endpointUrl))
     .region(Region.of(region))
     .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("any", "any")))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/LocalAwsConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/LocalAwsConfig.kt
@@ -1,0 +1,37 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.config
+
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
+import java.net.URI
+
+@Configuration
+@Profile("dev")
+class LocalAwsConfig {
+  @Value("\${aws.region-name}")
+  lateinit var region: String
+
+  @Value("\${aws.endpoint-url}")
+  lateinit var endpointUrl: String
+
+  @Bean
+  fun s3Client(): S3Client {
+    LOG.info("Creating S3 client endpoint={}", endpointUrl)
+    return S3Client.builder()
+      .endpointOverride(URI.create(endpointUrl))
+      .region(Region.of(region))
+      .forcePathStyle(true)
+      .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("any", "any")))
+      .build()
+  }
+
+  companion object {
+    val LOG = LoggerFactory.getLogger(this::class.java)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderDto.kt
@@ -11,8 +11,9 @@ data class OffenderDto(
   val dateOfBirth: LocalDate?,
   val status: OffenderStatus = OffenderStatus.INITIAL,
   val createdAt: Instant,
-//  val updatedAt: Instant,
+  // val updatedAt: Instant,
   val email: String? = null,
   val phoneNumber: String? = null,
-  val photoKey: String,
+  // not every context requires the photo URL, so we only include when needed
+  val photoUrl: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderDto.kt
@@ -14,4 +14,5 @@ data class OffenderDto(
 //  val updatedAt: Instant,
   val email: String? = null,
   val phoneNumber: String? = null,
+  val photoKey: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderInviteResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderInviteResource.kt
@@ -54,7 +54,7 @@ class OffenderInviteResource(
     return ResponseEntity.notFound().build()
   }
 
-  @PreAuthorize("hasRole('ROLE_ESUP_PRACTITIONER')")
+  @PreAuthorize("hasRole('ROLE_ESUPERVISION__ESUPERVISION_UI')")
   @Tag(name = "practitioner")
   @Operation(
     summary = "Returns a collection of invite records",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderInviteResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderInviteResource.kt
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.hmpps.esupervisionapi.offender
 
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -40,6 +42,11 @@ class OffenderInviteResource(
 ) {
 
   @PreAuthorize("hasRole('ROLE_ESUPERVISION__ESUPERVISION_UI')")
+  @Tag(name = "practitioner")
+  @Operation(
+    summary = "Returns a collection of invite records",
+    description = "The returned invites can be linked to any practitioner.",
+  )
   @GetMapping()
   fun getInvites(pageable: Pageable): ResponseEntity<OffenderInvitesDto> {
     //  val authentication = SecurityContextHolder.getContext().authentication
@@ -52,6 +59,12 @@ class OffenderInviteResource(
   }
 
   @PreAuthorize("hasRole('ROLE_ESUPERVISION__ESUPERVISION_UI')")
+  @Tag(name = "practitioner")
+  @Operation(
+    summary = "Creates and starts the invite process.",
+    description = """For each successfully created invite a notification will be scheduled (via specified contact method). 
+      When invite could not be created, `errorMessage` will be set.""",
+  )
   @PostMapping("/")
   fun createInvites(@RequestBody @Valid inviteInfo: InviteInfo): ResponseEntity<AggregateCreateInviteResult> {
     LOG.info("Creating offender invites")
@@ -63,6 +76,15 @@ class OffenderInviteResource(
   }
 
   @PreAuthorize("hasRole('ROLE_ESUPERVISION__ESUPERVISION_UI')")
+  @Tag(name = "offender")
+  @Operation(
+    summary = "Confirm the invite on behalf the offender",
+    description = """This step requires that a photo was uploaded (see `/offender_invites/upload_location`)
+      and the submitted information matches the information in the invite record. 
+      Once confirmed, the practitioner will need to approve the submission (e.g. the photo) 
+      via `/offender_invites/approve`.
+    """,
+  )
   @PostMapping("/confirm")
   fun confirmInvite(
     @ModelAttribute confirmationInfo: OffenderInviteConfirmation,
@@ -90,6 +112,12 @@ class OffenderInviteResource(
   }
 
   @PreAuthorize("hasRole('ROLE_ESUPERVISION__ESUPERVISION_UI')")
+  @Tag(name = "practitioner")
+  @Operation(
+    summary = "Approve the invite and add offender to the system",
+    description = """To be called on behalf the practitioner when data supplied by the offender confirms their identity.
+    Once approved, the practitioner will be able to schedule "checkins." """,
+  )
   @PostMapping("/approve")
   fun approveInvite(@RequestParam uuid: UUID): ResponseEntity<Map<String, String>> {
     // TODO: settle on return value
@@ -111,7 +139,7 @@ class OffenderInviteResource(
     )
   }
 
-  @PreAuthorize("hasRole('ROLE_ESUP_OFFENDER')")
+  @PreAuthorize("hasRole('ROLE_ESUPERVISION__ESUPERVISION_UI')")
   @PostMapping("/upload_location")
   fun invitePhotoUploadLocation(
     @RequestParam uuid: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderInviteResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderInviteResource.kt
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
+import software.amazon.awssdk.services.s3.model.S3Exception
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.invite.InviteInfo
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.invite.OffenderInviteConfirmation
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.invite.OffenderInviteDto
@@ -85,13 +86,18 @@ class OffenderInviteResource(private val offenderInviteService: OffenderInviteSe
       return ResponseEntity.badRequest().body(ConfirmationResultDto(error = "Invite not found"))
     }
 
-    val updatedInvite = offenderInviteService.confirmOffenderInvite(confirmationInfo, image)
-    if (updatedInvite.isEmpty) {
-      // the invite status changed already, we did not perform an update
-      return ResponseEntity.badRequest().body(ConfirmationResultDto(error = "Could not confirm offender invite"))
-    }
+    try {
+      val updatedInvite = offenderInviteService.confirmOffenderInvite(confirmationInfo, image)
+      if (updatedInvite.isEmpty) {
+        // the invite status changed already, we did not perform an update
+        return ResponseEntity.badRequest().body(ConfirmationResultDto(error = "Could not confirm offender invite"))
+      }
 
-    return ResponseEntity.ok(ConfirmationResultDto())
+      return ResponseEntity.ok(ConfirmationResultDto())
+    } catch (e: S3Exception) {
+      LOG.warn("confirmInvite(invite={}), S3 failure: {}", confirmationInfo.inviteUuid, e.message)
+      throw e
+    }
   }
 
   @PreAuthorize("hasRole('ROLE_ESUPERVISION__ESUPERVISION_UI')")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderInviteResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderInviteResource.kt
@@ -44,20 +44,6 @@ class OffenderInviteResource(private val offenderInviteService: OffenderInviteSe
       pagination = Pagination(pageNumber = 0, pageSize = 20),
       content = page,
     )
-//    val result = OffenderInvitesDto(
-//      pagination = page.pageable.toPagination(),
-//      content = page.content.map { OffenderInviteDto(
-//        it.uuid,
-//        status = it.status,
-//        practitionerUuid = it.practitioner.uuid,
-//        info = OffenderInfo(
-//          firstName = it.firstName,
-//          lastName = it.lastName,
-//          email = it.email,
-//          phoneNumber = it.phoneNumber,
-//          dateOfBirth = it.dateOfBirth,
-//        )) }
-//    )
     return ResponseEntity.ok(result)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderInviteService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderInviteService.kt
@@ -225,8 +225,11 @@ class OffenderInviteService(
    * Returns the invite only if it's status was updated.
    */
   @Transactional
-  fun confirmOffenderInvite(confirmation: OffenderInviteConfirmation): Optional<OffenderInvite> {
-    val inviteFound = offenderInviteRepository.findByUuid(confirmation.inviteUuid)
+  fun confirmOffenderInvite(
+    inviteUuid: UUID,
+    confirmation: OffenderInviteConfirmation,
+  ): Optional<OffenderInvite> {
+    val inviteFound = offenderInviteRepository.findByUuid(inviteUuid)
     if (inviteFound.isPresent) {
       val invite = inviteFound.get()
       // TODO: we should check for "SENT" here -

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderInviteService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderInviteService.kt
@@ -5,10 +5,8 @@ import com.google.i18n.phonenumbers.PhoneNumberUtil
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
-import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import org.springframework.web.multipart.MultipartFile
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.invite.InviteInfo
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.invite.OffenderInfo
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.invite.OffenderInviteConfirmation
@@ -34,7 +32,6 @@ fun OffenderInfo.asInviteInfo(practitioner: Practitioner, now: Instant, expiryDa
   practitioner = practitioner,
 )
 
-
 data class CreateInviteResult(
   val invite: OffenderInvite?,
   /**
@@ -44,7 +41,8 @@ data class CreateInviteResult(
   /**
    * Set only when an invite could not be created.
    */
-  val offenderInfo: OffenderInfo?)
+  val offenderInfo: OffenderInfo?,
+)
 data class AggregateCreateInviteResult(val results: List<CreateInviteResult>) {
   val importedRecords: Int
     get() = results.count { it.invite != null }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderRepository.kt
@@ -66,8 +66,6 @@ open class Offender(
   @ManyToOne(cascade = [CascadeType.ALL], fetch = FetchType.LAZY)
   @JoinColumn(name = "practitioner_id", referencedColumnName = "id", nullable = false)
   open var practitioner: Practitioner,
-  @Column("photo_key", nullable = false)
-  open var photoKey: String,
 ) : AEntity() {
   fun dto(): OffenderDto = OffenderDto(
     uuid = uuid,
@@ -78,7 +76,7 @@ open class Offender(
     email = email,
     phoneNumber = phoneNumber,
     createdAt = createdAt,
-    photoKey = photoKey,
+    photoUrl = null
   )
 }
 
@@ -133,14 +131,11 @@ open class OffenderInvite(
   @Enumerated(EnumType.STRING)
   // @Version
   open var status: OffenderInviteStatus = OffenderInviteStatus.CREATED,
-  @Column("photo_key", nullable = true)
-  open var photoKey: String?,
 ) : AEntity() {
   fun dto(): OffenderInviteDto = OffenderInviteDto(
     inviteUuid = uuid,
     practitionerUuid = practitioner.uuid,
     status = status,
-    photoKey = photoKey,
     info = OffenderInfo(
       firstName = firstName,
       lastName = lastName,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderRepository.kt
@@ -76,7 +76,7 @@ open class Offender(
     email = email,
     phoneNumber = phoneNumber,
     createdAt = createdAt,
-    photoUrl = null
+    photoUrl = null,
   )
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderRepository.kt
@@ -63,9 +63,11 @@ open class Offender(
   open var email: String? = null,
   @Column(name = "phone_number")
   open var phoneNumber: String? = null,
-//  @ManyToOne(cascade = [CascadeType.ALL], fetch = FetchType.LAZY)
-//  @JoinColumn(name = "practitioner_id", referencedColumnName = "id", nullable = false)
-//  open var practitioner: Practitioner,
+  @ManyToOne(cascade = [CascadeType.ALL], fetch = FetchType.LAZY)
+  @JoinColumn(name = "practitioner_id", referencedColumnName = "id", nullable = false)
+  open var practitioner: Practitioner,
+  @Column("photo_key", nullable = false)
+  open var photoKey: String,
 ) : AEntity() {
   fun dto(): OffenderDto = OffenderDto(
     uuid = uuid,
@@ -76,6 +78,7 @@ open class Offender(
     email = email,
     phoneNumber = phoneNumber,
     createdAt = createdAt,
+    photoKey = photoKey,
   )
 }
 
@@ -130,12 +133,14 @@ open class OffenderInvite(
   @Enumerated(EnumType.STRING)
   // @Version
   open var status: OffenderInviteStatus = OffenderInviteStatus.CREATED,
-  // TODO(rosado): photo url
+  @Column("photo_key", nullable = true)
+  open var photoKey: String?,
 ) : AEntity() {
   fun dto(): OffenderInviteDto = OffenderInviteDto(
     inviteUuid = uuid,
     practitionerUuid = practitioner.uuid,
     status = status,
+    photoKey = photoKey,
     info = OffenderInfo(
       firstName = firstName,
       lastName = lastName,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderResource.kt
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.hmpps.esupervisionapi.offender
 
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.data.domain.PageRequest
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
@@ -18,10 +20,11 @@ data class Offenders(
 @RequestMapping("/offenders", produces = ["application/json"])
 class OffenderResource(
   private val offenderService: OffenderService,
-  private val offenderRepository: OffenderRepository,
 ) {
 
   @PreAuthorize("hasRole('ROLE_ESUPERVISION__ESUPERVISION_UI')")
+  @Tag(name = "practitioner")
+  @Operation(summary = "Returns a collection of offender records")
   @GetMapping
   fun getOffenders(): ResponseEntity<Offenders> {
     val pageRequest = PageRequest.of(0, 20)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/invite/InviteInfo.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/invite/InviteInfo.kt
@@ -37,7 +37,6 @@ data class OffenderInviteDto(
  * To be supplied by the offender to confirm the invite.
  */
 data class OffenderInviteConfirmation(
-  val inviteUuid: UUID,
   val photoContentType: String,
   val info: OffenderInfo,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/invite/InviteInfo.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/invite/InviteInfo.kt
@@ -26,7 +26,10 @@ data class OffenderInviteDto(
   val inviteUuid: UUID,
   val practitionerUuid: UUID,
   val status: OffenderInviteStatus,
-  val photoKey: String? = null,
+  /**
+   * If set, it will be set to a pre-signed S3 URL
+   */
+  val photoUrl: String? = null,
   val info: OffenderInfo,
 )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/invite/InviteInfo.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/invite/InviteInfo.kt
@@ -35,6 +35,6 @@ data class OffenderInviteDto(
  */
 data class OffenderInviteConfirmation(
   val inviteUuid: UUID,
-  // val code: String
+  val photoContentType: String,
   val info: OffenderInfo,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/invite/InviteInfo.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/invite/InviteInfo.kt
@@ -26,6 +26,7 @@ data class OffenderInviteDto(
   val inviteUuid: UUID,
   val practitionerUuid: UUID,
   val status: OffenderInviteStatus,
+  val photoKey: String? = null,
   val info: OffenderInfo,
 )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/practitioner/PractitionerResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/practitioner/PractitionerResource.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.esupervisionapi.practitioner
 
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
@@ -14,6 +15,7 @@ import java.util.UUID
 class PractitionerResource(private val practitionerService: PractitionerService) {
 
   @PreAuthorize("hasRole('ROLE_ESUPERVISION__ESUPERVISION_UI')")
+  @Tag(name = "practitioner")
   @GetMapping("/{uuid}")
   fun getPractitioner(@PathVariable uuid: UUID): ResponseEntity<Practitioner> {
     val practitioner = practitionerService.getPractitionerByUuid(uuid)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/S3UploadService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/S3UploadService.kt
@@ -5,34 +5,92 @@ import org.springframework.stereotype.Service
 import org.springframework.web.multipart.MultipartFile
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
+import software.amazon.awssdk.services.s3.presigner.S3Presigner
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderInvite
+import java.net.URL
+import java.time.Duration
+import java.util.UUID
+
+/**
+ *
+ */
+data class InvitePhotoKey(
+  val invite: UUID,
+) {
+  fun asString(): String {
+    return "invite-${invite}"
+  }
+}
 
 @Service
 class S3UploadService(
   val s3uploadClient: S3Client,
+  val s3Presigner: S3Presigner,
   @Value("\${aws.s3.image-uploads}") private val imageUploadBucket: String,
 ) {
+
+  internal fun putObjectRequest(invite: OffenderInvite, contentType: String): PutObjectRequest {
+    val request = PutObjectRequest.builder()
+      .bucket(imageUploadBucket)
+      .key(InvitePhotoKey(invite.uuid).asString())
+      .contentType(contentType)
+      .build()
+    return request
+  }
 
   /**
    * Returns the uploaded object key on successful upload.
    */
   fun uploadInvitePhoto(invite: OffenderInvite, image: MultipartFile): String {
-    val ext = image.originalFilename?.substringAfterLast('.', "") ?: ""
-    val key = "invite-${invite.uuid}.$ext"
+    if (image.contentType != null) {
+      val request = putObjectRequest(invite, image.contentType!!)
+      s3uploadClient.putObject(
+        request,
+        RequestBody.fromInputStream(image.inputStream, image.size),
+      )
+      return request.key()
+    }
+    throw RuntimeException("file content type is null for file originalFileName='${image.originalFilename}'")
 
-    val request = PutObjectRequest.builder()
-      .bucket(imageUploadBucket)
-      .key(key)
-      .contentType(image.contentType)
-      .contentLength(image.size.toLong())
+  }
+
+  /**
+   * Generates a pre-signed URL for uploading a file to S3.
+   * @param invite The offender invite.
+   * @param contentType content type of the file - will be used to get file extension
+   * @param duration The expiration time for the pre-signed URL in minutes.
+   * @return A pre-signed URL for uploading the file.
+   */
+  fun generatePresignedUploadUrl(
+    invite: OffenderInvite,
+    contentType: String = "application/octet-stream",
+    duration: Duration
+  ): URL {
+    val putRequest = putObjectRequest(invite, contentType)
+    val presignRequest = PutObjectPresignRequest.builder()
+      .putObjectRequest(putRequest)
+      .signatureDuration(duration)
       .build()
 
-    s3uploadClient.putObject(
-      request,
-      RequestBody.fromInputStream(image.inputStream, image.size),
-    )
-
-    return key
+    return s3Presigner.presignPutObject(presignRequest).url()
   }
+
+  fun isInvitePhotoUploaded(invite: OffenderInvite): Boolean {
+    val request = HeadObjectRequest.builder()
+      .bucket(imageUploadBucket)
+      .key(InvitePhotoKey(invite.uuid).asString())
+      .build()
+
+    try {
+      s3uploadClient.headObject(request)
+      return true
+    } catch (e: NoSuchKeyException) {
+      return false
+    }
+  }
+
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/S3UploadService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/S3UploadService.kt
@@ -1,0 +1,38 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.utils
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import org.springframework.web.multipart.MultipartFile
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderInvite
+
+@Service
+class S3UploadService(
+  val s3uploadClient: S3Client,
+  @Value("\${aws.s3.image-uploads}") private val imageUploadBucket: String,
+) {
+
+  /**
+   * Returns the uploaded object key on successful upload.
+   */
+  fun uploadInvitePhoto(invite: OffenderInvite, image: MultipartFile): String {
+    val ext = image.originalFilename?.substringAfterLast('.', "") ?: ""
+    val key = "invite-${invite.uuid}.$ext"
+
+    val request = PutObjectRequest.builder()
+      .bucket(imageUploadBucket)
+      .key(key)
+      .contentType(image.contentType)
+      .contentLength(image.size.toLong())
+      .build()
+
+    s3uploadClient.putObject(
+      request,
+      RequestBody.fromInputStream(image.inputStream, image.size),
+    )
+
+    return key
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/S3UploadService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/S3UploadService.kt
@@ -21,9 +21,7 @@ import java.util.UUID
 data class InvitePhotoKey(
   val invite: UUID,
 ) {
-  fun asString(): String {
-    return "invite-${invite}"
-  }
+  fun asString(): String = "invite-$invite"
 }
 
 @Service
@@ -55,7 +53,6 @@ class S3UploadService(
       return request.key()
     }
     throw RuntimeException("file content type is null for file originalFileName='${image.originalFilename}'")
-
   }
 
   /**
@@ -68,7 +65,7 @@ class S3UploadService(
   fun generatePresignedUploadUrl(
     invite: OffenderInvite,
     contentType: String = "application/octet-stream",
-    duration: Duration
+    duration: Duration,
   ): URL {
     val putRequest = putObjectRequest(invite, contentType)
     val presignRequest = PutObjectPresignRequest.builder()
@@ -92,5 +89,4 @@ class S3UploadService(
       return false
     }
   }
-
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -27,3 +27,9 @@ spring:
         dialect: org.hibernate.dialect.PostgreSQLDialect
         hbm2ddl:
           auto: update
+
+aws:
+  endpoint-url: "http://localhost:4566"
+  s3:
+    image-uploads: hmpps-esupervision-image-uploads
+    video-uploads: hmpss-esupervision-video-uploads

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,20 +1,6 @@
-hmpps-auth:
-  url: "http://localhost:8090/auth"
-
 spring:
   config:
     import: "optional:file:.env[.properties]"
-  datasource:
-    url: jdbc:postgresql://localhost:5432/postgres
-    driver-class-name: org.postgresql.Driver
-    username: postgres
-    password: ${POSTGRES_PASSWORD}
-    hikari:
-      maximum-pool-size: 10
-      minimum-idle: 5
-      idle-timeout: 60000
-      connection-timeout: 30000
-      pool-name: HikariPool-esupervision
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     show-sql: true
@@ -28,8 +14,11 @@ spring:
         hbm2ddl:
           auto: update
 
+logging:
+  level:
+    org.springframework.web: INFO
+
 aws:
-  endpoint-url: "http://localhost:4566"
   s3:
     image-uploads: hmpps-esupervision-image-uploads
     video-uploads: hmpss-esupervision-video-uploads

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -48,6 +48,7 @@ spring:
         hbm2ddl:
           auto: update
 
+
 aws:
   endpoint-url: "http://localhost:4566"
   s3:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,55 @@
+hmpps-auth:
+  url: "http://localhost:8090/auth"
+
+management:
+  security:
+    enabled: false
+  health:
+    probes:
+      enabled: true
+    jms:
+      enabled: true
+  endpoints:
+    web:
+      base-path: /
+      exposure:
+        include: health,info
+  endpoint:
+    info:
+      enabled: true
+    health:
+      show-details: always
+      path-mapping: "health"
+
+spring:
+  config:
+    import: "optional:file:.env[.properties]"
+  datasource:
+    url: jdbc:postgresql://localhost:5432/postgres
+    driver-class-name: org.postgresql.Driver
+    username: postgres
+    password: ${POSTGRES_PASSWORD}
+    hikari:
+      maximum-pool-size: 10
+      minimum-idle: 5
+      idle-timeout: 60000
+      connection-timeout: 30000
+      pool-name: HikariPool-esupervision
+  jpa:
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    show-sql: true
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+        use_sql_comments: true
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        hbm2ddl:
+          auto: update
+
+aws:
+  endpoint-url: "http://localhost:4566"
+  s3:
+    image-uploads: hmpps-esupervision-image-uploads
+    video-uploads: hmpss-esupervision-video-uploads

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -80,3 +80,6 @@ management:
     info:
       cache:
         time-to-live: 2000ms
+
+aws:
+  region-name: eu-west-2

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -36,3 +36,10 @@ spring:
     console:
       enabled: true
       path: /h2-console
+
+aws:
+  region-name: eu-west-2
+  endpoint-url: "http://localhost:4566"
+  s3:
+    image-uploads: test-hmpps-esupervision-image-uploads
+    video-uploads: test-hmpss-esupervision-video-uploads


### PR DESCRIPTION
- Updates the flow to support the frontend's flow of uploading image as a separate step.
- The images are uploaded to S3 using pre-signed URLs. The frontend needs to request the URL by passing the invite uuid &  content type of the image (the frontend should have the content-type, and we don't want to deal with file extensions)

Note: all this currently works with localstack only. 
