### PR TITLE
Change port for mock HMPPS auth server in tests

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/wiremock/HmppsAuthMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/wiremock/HmppsAuthMockServer.kt
@@ -38,7 +38,7 @@ class HmppsAuthApiExtension :
 
 class HmppsAuthMockServer : WireMockServer(WIREMOCK_PORT) {
   companion object {
-    private const val WIREMOCK_PORT = 8090
+    private const val WIREMOCK_PORT = 8091
   }
 
   fun stubGrantToken() {

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -9,7 +9,7 @@ management.endpoint:
   info.cache.time-to-live: 0
 
 hmpps-auth:
-  url: "http://localhost:8090/auth"
+  url: "http://localhost:8091/auth"
 
 spring:
   datasource:


### PR DESCRIPTION
Use port 8091 for the mock HMPPS auth server in the tests so it differs from the port used by default in development. This means the tests can be run while the API is running in dev mode under the default configuration.