### PR TITLE
Add endpoint to persist auto id check result

### DIFF
--- a/docs/http/full-checkin-flow.http
+++ b/docs/http/full-checkin-flow.http
@@ -70,3 +70,12 @@ Content-Type: application/json
   "answers": "yellow"
 }
 
+### Review the checkin
+POST {{HOST}}/offender_checkins/{{checkin_uuid}}/review
+Authorization: Bearer {{hmpps_auth.token}}
+Content-Type: application/json
+
+{
+  "practitioner": "{{practitioner_uuid}}",
+  "manualIdCheck": "MATCH"
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinResource.kt
@@ -96,6 +96,14 @@ class OffenderCheckinResource(
     TODO("not implemented yet")
   }
 
+  @PostMapping("/{uuid}/auto_id_check")
+  @Tag(name = "practitioner")
+  @PreAuthorize("hasRole('ROLE_ESUPERVISION__ESUPERVISION_UI')")
+  fun automatedIdentityCheck(@PathVariable uuid: UUID, @RequestParam result: AutomatedIdVerificationResult): ResponseEntity<OffenderCheckinDto> {
+    val checkin = offenderCheckinService.setAutomatedIdCheckStatus(uuid, result)
+    return ResponseEntity.ok(checkin)
+  }
+
   // NOTE(rosado): temporary, just to test if we can reach outside
   @GetMapping("/rekog")
   @PreAuthorize("hasRole('ROLE_ESUPERVISION__ESUPERVISION_UI')")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinResource.kt
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
+import uk.gov.justice.digital.hmpps.esupervisionapi.utils.CheckinReviewRequest
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.CollectionDto
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.CreateCheckinRequest
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.LocationInfo
@@ -92,8 +93,9 @@ class OffenderCheckinResource(
   @PostMapping("/{uuid}/review")
   @Tag(name = "practitioner")
   @PreAuthorize("hasRole('ROLE_ESUPERVISION__ESUPERVISION_UI')")
-  fun reviewCheckin(@PathVariable uuid: UUID): ResponseEntity<OffenderCheckinDto> {
-    TODO("not implemented yet")
+  fun reviewCheckin(@PathVariable uuid: UUID, reviewRequest: CheckinReviewRequest): ResponseEntity<OffenderCheckinDto> {
+    val checkin = offenderCheckinService.reviewCheckin(uuid, reviewRequest)
+    return ResponseEntity.ok(checkin)
   }
 
   @PostMapping("/{uuid}/auto_id_check")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinService.kt
@@ -173,6 +173,7 @@ class OffenderCheckinService(
 
     checkin.reviewedBy = practitioner
     checkin.manualIdCheck = checkin.manualIdCheck
+    checkin.status = CheckinStatus.REVIEWED
 
     return checkinRepository.save(checkin).dto(this.s3UploadService)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/ResourceDtos.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/ResourceDtos.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.esupervisionapi.utils
 
 import org.springframework.data.domain.Pageable
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.ManualIdVerificationResult
 import java.net.URL
 import java.time.LocalDate
 import java.util.UUID
@@ -40,4 +41,12 @@ data class CreateCheckinRequest(
   val offender: UUID,
   val questions: String,
   val dueDate: LocalDate,
+)
+
+/**
+ * Submitted on behalf of the practitioner as a review of the checkin.
+ */
+data class CheckinReviewRequest(
+  val practitioner: String,
+  val manualIdCCheck: ManualIdVerificationResult,
 )


### PR DESCRIPTION
- Adds a `POST /{uuid}/auto_id_check` to update the checkin with rekognition face compare result.
- Adds a `POST /{uuid}/review`
