### PR TITLE
Send messages on checkin invite and submission

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -10,7 +10,7 @@ generic-service:
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: "applicationinsights.dev.json"
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
-    HOSTED_AT: "https://esupervision-api-dev.hmpps.service.justice.gov.uk"
+    HOSTED_AT: "https://esupervision-dev.hmpps.service.justice.gov.uk"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/AppConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/AppConfig.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.config
+
+import java.net.URI
+import java.util.UUID
+
+class AppConfig(private val hostedAt: String) {
+  // WARNING: this depends on the routes in the UI!
+  fun checkinSubmitUrl(checkinUuid: UUID): URI = URI(
+    "$hostedAt/submission/$checkinUuid",
+  )
+
+  // WARNING: this depends on the routes in the UI!
+  fun checkinDashboardUrl(checkinUuid: UUID): URI = URI(
+    "$hostedAt/practitioners/checkin/$checkinUuid",
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/NotificationsConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/NotificationsConfig.kt
@@ -1,0 +1,31 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.config
+import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.Email
+import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.NotificationMethod
+import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.PhoneNumber
+
+class NotificationsConfig(
+  private val emailTemplates: Map<String, String>,
+  private val smsTemplates: Map<String, String>,
+) {
+  fun getTemplateId(notificationMethod: NotificationMethod, templateName: String): String {
+    val templates = templatesFor(notificationMethod)
+    val templateId = templates.get(templateName)
+
+    if (templateId == null) {
+      throw IllegalArgumentException("Template '$templateName' does not exist")
+    } else {
+      return templateId
+    }
+  }
+
+  fun templatesFor(notificationMethod: NotificationMethod): Map<String, String> {
+    when (notificationMethod) {
+      is Email -> {
+        return emailTemplates
+      }
+      is PhoneNumber -> {
+        return smsTemplates
+      }
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/NotifyConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/NotifyConfig.kt
@@ -6,22 +6,39 @@ import org.springframework.context.annotation.Configuration
 import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.GovNotifyNotificationService
 import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.NotificationService
 import uk.gov.service.notify.NotificationClient
+import uk.gov.service.notify.NotificationClientApi
 
 @Configuration
 class NotifyConfig(
   @Value("\${app.hostedAt}") val hostedAt: String,
   @Value("\${notify.apiKey}") val apiKey: String,
-  @Value("\${notify.offenderInviteSmsTemplateId}") val inviteSMSTemplateId: String,
-  @Value("\${notify.offenderInviteEmailTemplateId}") val inviteEmailTemplateId: String,
+  @Value("\${notify.sms-templates.POP_CHECKIN_INVITE}") val checkinInviteSmsTemplate: String,
+  @Value("\${notify.sms-templates.PRACTITIONER_CHECKIN_SUBMITTED}") val checkinSubmittedSmsTemplate: String,
+  @Value("\${notify.email-templates.POP_CHECKIN_INVITE}") val checkinInviteEmailTemplate: String,
+  @Value("\${notify.email-templates.PRACTITIONER_CHECKIN_SUBMITTED}") val checkinSubmittedEmailTemplate: String,
 ) {
   @Bean
-  fun notificationService(): NotificationService {
-    val client = NotificationClient(apiKey)
-    return GovNotifyNotificationService(
-      hostedAt,
-      offenderInviteEmailTemplateId = inviteEmailTemplateId,
-      offenderInviteSMSTemplateId = inviteSMSTemplateId,
-      notifyClient = client,
-    )
-  }
+  fun notificationClient(): NotificationClientApi = NotificationClient(apiKey)
+
+  @Bean
+  fun appConfig() = AppConfig(hostedAt)
+
+  @Bean
+  fun notificationsConfig() = NotificationsConfig(
+    emailTemplates = mapOf(
+      "POP_CHECKIN_INVITE" to checkinInviteEmailTemplate,
+      "PRACTITIONER_CHECKIN_SUBMITTED" to checkinSubmittedEmailTemplate,
+    ),
+    smsTemplates = mapOf(
+      "POP_CHECKIN_INVITE" to checkinInviteSmsTemplate,
+      "PRACTITIONER_CHECKIN_SUBMITTED" to checkinSubmittedSmsTemplate,
+    ),
+  )
+
+  @Bean
+  fun notificationService(): NotificationService = GovNotifyNotificationService(
+    notifyClient = this.notificationClient(),
+    appConfig = this.appConfig(),
+    notificationsConfig = this.notificationsConfig(),
+  )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/Contactable.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/Contactable.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.notifications
+
+interface Contactable {
+  fun contactMethods(): Iterable<NotificationMethod>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/Message.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/Message.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.notifications
+
+import uk.gov.justice.digital.hmpps.esupervisionapi.config.AppConfig
+
+interface Message {
+  fun personalisationData(appConfig: AppConfig): Map<String, String>
+  val templateName: String
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/NotificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/NotificationService.kt
@@ -1,17 +1,5 @@
 package uk.gov.justice.digital.hmpps.esupervisionapi.notifications
 
-data class OffenderInviteMessage(
-  val firstName: String,
-  val lastName: String,
-  val invitePath: String,
-) {
-  fun personalisationData(hostedAt: String): Map<String, String> = mapOf(
-    "firstName" to firstName,
-    "lastName" to lastName,
-    "inviteUrl" to "$hostedAt$invitePath",
-  )
-}
-
 interface NotificationService {
-  fun notifyOffenderInvite(method: NotificationMethod, invite: OffenderInviteMessage)
+  fun sendMessage(message: Message, recipient: Contactable)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/OffenderCheckinInviteMessage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/OffenderCheckinInviteMessage.kt
@@ -1,0 +1,28 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.notifications
+
+import uk.gov.justice.digital.hmpps.esupervisionapi.config.AppConfig
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderCheckin
+import java.util.UUID
+
+data class OffenderCheckinInviteMessage(
+  val firstName: String,
+  val lastName: String,
+  val checkinUuid: UUID,
+) : Message {
+  override fun personalisationData(appConfig: AppConfig): Map<String, String> = mapOf(
+    "firstName" to firstName,
+    "lastName" to lastName,
+    "checkinURL" to appConfig.checkinSubmitUrl(checkinUuid).toString(),
+  )
+
+  override val templateName: String
+    get() = "POP_CHECKIN_INVITE"
+
+  companion object {
+    fun fromCheckin(checkin: OffenderCheckin): OffenderCheckinInviteMessage = OffenderCheckinInviteMessage(
+      firstName = checkin.offender.firstName,
+      lastName = checkin.offender.lastName,
+      checkinUuid = checkin.uuid,
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/OffenderCheckinInviteMessage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/OffenderCheckinInviteMessage.kt
@@ -2,16 +2,22 @@ package uk.gov.justice.digital.hmpps.esupervisionapi.notifications
 
 import uk.gov.justice.digital.hmpps.esupervisionapi.config.AppConfig
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderCheckin
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
 import java.util.UUID
 
 data class OffenderCheckinInviteMessage(
   val firstName: String,
   val lastName: String,
+  val checkinDueDate: LocalDate,
   val checkinUuid: UUID,
 ) : Message {
   override fun personalisationData(appConfig: AppConfig): Map<String, String> = mapOf(
     "firstName" to firstName,
     "lastName" to lastName,
+    "checkinDueDate" to DATE_FORMAT.format(checkinDueDate),
     "checkinURL" to appConfig.checkinSubmitUrl(checkinUuid).toString(),
   )
 
@@ -19,9 +25,13 @@ data class OffenderCheckinInviteMessage(
     get() = "POP_CHECKIN_INVITE"
 
   companion object {
+    val LONDON_ZONE = ZoneId.of("Europe/London")
+    val DATE_FORMAT = DateTimeFormatter.ofPattern("dd/MM/yyyy")
+
     fun fromCheckin(checkin: OffenderCheckin): OffenderCheckinInviteMessage = OffenderCheckinInviteMessage(
       firstName = checkin.offender.firstName,
       lastName = checkin.offender.lastName,
+      checkinDueDate = ZonedDateTime.ofInstant(checkin.dueDate, LONDON_ZONE).toLocalDate(),
       checkinUuid = checkin.uuid,
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/PractitionerCheckinSubmittedMessage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/PractitionerCheckinSubmittedMessage.kt
@@ -1,0 +1,31 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.notifications
+
+import uk.gov.justice.digital.hmpps.esupervisionapi.config.AppConfig
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderCheckin
+import java.util.UUID
+
+data class PractitionerCheckinSubmittedMessage(
+  val practitionerFirstName: String,
+  val offenderFirstName: String,
+  val offenderLastName: String,
+  val checkinUuid: UUID,
+) : Message {
+  override fun personalisationData(appConfig: AppConfig): Map<String, String> = mapOf(
+    "practitionerFirstName" to practitionerFirstName,
+    "offenderFirstName" to offenderFirstName,
+    "offenderLastName" to offenderLastName,
+    "checkinDashboardUrl" to appConfig.checkinDashboardUrl(checkinUuid).toString(),
+  )
+
+  override val templateName: String
+    get() = "PRACTITIONER_CHECKIN_SUBMITTED"
+
+  companion object {
+    fun fromCheckin(checkin: OffenderCheckin) = PractitionerCheckinSubmittedMessage(
+      practitionerFirstName = checkin.createdBy.firstName,
+      offenderFirstName = checkin.createdBy.firstName,
+      offenderLastName = checkin.createdBy.lastName,
+      checkinUuid = checkin.uuid,
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderRepository.kt
@@ -10,6 +10,10 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.Contactable
+import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.Email
+import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.NotificationMethod
+import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.PhoneNumber
 import uk.gov.justice.digital.hmpps.esupervisionapi.practitioner.Practitioner
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.AEntity
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.ResourceLocator
@@ -64,7 +68,8 @@ open class Offender(
   @ManyToOne(cascade = [CascadeType.ALL], fetch = FetchType.LAZY)
   @JoinColumn(name = "practitioner_id", referencedColumnName = "id", nullable = false)
   open var practitioner: Practitioner,
-) : AEntity() {
+) : AEntity(),
+  Contactable {
   fun dto(resourceLocator: ResourceLocator): OffenderDto = OffenderDto(
     uuid = uuid,
     firstName = firstName,
@@ -76,6 +81,13 @@ open class Offender(
     createdAt = createdAt,
     photoUrl = resourceLocator.getOffenderPhoto(this),
   )
+
+  override fun contactMethods(): Iterable<NotificationMethod> {
+    val methods = mutableListOf<NotificationMethod>()
+    this.email?.let { methods.add(Email(it)) }
+    this.phoneNumber?.let { methods.add(PhoneNumber(it)) }
+    return methods
+  }
 }
 
 @Repository

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderSetupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderSetupService.kt
@@ -6,7 +6,6 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.NotificationService
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.invite.OffenderInfo
 import uk.gov.justice.digital.hmpps.esupervisionapi.practitioner.PractitionerRepository
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.BadArgumentException
@@ -20,7 +19,6 @@ class OffenderSetupService(
   private val offenderRepository: OffenderRepository,
   private val practitionerRepository: PractitionerRepository,
   private val s3UploadService: S3UploadService,
-  private val notificationService: NotificationService,
   private val offenderSetupRepository: OffenderSetupRepository,
 ) {
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/practitioner/PractitionerRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/practitioner/PractitionerRepository.kt
@@ -4,6 +4,10 @@ import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Table
 import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.Contactable
+import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.Email
+import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.NotificationMethod
+import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.PhoneNumber
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.AEntity
 import java.util.Optional
 
@@ -21,7 +25,8 @@ open class Practitioner(
   @Column("phone_number")
   open var phoneNumber: String? = null,
   open var roles: List<String> = listOf(),
-) : AEntity() {
+) : AEntity(),
+  Contactable {
   fun dto(): PractitionerDto = PractitionerDto(
     uuid = uuid,
     firstName = firstName,
@@ -30,6 +35,12 @@ open class Practitioner(
     phoneNumber = phoneNumber,
     roles = roles,
   )
+
+  override fun contactMethods(): Iterable<NotificationMethod> {
+    val methods = mutableListOf<NotificationMethod>(Email(this.email))
+    this.phoneNumber?.let { methods.add(PhoneNumber(it)) }
+    return methods
+  }
 }
 
 @Repository

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -28,8 +28,13 @@ aws:
 
 notify:
   apiKey: ${NOTIFY_API_KEY}
-  offenderInviteSmsTemplateId: 306223e2-b69c-477f-840c-c98b029021f0
-  offenderInviteEmailTemplateId: fc8394c1-81f4-42ba-80ab-65ebb627daeb
+  sms-templates:
+    POP_CHECKIN_INVITE: d332e869-a667-43ad-8a01-9c2b609e01c8
+    PRACTITIONER_CHECKIN_SUBMITTED: 611d8bed-f8ae-46ec-b38f-9173135d206c
+  email-templates:
+    POP_CHECKIN_INVITE: ab3bd00d-b0e7-477e-abb0-7197ab91aa70
+    PRACTITIONER_CHECKIN_SUBMITTED: 81d859ad-9469-405b-8949-a9d62fe8f080
+
 
 rekognition:
   s3_bucket_name: user-ids-rekognition-d-2

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -60,3 +60,12 @@ aws:
 
 rekognition:
   s3_bucket_name: ${REKOG_S3_DATA_BUCKET}
+
+notify:
+  apiKey: ${NOTIFY_API_KEY}
+  sms-templates:
+    POP_CHECKIN_INVITE: d332e869-a667-43ad-8a01-9c2b609e01c8
+    PRACTITIONER_CHECKIN_SUBMITTED: 611d8bed-f8ae-46ec-b38f-9173135d206c
+  email-templates:
+    POP_CHECKIN_INVITE: ab3bd00d-b0e7-477e-abb0-7197ab91aa70
+    PRACTITIONER_CHECKIN_SUBMITTED: 81d859ad-9469-405b-8949-a9d62fe8f080

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -92,8 +92,12 @@ aws:
 
 notify:
   apiKey: ${NOTIFY_API_KEY}
-  offenderInviteSmsTemplateId: 306223e2-b69c-477f-840c-c98b029021f0
-  offenderInviteEmailTemplateId: fc8394c1-81f4-42ba-80ab-65ebb627daeb
+  sms-templates:
+    POP_CHECKIN_INVITE: d332e869-a667-43ad-8a01-9c2b609e01c8
+    PRACTITIONER_CHECKIN_SUBMITTED: 611d8bed-f8ae-46ec-b38f-9173135d206c
+  email-templates:
+    POP_CHECKIN_INVITE: ab3bd00d-b0e7-477e-abb0-7197ab91aa70
+    PRACTITIONER_CHECKIN_SUBMITTED: 81d859ad-9469-405b-8949-a9d62fe8f080
 
 rekognition:
   region: eu-west-2


### PR DESCRIPTION
Message templates have been added to the gov.uk notify configuration for checkin invite and submission messages. Add these to the app configuration(s) and remove the templates used for the old invite flow.

Add a Message interface type for messages which can be sent to a recipient. A recipient is a type which exposes a collection of contact methods (phone number or email). Implement the Contactable inteface for Offender and Practitioner types.

Add message types for the checkin invite and submission messages. These return a collection of named template parameters based on the message properties and application configuration. The application parameters are exposed via a new AppConfig class which is used to resolve references to checkins within the UI.

Update the NotificationService to send a generic message to an arbitrary contactable recipient. The template is resolved from the configuration based on the message and notification method types.