### PR TITLE
Use alternate S3 service for rekog, snapshot URL locations

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinResource.kt
@@ -100,7 +100,7 @@ class OffenderCheckinResource(
   @GetMapping("/rekog")
   @PreAuthorize("hasRole('ROLE_ESUPERVISION__ESUPERVISION_UI')")
   fun rekog(): ResponseEntity<String> {
-      val result = rekognitionS3.getObject(
+    val result = rekognitionS3.getObject(
       GetObjectRequest.builder()
         .bucket(rekogBucketName).key("hello.txt").build(),
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinService.kt
@@ -121,7 +121,7 @@ class OffenderCheckinService(
   fun generateVideoUploadLocation(checkinUuid: UUID, contentType: String, duration: Duration): URL {
     val checkin = checkinRepository.findByUuid(checkinUuid)
     if (checkin.isPresent) {
-      validateCheckingUpdatable(checkin.get())
+      validateCheckinUpdatable(checkin.get())
       return s3UploadService.generatePresignedUploadUrl(checkin.get(), contentType, duration)
     }
 
@@ -131,7 +131,7 @@ class OffenderCheckinService(
   fun generatePhotoSnapshotLocations(checkinUuid: UUID, contentType: String, number: Long, duration: Duration): List<URL> {
     val checkin = checkinRepository.findByUuid(checkinUuid)
     if (checkin.isPresent) {
-      validateCheckingUpdatable(checkin.get())
+      validateCheckinUpdatable(checkin.get())
       val urls = mutableListOf<URL>()
       for (index in 0..<number) {
         val rekogUrl = rekogS3UploadService.generatePresignedUploadUrl(checkin.get(), contentType, index, duration)
@@ -151,7 +151,7 @@ class OffenderCheckinService(
 
   companion object {
     // checkin has been SUBMITTED so we no longer allow ot overwrite the associated files
-    private fun validateCheckingUpdatable(checkin: OffenderCheckin) {
+    private fun validateCheckinUpdatable(checkin: OffenderCheckin) {
       if (checkin.status != CheckinStatus.CREATED) {
         throw BadArgumentException("You can no longer add photos/videos to checkin with uuid=${checkin.uuid}")
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/ResourceDtos.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/ResourceDtos.kt
@@ -18,8 +18,12 @@ data class LocationInfo(
   val duration: String,
 )
 
+/**
+ * Note, only one of `locationInfo` or `locations` should be non-null.
+ */
 data class UploadLocationResponse(
   val locationInfo: LocationInfo?,
+  val locations: List<LocationInfo>? = null,
   val errorMessage: String? = null,
 )
 


### PR DESCRIPTION
- Requesting checkin upload locations can now return a collection of URLs. 
  - we'll be using locations[0] as the upload location for the reference photo - not the cleanest, but properly shaping the API respose will have to wait
 - adds an additional S3 service class to access the non MOJ resources used for the pilot