### PR TITLE
Change practitioner uuid type to string

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/App.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/App.kt
@@ -21,7 +21,7 @@ class StartupRunner(val practitionerService: PractitionerService) : ApplicationR
     try {
       practitionerService.createPractitioner(
         Practitioner(
-          uuid = UUID.randomUUID(),
+          uuid = UUID.randomUUID().toString(),
           firstName = "John",
           lastName = "Doe",
           email = "john@example.bar",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinDto.kt
@@ -31,9 +31,9 @@ data class OffenderCheckinDto(
   val submittedOn: Instant?,
   val questions: String,
   val answers: String?,
-  val createdBy: UUID,
+  val createdBy: String,
   val createdAt: Instant,
-  val reviewedBy: UUID?,
+  val reviewedBy: String?,
   /**
    * Will be set to pre-signed S3 URL
    */

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinRepository.kt
@@ -83,5 +83,5 @@ interface OffenderCheckinRepository : org.springframework.data.jpa.repository.Jp
   fun findByOffender(offender: Offender): Optional<OffenderCheckin>
 
   // returns checkins created by a practitioner with the given uuid
-  fun findAllByCreatedByUuid(practitionerUuid: UUID, pageable: Pageable): Page<OffenderCheckin>
+  fun findAllByCreatedByUuid(practitionerUuid: String, pageable: Pageable): Page<OffenderCheckin>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinResource.kt
@@ -35,7 +35,7 @@ class OffenderCheckinResource(
   @GetMapping(produces = [APPLICATION_JSON_VALUE])
   @Tag(name = "practitioner")
   @PreAuthorize("hasRole('ROLE_ESUPERVISION__ESUPERVISION_UI')")
-  fun getCheckins(@RequestParam("practitionerUuid") practitionerUuid: UUID): ResponseEntity<CollectionDto<OffenderCheckinDto>> {
+  fun getCheckins(@RequestParam("practitionerUuid") practitionerUuid: String): ResponseEntity<CollectionDto<OffenderCheckinDto>> {
     val pageRequest = PageRequest.of(0, 20)
     val checkins = offenderCheckinService.getCheckins(practitionerUuid, pageRequest)
     return ResponseEntity.ok(checkins)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinService.kt
@@ -125,7 +125,7 @@ class OffenderCheckinService(
     throw ResourceNotFoundException("checkin not found")
   }
 
-  fun getCheckins(practitionerUuid: UUID, pageRequest: PageRequest): CollectionDto<OffenderCheckinDto> {
+  fun getCheckins(practitionerUuid: String, pageRequest: PageRequest): CollectionDto<OffenderCheckinDto> {
     val page = checkinRepository.findAllByCreatedByUuid(practitionerUuid, pageRequest)
     val checkins = page.content.map { it.dto(this.s3UploadService) }
     return CollectionDto(page.pageable.toPagination(), checkins)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderDto.kt
@@ -21,7 +21,7 @@ data class OffenderDto(
 
 data class OffenderSetupDto(
   val uuid: UUID,
-  val practitioner: UUID,
+  val practitioner: String,
   val offender: UUID,
   val createdAt: Instant,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/invite/InviteInfo.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/invite/InviteInfo.kt
@@ -12,7 +12,7 @@ data class InviteInfo(
  */
 data class OffenderInfo(
   val setupUuid: UUID,
-  val practitionerId: UUID,
+  val practitionerId: String,
   val firstName: String,
   val lastName: String,
   val dateOfBirth: LocalDate,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/practitioner/PractitionerDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/practitioner/PractitionerDto.kt
@@ -1,9 +1,7 @@
 package uk.gov.justice.digital.hmpps.esupervisionapi.practitioner
 
-import java.util.UUID
-
 data class PractitionerDto(
-  val uuid: UUID,
+  val uuid: String,
   val firstName: String,
   val lastName: String,
   val email: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/practitioner/PractitionerRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/practitioner/PractitionerRepository.kt
@@ -6,13 +6,12 @@ import jakarta.persistence.Table
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.AEntity
 import java.util.Optional
-import java.util.UUID
 
 @Entity
 @Table(name = "practitioner")
 open class Practitioner(
   @Column(unique = true, nullable = false)
-  open var uuid: UUID,
+  open var uuid: String,
   @Column("first_name")
   open var firstName: String,
   @Column("last_name")
@@ -36,5 +35,5 @@ open class Practitioner(
 @Repository
 interface PractitionerRepository : org.springframework.data.jpa.repository.JpaRepository<Practitioner, Long> {
   fun findByEmail(email: String): Optional<Practitioner>
-  fun findByUuid(uuid: UUID): Optional<Practitioner>
+  fun findByUuid(uuid: String): Optional<Practitioner>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/practitioner/PractitionerResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/practitioner/PractitionerResource.kt
@@ -12,7 +12,6 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder
-import java.util.UUID
 
 @RestController
 @RequestMapping("/practitioners", produces = [APPLICATION_JSON_VALUE])
@@ -43,7 +42,7 @@ class PractitionerResource(private val practitionerService: PractitionerService)
   @PreAuthorize("hasRole('ROLE_ESUPERVISION__ESUPERVISION_UI')")
   @Tag(name = "practitioner")
   @GetMapping("/{uuid}")
-  fun getPractitioner(@PathVariable uuid: UUID): ResponseEntity<Practitioner> {
+  fun getPractitioner(@PathVariable uuid: String): ResponseEntity<Practitioner> {
     val practitioner = practitionerService.getPractitionerByUuid(uuid)
     if (practitioner != null) {
       return ResponseEntity.ok(practitioner)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/practitioner/PractitionerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/practitioner/PractitionerService.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.esupervisionapi.practitioner
 
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.util.UUID
 
 @Service
 class PractitionerService(private val practitionerRepository: PractitionerRepository) {
@@ -17,7 +16,7 @@ class PractitionerService(private val practitionerRepository: PractitionerReposi
   fun getPractitionerById(id: Long): Practitioner? = practitionerRepository.findById(id).orElse(null)
 
   @Transactional
-  fun getPractitionerByUuid(uuid: UUID): Practitioner? {
+  fun getPractitionerByUuid(uuid: String): Practitioner? {
     var found: Practitioner? = null
     try {
       val practitioner = practitionerRepository.findByUuid(uuid)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/ResourceDtos.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/ResourceDtos.kt
@@ -32,7 +32,7 @@ data class CollectionDto<ElemDto>(
  * Everything we need to create a checkin
  */
 data class CreateCheckinRequest(
-  val practitioner: UUID,
+  val practitioner: String,
   val offender: UUID,
   val questions: String,
   val dueDate: LocalDate,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/offender/OffenderSetup.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/offender/OffenderSetup.kt
@@ -44,7 +44,7 @@ class OffenderSetup : IntegrationTestBase() {
     val result = offenderInviteService.startOffenderSetup(
       OffenderInfo(
         setupUuid = UUID.randomUUID(),
-        practitionerId = UUID.randomUUID(),
+        practitionerId = UUID.randomUUID().toString(),
         firstName = "John",
         lastName = "Smith",
         dateOfBirth = LocalDate.of(1980, 1, 1),


### PR DESCRIPTION
Practitioner ids are defined by the ids on the user tokens returned by HMPPS auth. These are not necessarily valid UUIDs.

Change the type of the practitioner uuid field to String and update the related fields in various DTOs.