### PR TITLE
Resolve GET URLs for video and photo uploads

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinRepository.kt
@@ -12,6 +12,7 @@ import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.practitioner.Practitioner
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.AEntity
+import uk.gov.justice.digital.hmpps.esupervisionapi.utils.ResourceLocator
 import java.time.Instant
 import java.util.Optional
 import java.util.UUID
@@ -59,18 +60,18 @@ open class OffenderCheckin(
   @Enumerated(EnumType.STRING)
   open var manualIdCheck: ManualIdVerificationResult?,
 ) : AEntity() {
-  fun dto(): OffenderCheckinDto = OffenderCheckinDto(
+  fun dto(resourceLocator: ResourceLocator): OffenderCheckinDto = OffenderCheckinDto(
     uuid = uuid,
     status = status,
     dueDate = dueDate,
-    offender = offender.dto(), // TODO: don't return whole dto, just the uuid
+    offender = offender.dto(resourceLocator), // TODO: don't return whole dto, just the uuid
     submittedOn = submittedAt,
     questions = questions,
     answers = answers,
     reviewedBy = reviewedBy?.uuid,
     createdBy = createdBy.uuid,
     createdAt = createdAt,
-    videoUrl = null,
+    videoUrl = resourceLocator.getCheckinVideo(uuid),
     autoIdCheck = autoIdCheck,
     manualIdCheck = manualIdCheck,
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinService.kt
@@ -30,7 +30,7 @@ class OffenderCheckinService(
 
   fun getCheckin(uuid: UUID): Optional<OffenderCheckinDto> {
     val checkin = checkinRepository.findByUuid(uuid)
-    return checkin.map { it.dto() }
+    return checkin.map { it.dto(this.s3UploadService) }
   }
 
   fun createCheckin(createCheckin: CreateCheckinRequest): OffenderCheckinDto {
@@ -68,7 +68,7 @@ class OffenderCheckinService(
     )
 
     val saved = checkinRepository.save(checkin)
-    return saved.dto()
+    return saved.dto(this.s3UploadService)
   }
 
   /**
@@ -113,7 +113,7 @@ class OffenderCheckinService(
     checkin.status = CheckinStatus.SUBMITTED
 
     checkinRepository.save(checkin)
-    return checkin.dto()
+    return checkin.dto(this.s3UploadService)
   }
 
   fun generateVideoUploadLocation(checkinUuid: UUID, contentType: String, duration: Duration): URL {
@@ -127,7 +127,7 @@ class OffenderCheckinService(
 
   fun getCheckins(practitionerUuid: UUID, pageRequest: PageRequest): CollectionDto<OffenderCheckinDto> {
     val page = checkinRepository.findAllByCreatedByUuid(practitionerUuid, pageRequest)
-    val checkins = page.content.map { it.dto() }
+    val checkins = page.content.map { it.dto(this.s3UploadService) }
     return CollectionDto(page.pageable.toPagination(), checkins)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderDto.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.esupervisionapi.offender
 
+import java.net.URL
 import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
@@ -15,7 +16,7 @@ data class OffenderDto(
   val email: String? = null,
   val phoneNumber: String? = null,
   // not every context requires the photo URL, so we only include when needed
-  val photoUrl: String?,
+  val photoUrl: URL?,
 )
 
 data class OffenderSetupDto(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderRepository.kt
@@ -12,6 +12,7 @@ import jakarta.persistence.Table
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.practitioner.Practitioner
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.AEntity
+import uk.gov.justice.digital.hmpps.esupervisionapi.utils.ResourceLocator
 import java.time.Instant
 import java.time.LocalDate
 import java.util.Optional
@@ -64,7 +65,7 @@ open class Offender(
   @JoinColumn(name = "practitioner_id", referencedColumnName = "id", nullable = false)
   open var practitioner: Practitioner,
 ) : AEntity() {
-  fun dto(): OffenderDto = OffenderDto(
+  fun dto(resourceLocator: ResourceLocator): OffenderDto = OffenderDto(
     uuid = uuid,
     firstName = firstName,
     lastName = lastName,
@@ -73,7 +74,7 @@ open class Offender(
     email = email,
     phoneNumber = phoneNumber,
     createdAt = createdAt,
-    photoUrl = null,
+    photoUrl = resourceLocator.getOffenderPhoto(uuid),
   )
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderService.kt
@@ -5,15 +5,19 @@ import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.CollectionDto
+import uk.gov.justice.digital.hmpps.esupervisionapi.utils.S3UploadService
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.toPagination
 import java.util.UUID
 
 @Service
-class OffenderService(private val offenderRepository: OffenderRepository) {
+class OffenderService(
+  private val offenderRepository: OffenderRepository,
+  private val s3UploadService: S3UploadService,
+) {
 
   fun getOffenders(pageable: Pageable): CollectionDto<OffenderDto> {
     val page = offenderRepository.findAll(pageable)
-    val offenders = page.content.map { it.dto() }
+    val offenders = page.content.map { it.dto(this.s3UploadService) }
     return CollectionDto(page.pageable.toPagination(), offenders)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderSetupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderSetupService.kt
@@ -106,7 +106,7 @@ class OffenderSetupService(
     offenderRepository.save(offender)
 
     val saved = offenderRepository.save(offender)
-    return saved.dto()
+    return saved.dto(this.s3UploadService)
   }
 
   @Transactional
@@ -129,7 +129,7 @@ class OffenderSetupService(
     val deleted = offenderRepository.save(offender)
     offenderSetupRepository.delete(setup.get())
 
-    return deleted.dto()
+    return deleted.dto(this.s3UploadService)
   }
 
   companion object {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/ResourceLocator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/ResourceLocator.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.utils
+
+import java.net.URL
+import java.util.UUID
+
+interface ResourceLocator {
+  fun getOffenderPhoto(offenderUuid: UUID): URL?
+  fun getCheckinVideo(checkinUuid: UUID): URL?
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/S3UploadService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/S3UploadService.kt
@@ -3,10 +3,12 @@ package uk.gov.justice.digital.hmpps.esupervisionapi.utils
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.GetObjectRequest
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import software.amazon.awssdk.services.s3.presigner.S3Presigner
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderCheckin
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderSetup
@@ -14,12 +16,25 @@ import java.net.URL
 import java.time.Duration
 import java.util.UUID
 
+sealed class S3Keyable {
+  fun toKey(): String {
+    when (this) {
+      is SetupPhotoKey -> {
+        return "invite-${this.invite}"
+      }
+      is CheckinVideoKey -> {
+        return "checkin-${this.checkin}"
+      }
+    }
+  }
+}
+
 /**
  * Ensure we're being consistent with object keys in S3
  */
 data class SetupPhotoKey(
   val invite: UUID,
-) {
+) : S3Keyable() {
   fun asString(): String = "invite-$invite"
 }
 
@@ -28,7 +43,7 @@ data class SetupPhotoKey(
  */
 data class CheckinVideoKey(
   val checkin: UUID,
-) {
+) : S3Keyable() {
   fun asString(): String = "checkin-$checkin"
 }
 
@@ -38,7 +53,7 @@ class S3UploadService(
   val s3Presigner: S3Presigner,
   @Value("\${aws.s3.image-uploads}") private val imageUploadBucket: String,
   @Value("\${aws.s3.video-uploads}") private val videoUploadBucket: String,
-) {
+) : ResourceLocator {
 
   private fun putObjectRequest(bucket: String, key: String, contentType: String): PutObjectRequest {
     val request = PutObjectRequest.builder()
@@ -95,20 +110,35 @@ class S3UploadService(
     return s3Presigner.presignPutObject(presignRequest).url()
   }
 
-  fun isSetupPhotoUploaded(setup: OffenderSetup): Boolean {
-    val request = HeadObjectRequest.builder()
-      .bucket(imageUploadBucket)
-      .key(SetupPhotoKey(setup.offender.uuid).asString())
-      .build()
+  fun bucketFor(key: S3Keyable): String {
+    when (key) {
+      is SetupPhotoKey -> {
+        return this.imageUploadBucket
+      }
+      is CheckinVideoKey -> {
+        return this.videoUploadBucket
+      }
+    }
+  }
+
+  fun getHeadObjectRequest(key: S3Keyable): HeadObjectRequest = HeadObjectRequest.builder()
+    .bucket(this.bucketFor(key))
+    .key(key.toKey())
+    .build()
+
+  fun keyExists(key: S3Keyable): Boolean {
+    val request = getHeadObjectRequest(key)
     return isObjectUploaded(request)
   }
 
+  fun isSetupPhotoUploaded(setup: OffenderSetup): Boolean {
+    val photoKey = SetupPhotoKey(setup.offender.uuid)
+    return keyExists(photoKey)
+  }
+
   fun isCheckinVideoUploaded(checkin: OffenderCheckin): Boolean {
-    val request = HeadObjectRequest.builder()
-      .bucket(videoUploadBucket)
-      .key(CheckinVideoKey(checkin.uuid).asString())
-      .build()
-    return isObjectUploaded(request)
+    val videoKey = CheckinVideoKey(checkin.uuid)
+    return keyExists(videoKey)
   }
 
   private fun isObjectUploaded(request: HeadObjectRequest): Boolean {
@@ -118,5 +148,35 @@ class S3UploadService(
     } catch (e: NoSuchKeyException) {
       return false
     }
+  }
+
+  fun getObjectRequestFor(key: S3Keyable): GetObjectRequest = GetObjectRequest.builder()
+    .bucket(this.bucketFor(key))
+    .key(key.toKey())
+    .build()
+
+  fun presignedGetUrlFor(key: S3Keyable): URL? {
+    val keyExists = this.keyExists(key)
+    if (keyExists) {
+      val getRequest = getObjectRequestFor(key)
+      val presignRequest = GetObjectPresignRequest.builder()
+        .signatureDuration(Duration.ofMinutes(5))
+        .getObjectRequest(getRequest)
+        .build()
+      val presigned = this.s3Presigner.presignGetObject(presignRequest)
+      return presigned.url()
+    } else {
+      return null
+    }
+  }
+
+  override fun getOffenderPhoto(offenderUuid: UUID): URL? {
+    val photoKey = SetupPhotoKey(offenderUuid)
+    return presignedGetUrlFor(photoKey)
+  }
+
+  override fun getCheckinVideo(checkinUuid: UUID): URL? {
+    val videoKey = CheckinVideoKey(checkinUuid)
+    return presignedGetUrlFor(videoKey)
   }
 }


### PR DESCRIPTION
Add ResourceLocator interface which resolves PoP identity photos and checkin video GET locations. Implement this interface within S3Upload service to return presigned URLs for PoP and checkin intstances if the corresponding keys exist within S3.

Update the dto methods on the model classes to resolve download URLs using ResourceLocator and pass the upload service to these methods within the corresponding services.