### PR TITLE
Add next checkin date and checkin frequency to Offender model

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,8 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-webflux")
   implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
+  implementation("net.javacrumbs.shedlock:shedlock-spring:6.9.2")
+  implementation("net.javacrumbs.shedlock:shedlock-provider-jdbc-template:6.9.2")
 
   api("software.amazon.awssdk:s3")
   implementation("software.amazon.awssdk:s3:2.31.63")

--- a/docs/http/full-checkin-flow.http
+++ b/docs/http/full-checkin-flow.http
@@ -49,7 +49,7 @@ Authorization: Bearer {{hmpps_auth.token}}
 
 > {%
     if (response.status === 200) {
-        const uploadUrl = response.body["locationInfo"]["url"]
+        const uploadUrl = response.body["video"]["url"]
         client.log("upload url: ", uploadUrl)
         client.global.set("checkinVideoUploadUrl", uploadUrl)
     }

--- a/docs/http/full-offender-setup-flow.http
+++ b/docs/http/full-offender-setup-flow.http
@@ -19,6 +19,9 @@ Authorization: Bearer {{hmpps_auth.token}}
   "lastName": "Bronson",
   "dateOfBirth": "1990-01-30",
   "email": "barry@example.com"
+  "firstCheckinDate": "2025-07-25",
+  "checkinInterval": "WEEKLY",
+  "zoneId": "Europe/London"
 }
 
 
@@ -61,7 +64,7 @@ Authorization: Bearer {{hmpps_auth.token}}
 
 
 ### Let's verify we created an offender record
-GET {{HOST}}/offenders
+GET {{HOST}}/offenders?page=0&size=100&practitionerUuid={{practitioner_uuid}}
 Authorization: Bearer {{hmpps_auth.token}}
 Content-Type: application/json
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/App.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/App.kt
@@ -2,9 +2,15 @@ package uk.gov.justice.digital.hmpps.esupervisionapi
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.context.annotation.Bean
+import org.springframework.scheduling.annotation.EnableScheduling
+import java.time.Clock
 
 @SpringBootApplication
-class EsupervisionApp
+@EnableScheduling
+class EsupervisionApp {
+  @Bean fun clock(): Clock = Clock.systemUTC()
+}
 
 fun main(args: Array<String>) {
   runApplication<EsupervisionApp>(*args)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/App.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/App.kt
@@ -5,11 +5,14 @@ import org.springframework.boot.runApplication
 import org.springframework.context.annotation.Bean
 import org.springframework.scheduling.annotation.EnableScheduling
 import java.time.Clock
+import java.time.ZoneId
+
+private val defaultTimeZone = ZoneId.of(System.getenv("TZ") ?: "Europe/London")
 
 @SpringBootApplication
 @EnableScheduling
 class EsupervisionApp {
-  @Bean fun clock(): Clock = Clock.systemUTC()
+  @Bean fun clock(): Clock = Clock.system(defaultTimeZone)
 }
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/AppConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/AppConfig.kt
@@ -6,7 +6,10 @@ import java.net.URI
 import java.util.UUID
 
 @Component
-class AppConfig(@Value("\${app.hostedAt}") private val hostedAt: String) {
+class AppConfig(
+  @Value("\${app.hostedAt}") private val hostedAt: String,
+  @Value("\${app.scheduling.checkin-notification.cron}") val checkinNotificationCron: String,
+) {
   // WARNING: this depends on the routes in the UI!
   fun checkinSubmitUrl(checkinUuid: UUID): URI = URI(
     "$hostedAt/submission/$checkinUuid",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/CheckinNotifierConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/CheckinNotifierConfiguration.kt
@@ -12,7 +12,7 @@ import javax.sql.DataSource
 @Profile("!test")
 @EnableSchedulerLock(
   defaultLockAtLeastFor = "PT1M",
-  defaultLockAtMostFor = "PT5M",
+  defaultLockAtMostFor = "PT10M",
 )
 class CheckinNotifierConfiguration {
   @Bean

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/CheckinNotifierConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/CheckinNotifierConfiguration.kt
@@ -3,9 +3,11 @@ package uk.gov.justice.digital.hmpps.esupervisionapi.config
 import net.javacrumbs.shedlock.core.LockProvider
 import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider
 import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
+import java.time.Duration
 import javax.sql.DataSource
 
 @Configuration
@@ -14,7 +16,13 @@ import javax.sql.DataSource
   defaultLockAtLeastFor = "PT1M",
   defaultLockAtMostFor = "PT10M",
 )
-class CheckinNotifierConfiguration {
+class CheckinNotifierConfiguration(
+  /**
+   * How long, starting from dueDate, do we accept checkin submissions.
+   * Afterward the checkin's status is updated to EXPIRED.
+   */
+  @Value("\${app.scheduling.checkin-notification.window:72h}") val checkinWindow: Duration,
+) {
   @Bean
   fun lockProvider(ds: DataSource): LockProvider = JdbcTemplateLockProvider(ds)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/CheckinNotifierConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/CheckinNotifierConfiguration.kt
@@ -3,11 +3,9 @@ package uk.gov.justice.digital.hmpps.esupervisionapi.config
 import net.javacrumbs.shedlock.core.LockProvider
 import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider
 import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
-import java.time.Duration
 import javax.sql.DataSource
 
 @Configuration
@@ -16,13 +14,7 @@ import javax.sql.DataSource
   defaultLockAtLeastFor = "PT1M",
   defaultLockAtMostFor = "PT10M",
 )
-class CheckinNotifierConfiguration(
-  /**
-   * How long, starting from dueDate, do we accept checkin submissions.
-   * Afterward the checkin's status is updated to EXPIRED.
-   */
-  @Value("\${app.scheduling.checkin-notification.window:72h}") val checkinWindow: Duration,
-) {
+class CheckinNotifierConfiguration {
   @Bean
   fun lockProvider(ds: DataSource): LockProvider = JdbcTemplateLockProvider(ds)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/CheckinNotifierConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/CheckinNotifierConfiguration.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.config
+
+import net.javacrumbs.shedlock.core.LockProvider
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import javax.sql.DataSource
+
+@Configuration
+@Profile("!test")
+@EnableSchedulerLock(
+  defaultLockAtLeastFor = "PT1M",
+  defaultLockAtMostFor = "PT5M",
+)
+class CheckinNotifierConfiguration {
+  @Bean
+  fun lockProvider(ds: DataSource): LockProvider = JdbcTemplateLockProvider(ds)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/HmppsESupervisionExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/HmppsESupervisionExceptionHandler.kt
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
 import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY
 import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.security.access.AccessDeniedException
 import org.springframework.web.bind.MissingServletRequestParameterException
 import org.springframework.web.bind.annotation.ExceptionHandler
@@ -33,6 +34,17 @@ class HmppsESupervisionExceptionHandler {
         developerMessage = e.message,
       ),
     )
+
+  @ExceptionHandler(org.springframework.http.converter.HttpMessageNotReadableException::class)
+  fun handleHttpMessageNotReadableException(e: org.springframework.http.converter.HttpMessageNotReadableException): ResponseEntity<ErrorResponse> = ResponseEntity
+    .status(BAD_REQUEST)
+    .body(
+      ErrorResponse(
+        status = BAD_REQUEST,
+        userMessage = "Invalid request format or content",
+        developerMessage = e.message,
+      ),
+    ).also { log.info("Message not readable: {}", e.message) }
 
   @ExceptionHandler(MissingVideoException::class)
   fun handleMissingVideoException(e: MissingVideoException): ResponseEntity<ErrorResponse> = ResponseEntity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/CheckinNotifier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/CheckinNotifier.kt
@@ -52,8 +52,9 @@ class CheckinNotifier(
    * abort the transaction because a single error. We want the notification ID
    * saved in the OffenderCheckin record.
    */
-  //@Scheduled(cron = "0 0 3,5 * * *")
-  @Scheduled(cron = "*/30 * * * * *")
+  // @Scheduled(cron = "0 0 3,5 * * *") // PROD
+  @Scheduled(cron = "0 */15 * * * *")
+  // @Scheduled(cron = "*/30 * * * * *") // LOCAL
   @SchedulerLock(
     name = "CheckinNotifier - send notifications",
     lockAtLeastFor = "PT5S",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/CheckinNotifier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/CheckinNotifier.kt
@@ -1,0 +1,120 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.jobs
+
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.Offender
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderCheckinRepository
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderCheckinService
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderRepository
+import uk.gov.justice.digital.hmpps.esupervisionapi.utils.CreateCheckinRequest
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+
+data class NotificationContext(
+  val today: ZonedDateTime,
+  val notificationLeadTime: Duration,
+  val checkinDate: ZonedDateTime = today.plus(notificationLeadTime),
+) {
+  fun isCheckinDay(offender: Offender): Boolean {
+    if (offender.firstCheckin != null) {
+      val firstCheckin = offender.firstCheckin!!.atStartOfDay(ZoneOffset.UTC)
+      val delta = Duration.between(firstCheckin, checkinDate)
+      return delta.toDays() / offender.checkinInterval.toDays() == 0L
+    }
+    return false
+  }
+}
+
+@Component
+class CheckinNotifier(
+  private val offenderRepository: OffenderRepository,
+  private val offenderCheckinRepository: OffenderCheckinRepository,
+  private val offenderCheckinService: OffenderCheckinService,
+  private val clock: Clock,
+) {
+
+  val notificationLeadTime: Duration = Duration.ofDays(0)
+
+  /**
+   * This method is meant to be called via a scheduling mechanism and not directly.
+   *
+   * It processes relevant Offender records, determines whether a notification should be
+   * sent and attempts to send it.
+   *
+   * We process a stream of Offenders but catch individual errors - we don't want to
+   * abort the transaction because a single error. We want the notification ID
+   * saved in the OffenderCheckin record.
+   */
+  @Scheduled(cron = "0 0 3,5 * * *")
+  // @Scheduled(cron = "*/30 * * * * *")
+  @SchedulerLock(
+    name = "CheckinNotifier - send notifications",
+    lockAtLeastFor = "PT5S",
+    lockAtMostFor = "PT30S",
+  )
+  fun process() {
+    LOG.info("processing starts")
+
+    val now = clock.instant()
+    val startOfDayUtc: ZonedDateTime = startOfDay(now, ZoneOffset.UTC)
+
+    val context = NotificationContext(
+      startOfDayUtc,
+      notificationLeadTime,
+    )
+
+    val offenders = offenderRepository.findAllCheckinNotificationCandidates(
+      startOfDayUtc,
+      startOfDayUtc.plusDays(1),
+    )
+    var numProcessed = 0
+    var numErrors = 0
+    for (offender in offenders) {
+      try {
+        processOffender(offender, context)
+        numProcessed += 1
+      } catch (e: Exception) {
+        LOG.warn("Error processing offender=${offender.uuid}", e)
+        numErrors += 1
+      }
+    }
+
+    LOG.info(
+      "processing ends. processed={}, errors={}, took={} ms",
+      numProcessed,
+      numErrors,
+      Duration.between(now, clock.instant()),
+    )
+  }
+
+  internal fun processOffender(offender: Offender, context: NotificationContext) {
+    // assumptions:
+    // - no `OffenderCheckin` records with due date between `context.today`, context.potentialCheckin
+    val isCheckinDay = context.isCheckinDay(offender)
+    LOG.debug("is offender={} due for a checkin? {}", offender.uuid, if (isCheckinDay) "yes" else "no")
+    if (isCheckinDay) {
+      offenderCheckinService.createCheckin(
+        CreateCheckinRequest(
+          offender.practitioner.uuid,
+          offender.uuid,
+          context.checkinDate.toLocalDate(),
+        ),
+      )
+    }
+  }
+
+  private fun startOfDay(now: Instant, offset: ZoneOffset): ZonedDateTime = now.atZone(offset)
+    .withHour(0)
+    .withMinute(0)
+    .withSecond(0)
+    .withNano(0)
+
+  companion object {
+    private val LOG = LoggerFactory.getLogger(CheckinNotifier::class.java)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/CheckinNotifier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/CheckinNotifier.kt
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.Offender
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderCheckinDto
-import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderCheckinRepository
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderCheckinService
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderRepository
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.CreateCheckinRequest
@@ -35,7 +34,6 @@ data class NotificationContext(
 @Component
 class CheckinNotifier(
   private val offenderRepository: OffenderRepository,
-  private val offenderCheckinRepository: OffenderCheckinRepository,
   private val offenderCheckinService: OffenderCheckinService,
   private val clock: Clock,
 ) {
@@ -49,7 +47,7 @@ class CheckinNotifier(
    * sent and attempts to send it.
    *
    * We process a stream of Offenders but catch individual errors - we don't want to
-   * abort the transaction because a single error. We want the notification ID
+   * abort the transaction because of a single error. We want the notification ID
    * saved in the OffenderCheckin record.
    */
   @Scheduled(cron = "#{@appConfig.checkinNotificationCron}")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/CheckinNotifier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/CheckinNotifier.kt
@@ -13,17 +13,18 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.utils.CreateCheckinRequest
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
+import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
 
-data class NotificationContext(
+internal data class NotificationContext(
   val today: ZonedDateTime,
   val notificationLeadTime: Duration,
   val checkinDate: ZonedDateTime = today.plus(notificationLeadTime),
 ) {
   fun isCheckinDay(offender: Offender): Boolean {
-    if (offender.firstCheckin != null) {
-      val firstCheckin = offender.firstCheckin!!.atStartOfDay(ZoneOffset.UTC)
+    val firstCheckin = offender.firstCheckin?.withZoneSameInstant(ZoneId.of("UTC"))
+    if (firstCheckin != null) {
       val delta = Duration.between(firstCheckin, checkinDate)
       return delta.toDays() / offender.checkinInterval.toDays() == 0L
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/CheckinNotifier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/CheckinNotifier.kt
@@ -52,9 +52,7 @@ class CheckinNotifier(
    * abort the transaction because a single error. We want the notification ID
    * saved in the OffenderCheckin record.
    */
-  // @Scheduled(cron = "0 0 3,5 * * *") // PROD
-  @Scheduled(cron = "0 */15 * * * *")
-  // @Scheduled(cron = "*/30 * * * * *") // LOCAL
+  @Scheduled(cron = "#{@appConfig.checkinNotificationCron}")
   @SchedulerLock(
     name = "CheckinNotifier - send notifications",
     lockAtLeastFor = "PT5S",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/CheckinNotifier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/CheckinNotifier.kt
@@ -86,9 +86,9 @@ class CheckinNotifier(
 
     for (offender in offenders) {
       try {
-        val checkin = processOffender(offender, context)
+        processOffender(offender, context)
         numProcessed += 1
-        numNotifAttempts += if ((checkin?.notifications?.results?.size ?: 0) > 0) 1 else 0
+        numNotifAttempts += 1
       } catch (e: Exception) {
         LOG.warn("Error processing offender=${offender.uuid}", e)
         numErrors += 1

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/CheckinNotifier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/CheckinNotifier.kt
@@ -55,7 +55,7 @@ class CheckinNotifier(
   @SchedulerLock(
     name = "CheckinNotifier - send notifications",
     lockAtLeastFor = "PT5S",
-    lockAtMostFor = "PT30S",
+    lockAtMostFor = "PT10M",
   )
   @Transactional
   fun process() {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/Schedlock.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/Schedlock.kt
@@ -1,0 +1,24 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.jobs
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.Instant
+
+@Entity
+@Table(name = "shedlock")
+open class Schedlock(
+  @Id
+  @Column(name = "name", length = 64, nullable = false)
+  open var name: String,
+
+  @Column(name = "lock_until", nullable = true)
+  open var lockUntil: Instant? = null,
+
+  @Column(name = "locked_at", nullable = true)
+  open var lockedAt: Instant? = null,
+
+  @Column(name = "locked_by", length = 255, nullable = true)
+  open var lockedBy: String? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/GovNotifyNotificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/GovNotifyNotificationService.kt
@@ -13,11 +13,6 @@ import java.time.Clock
 import java.time.Instant
 import java.time.ZoneId
 
-enum class NotificationMethodKey {
-  PHONE,
-  EMAIL,
-}
-
 @Service
 class GovNotifyNotificationService(
   private val clock: Clock,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/GovNotifyNotificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/GovNotifyNotificationService.kt
@@ -5,24 +5,30 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.esupervisionapi.config.AppConfig
 import uk.gov.justice.digital.hmpps.esupervisionapi.config.MessageTemplateConfig
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.NotificationResultSummary
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.NotificationResults
 import uk.gov.service.notify.NotificationClientApi
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
 import java.util.UUID
 
 @Service
 class GovNotifyNotificationService(
+  private val clock: Clock,
   private val notifyClient: NotificationClientApi,
   private val appConfig: AppConfig,
   private val notificationsConfig: MessageTemplateConfig,
 ) : NotificationService {
-  override fun sendMessage(message: Message, recipient: Contactable) {
+  override fun sendMessage(message: Message, recipient: Contactable): NotificationResults {
     val reference = UUID.randomUUID().toString()
-
-    recipient.contactMethods().forEach {
+    val notificationRefs = recipient.contactMethods().mapNotNull {
       dispatchNotification(it, reference, message)
     }
+    return notificationResults(clock.instant(), notificationRefs)
   }
 
-  fun dispatchNotification(method: NotificationMethod, reference: String, message: Message) {
+  fun dispatchNotification(method: NotificationMethod, reference: String, message: Message): NotificationReference? {
     val templateId = this.notificationsConfig.templatesFor(method).getTemplate(message.messageType)
     val personalisation = message.personalisationData(this.appConfig)
 
@@ -30,18 +36,54 @@ class GovNotifyNotificationService(
       when (method) {
         is PhoneNumber -> {
           val smsResponse = this.notifyClient.sendSms(templateId, method.phoneNumber, personalisation, reference)
+          return NotificationReference(method.method, smsResponse.notificationId)
         }
         is Email -> {
           val emailResponse = this.notifyClient.sendEmail(templateId, method.email, personalisation, reference)
+          return NotificationReference(method.method, emailResponse.notificationId)
         }
       }
     } catch (ex: Exception) {
       // log failure and continue
       LOGGER.error("Failed to send notification message", ex)
     }
+    return null
   }
 
   companion object {
     val LOGGER: Logger = LoggerFactory.getLogger(this::class.java)
   }
+}
+
+private fun notificationResults(
+  now: Instant,
+  inviteReferences: List<NotificationReference>,
+): NotificationResults {
+  val groupedInviteRefs = inviteReferences.groupBy { it.method }
+  val notificationTime = now.atZone(ZoneId.of("UTC"))
+  val phoneNotification = groupedInviteRefs.get(NotificationMethodKey.PHONE)?.first()
+  val emailNotification = groupedInviteRefs.get(NotificationMethodKey.EMAIL)?.first()
+
+  val phoneNotificationSummary = if (phoneNotification != null) {
+    NotificationResultSummary(
+      phoneNotification.notificationId,
+      notificationTime,
+      null,
+      null,
+    )
+  } else {
+    null
+  }
+  val emailNotificationSummary = if (emailNotification != null) {
+    NotificationResultSummary(
+      emailNotification.notificationId,
+      notificationTime,
+      null,
+      null,
+    )
+  } else {
+    null
+  }
+
+  return NotificationResults(listOfNotNull(phoneNotificationSummary, emailNotificationSummary))
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/NotificationMethod.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/NotificationMethod.kt
@@ -1,6 +1,17 @@
 package uk.gov.justice.digital.hmpps.esupervisionapi.notifications
 
-sealed class NotificationMethod
+enum class NotificationMethodKey {
+  PHONE,
+  EMAIL,
+}
 
-class PhoneNumber(val phoneNumber: String) : NotificationMethod()
-class Email(val email: String) : NotificationMethod()
+sealed class NotificationMethod {
+  abstract val method: NotificationMethodKey
+}
+
+data class PhoneNumber(val phoneNumber: String) : NotificationMethod() {
+  override val method = NotificationMethodKey.PHONE
+}
+data class Email(val email: String) : NotificationMethod() {
+  override val method = NotificationMethodKey.EMAIL
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/NotificationMethod.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/NotificationMethod.kt
@@ -1,17 +1,6 @@
 package uk.gov.justice.digital.hmpps.esupervisionapi.notifications
 
-enum class NotificationMethodKey {
-  PHONE,
-  EMAIL,
-}
+sealed class NotificationMethod
 
-sealed class NotificationMethod {
-  abstract val method: NotificationMethodKey
-}
-
-data class PhoneNumber(val phoneNumber: String) : NotificationMethod() {
-  override val method = NotificationMethodKey.PHONE
-}
-data class Email(val email: String) : NotificationMethod() {
-  override val method = NotificationMethodKey.EMAIL
-}
+data class PhoneNumber(val phoneNumber: String) : NotificationMethod()
+data class Email(val email: String) : NotificationMethod()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/NotificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/NotificationService.kt
@@ -1,13 +1,8 @@
 package uk.gov.justice.digital.hmpps.esupervisionapi.notifications
 
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.NotificationContext
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.NotificationResults
-import java.util.UUID
-
-data class NotificationReference(
-  val method: NotificationMethodKey,
-  val notificationId: UUID,
-)
 
 interface NotificationService {
-  fun sendMessage(message: Message, recipient: Contactable): NotificationResults
+  fun sendMessage(message: Message, recipient: Contactable, context: NotificationContext): NotificationResults
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/NotificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/NotificationService.kt
@@ -1,5 +1,13 @@
 package uk.gov.justice.digital.hmpps.esupervisionapi.notifications
 
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.NotificationResults
+import java.util.UUID
+
+data class NotificationReference(
+  val method: NotificationMethodKey,
+  val notificationId: UUID,
+)
+
 interface NotificationService {
-  fun sendMessage(message: Message, recipient: Contactable)
+  fun sendMessage(message: Message, recipient: Contactable): NotificationResults
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/OffenderCheckinInviteMessage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/OffenderCheckinInviteMessage.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.esupervisionapi.notifications
 import uk.gov.justice.digital.hmpps.esupervisionapi.config.AppConfig
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderCheckin
 import java.time.LocalDate
-import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.UUID
 
@@ -24,13 +23,12 @@ data class OffenderCheckinInviteMessage(
     get() = NotificationType.OffenderCheckinInvite
 
   companion object {
-    val LONDON_ZONE = ZoneId.of("Europe/London")
     val DATE_FORMAT = DateTimeFormatter.ofPattern("dd/MM/yyyy")
 
     fun fromCheckin(checkin: OffenderCheckin): OffenderCheckinInviteMessage = OffenderCheckinInviteMessage(
       firstName = checkin.offender.firstName,
       lastName = checkin.offender.lastName,
-      checkinDueDate = checkin.dueDate.withZoneSameLocal(LONDON_ZONE).toLocalDate(),
+      checkinDueDate = checkin.dueDate,
       checkinUuid = checkin.uuid,
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/OffenderCheckinInviteMessage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/OffenderCheckinInviteMessage.kt
@@ -30,8 +30,6 @@ data class OffenderCheckinInviteMessage(
     fun fromCheckin(checkin: OffenderCheckin): OffenderCheckinInviteMessage = OffenderCheckinInviteMessage(
       firstName = checkin.offender.firstName,
       lastName = checkin.offender.lastName,
-      // checkinDueDate = ZonedDateTime.of(checkin.dueDate, LocalTime.of(0, 0, 0), LONDON_ZONE),
-      // checkinDueDate = ZonedDateTime.ofInstant(checkin.dueDate,LONDON_ZONE).toLocalDate(),
       checkinDueDate = checkin.dueDate.withZoneSameLocal(LONDON_ZONE).toLocalDate(),
       checkinUuid = checkin.uuid,
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/OffenderCheckinInviteMessage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/OffenderCheckinInviteMessage.kt
@@ -4,7 +4,6 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.config.AppConfig
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderCheckin
 import java.time.LocalDate
 import java.time.ZoneId
-import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.util.UUID
 
@@ -31,7 +30,9 @@ data class OffenderCheckinInviteMessage(
     fun fromCheckin(checkin: OffenderCheckin): OffenderCheckinInviteMessage = OffenderCheckinInviteMessage(
       firstName = checkin.offender.firstName,
       lastName = checkin.offender.lastName,
-      checkinDueDate = ZonedDateTime.ofInstant(checkin.dueDate, LONDON_ZONE).toLocalDate(),
+      // checkinDueDate = ZonedDateTime.of(checkin.dueDate, LocalTime.of(0, 0, 0), LONDON_ZONE),
+      // checkinDueDate = ZonedDateTime.ofInstant(checkin.dueDate,LONDON_ZONE).toLocalDate(),
+      checkinDueDate = checkin.dueDate.withZoneSameLocal(LONDON_ZONE).toLocalDate(),
       checkinUuid = checkin.uuid,
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinDto.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 import java.net.URL
 import java.time.Instant
+import java.time.ZonedDateTime
 import java.util.UUID
 
 enum class CheckinStatus {
@@ -31,7 +32,7 @@ typealias SurveyContents = Map<String, Object>
 data class OffenderCheckinDto(
   val uuid: UUID,
   val status: CheckinStatus,
-  val dueDate: Instant,
+  val dueDate: ZonedDateTime,
   val offender: OffenderDto,
   val submittedOn: Instant?,
   val surveyResponse: SurveyContents?,
@@ -44,6 +45,7 @@ data class OffenderCheckinDto(
   val videoUrl: URL?,
   val autoIdCheck: AutomatedIdVerificationResult?,
   val manualIdCheck: ManualIdVerificationResult?,
+  val notifications: NotificationResults?,
 ) {
 
   @get:JsonProperty("flaggedResponses")
@@ -102,3 +104,17 @@ fun flaggedFor20250710pilot(survey: SurveyContents): List<String> {
 
   return result.toList()
 }
+
+data class NotificationResultSummary(
+  val notificationId: UUID,
+  val timestamp: ZonedDateTime,
+  val status: String?,
+  val error: String?,
+)
+
+/**
+ * NOTE: stored in as JSON in the DB
+ */
+data class NotificationResults(
+  val results: List<NotificationResultSummary>,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinDto.kt
@@ -105,8 +105,43 @@ fun flaggedFor20250710pilot(survey: SurveyContents): List<String> {
   return result.toList()
 }
 
+enum class NotificationContextType {
+  SCHEDULED_JOB,
+  SINGLE,
+}
+
+sealed class NotificationContext {
+  /**
+   * Answers *why* are we sending the notification
+   */
+  abstract val type: NotificationContextType
+
+  /**
+   * Allows us to link it to other information
+   */
+  abstract val reference: String
+}
+
+/**
+ * To be used for bulk notifications (e.g., in a scheduled job, so that we can link
+ * are notifications to that job).
+ */
+data class BulkNotificationContext(val value: UUID) : NotificationContext() {
+  override val type: NotificationContextType = NotificationContextType.SCHEDULED_JOB
+  override val reference: String = value.toString()
+}
+
+/**
+ * To be used for one-off notification.
+ */
+data class SingleNotificationContext(val value: UUID) : NotificationContext() {
+  override val type: NotificationContextType = NotificationContextType.SINGLE
+  override val reference: String = value.toString()
+}
+
 data class NotificationResultSummary(
   val notificationId: UUID,
+  val reference: NotificationContext,
   val timestamp: ZonedDateTime,
   val status: String?,
   val error: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinDto.kt
@@ -45,7 +45,6 @@ data class OffenderCheckinDto(
   val videoUrl: URL?,
   val autoIdCheck: AutomatedIdVerificationResult?,
   val manualIdCheck: ManualIdVerificationResult?,
-  val notifications: NotificationResults?,
 ) {
 
   @get:JsonProperty("flaggedResponses")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinDto.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 import java.net.URL
 import java.time.Instant
+import java.time.LocalDate
 import java.time.ZonedDateTime
 import java.util.UUID
 
@@ -32,7 +33,7 @@ typealias SurveyContents = Map<String, Object>
 data class OffenderCheckinDto(
   val uuid: UUID,
   val status: CheckinStatus,
-  val dueDate: ZonedDateTime,
+  val dueDate: LocalDate,
   val offender: OffenderDto,
   val submittedOn: Instant?,
   val surveyResponse: SurveyContents?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinRepository.kt
@@ -53,13 +53,6 @@ open class OffenderCheckin(
   @JdbcTypeCode(SqlTypes.JSON)
   open var surveyResponse: Map<String, Object>?,
 
-  /**
-   * Will hold the latest status and/or error of any sent notifications.
-   */
-  @Column("notifications", nullable = true)
-  @JdbcTypeCode(SqlTypes.JSON)
-  open var notifications: NotificationResults?,
-
   @Column("due_date")
   open var dueDate: ZonedDateTime,
 
@@ -84,7 +77,6 @@ open class OffenderCheckin(
     videoUrl = resourceLocator.getCheckinVideo(this),
     autoIdCheck = autoIdCheck,
     manualIdCheck = manualIdCheck,
-    notifications = notifications,
   )
 
   companion object {}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinRepository.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.practitioner.Practitioner
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.AEntity
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.ResourceLocator
 import java.time.Instant
+import java.time.ZonedDateTime
 import java.util.Optional
 import java.util.UUID
 
@@ -52,8 +53,15 @@ open class OffenderCheckin(
   @JdbcTypeCode(SqlTypes.JSON)
   open var surveyResponse: Map<String, Object>?,
 
+  /**
+   * Will hold the latest status and/or error of any sent notifications.
+   */
+  @Column("notifications", nullable = true)
+  @JdbcTypeCode(SqlTypes.JSON)
+  open var notifications: NotificationResults?,
+
   @Column("due_date")
-  open var dueDate: Instant,
+  open var dueDate: ZonedDateTime,
 
   @Column("id_check_auto", nullable = true)
   @Enumerated(EnumType.STRING)
@@ -76,7 +84,10 @@ open class OffenderCheckin(
     videoUrl = resourceLocator.getCheckinVideo(this),
     autoIdCheck = autoIdCheck,
     manualIdCheck = manualIdCheck,
+    notifications = notifications,
   )
+
+  companion object {}
 }
 
 @Repository

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinRepository.kt
@@ -17,7 +17,7 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.practitioner.Practitioner
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.AEntity
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.ResourceLocator
 import java.time.Instant
-import java.time.ZonedDateTime
+import java.time.LocalDate
 import java.util.Optional
 import java.util.UUID
 
@@ -54,7 +54,7 @@ open class OffenderCheckin(
   open var surveyResponse: Map<String, Object>?,
 
   @Column("due_date")
-  open var dueDate: ZonedDateTime,
+  open var dueDate: LocalDate,
 
   @Column("id_check_auto", nullable = true)
   @Enumerated(EnumType.STRING)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinResource.kt
@@ -74,7 +74,7 @@ class OffenderCheckinResource(
     if (bindingResult.hasErrors()) {
       throw intoResponseStatusException(bindingResult)
     }
-    val checkin = offenderCheckinService.createCheckin(createCheckin)
+    val checkin = offenderCheckinService.createCheckin(createCheckin, SingleNotificationContext(UUID.randomUUID()))
     return ResponseEntity.ok(checkin)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinService.kt
@@ -9,7 +9,6 @@ import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.web.server.ResponseStatusException
 import org.springframework.web.servlet.resource.NoResourceFoundException
-import uk.gov.justice.digital.hmpps.esupervisionapi.config.CheckinNotifierConfiguration
 import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.NotificationService
 import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.OffenderCheckinInviteMessage
 import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.PractitionerCheckinSubmittedMessage
@@ -43,7 +42,6 @@ data class UploadLocationTypes(
 @Service
 class OffenderCheckinService(
   private val clock: Clock,
-  private val checkinNotifierConfig: CheckinNotifierConfiguration,
   private val checkinRepository: OffenderCheckinRepository,
   private val offenderRepository: OffenderRepository,
   private val practitionerRepository: PractitionerRepository,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinService.kt
@@ -86,15 +86,13 @@ class OffenderCheckinService(
       dueDate = dueDateUTC,
       autoIdCheck = null,
       manualIdCheck = null,
-      notifications = null,
     )
 
     val saved = checkinRepository.save(checkin)
 
     // notify PoP of checkin invite
     val inviteMessage = OffenderCheckinInviteMessage.fromCheckin(checkin)
-    val currentResults = this.notificationService.sendMessage(inviteMessage, checkin.offender, notificationContext)
-    mergeNotificationResults(saved, currentResults)
+    this.notificationService.sendMessage(inviteMessage, checkin.offender, notificationContext)
 
     val savedWithNotificationRefs = checkinRepository.save(saved)
 
@@ -249,12 +247,11 @@ class OffenderCheckinService(
     validateUnscheduledNotification(clock.instant(), checkin)
 
     val inviteMessage = OffenderCheckinInviteMessage.fromCheckin(checkin)
-    val currentResults = this.notificationService.sendMessage(
+    this.notificationService.sendMessage(
       inviteMessage,
       checkin.offender,
       SingleNotificationContext(UUID.randomUUID()),
     )
-    mergeNotificationResults(checkin, currentResults)
 
     val saved = checkinRepository.save(checkin)
     return saved.dto(this.s3UploadService)
@@ -269,23 +266,7 @@ class OffenderCheckinService(
     }
 
     private fun validateUnscheduledNotification(now: Instant, checkin: OffenderCheckin) {
-      val notifications = checkin.notifications
-      if (notifications != null && notifications.results.isNotEmpty()) {
-        val latest = notifications.results.maxBy { it.timestamp }.timestamp
-        val now = now.atZone(ZoneId.of("UTC"))
-        val minDelta = Duration.ofMinutes(2)
-        if (Duration.between(latest, now) < minDelta) {
-          throw BadArgumentException("Only one unscheduled notification per $minDelta allowed")
-        }
-      }
-    }
-
-    private fun mergeNotificationResults(checkin: OffenderCheckin, results: NotificationResults) {
-      checkin.notifications = if (checkin.notifications != null) {
-        checkin.notifications!!.copy(results = checkin.notifications!!.results + results.results)
-      } else {
-        results
-      }
+      TODO("not implemented yet")
     }
 
     private val LOG = LoggerFactory.getLogger(this::class.java)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinService.kt
@@ -57,9 +57,9 @@ class OffenderCheckinService(
 
   fun createCheckin(createCheckin: CreateCheckinRequest): OffenderCheckinDto {
     val now = clock.instant()
-    val dueDateUTC = createCheckin.dueDate.atStartOfDay(ZoneId.of("UTC"))
-    val reqDueDate = Instant.from(dueDateUTC)
-    if (reqDueDate < now) {
+    val utcZone = ZoneId.of("UTC")
+    val dueDateUTC = createCheckin.dueDate.atStartOfDay(utcZone)
+    if (dueDateUTC.toLocalDate() < now.atZone(utcZone).toLocalDate()) {
       throw BadArgumentException("Due date is in the past: ${createCheckin.dueDate}")
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.esupervisionapi.offender
 
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.domain.PageRequest
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
@@ -49,6 +50,7 @@ class OffenderCheckinService(
   private val s3UploadService: S3UploadService,
   private val notificationService: NotificationService,
   @Qualifier("rekognitionS3") private val rekogS3UploadService: S3UploadService,
+  @Value("\${app.scheduling.checkin-notification.window:72h}") val checkinWindow: Duration,
 ) {
 
   fun getCheckin(uuid: UUID): Optional<OffenderCheckinDto> {
@@ -120,7 +122,7 @@ class OffenderCheckinService(
 
     val now = clock.instant()
     val submissionDate = now.atZone(clock.zone).toLocalDate()
-    val cutoff = checkin.dueDate.withZoneSameLocal(clock.zone).plus(checkinNotifierConfig.checkinWindow)
+    val cutoff = checkin.dueDate.withZoneSameLocal(clock.zone).plus(checkinWindow)
     if (submissionDate < cutoff.toLocalDate()) {
       throw InvalidStateTransitionException("Checkin submission past due date", checkin)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinService.kt
@@ -121,7 +121,7 @@ class OffenderCheckinService(
     val now = clock.instant()
     val submissionDate = now.atZone(clock.zone).toLocalDate()
     val cutoff = checkin.dueDate.withZoneSameLocal(clock.zone).plus(checkinWindow)
-    if (submissionDate < cutoff.toLocalDate()) {
+    if (cutoff.toLocalDate() <= submissionDate) {
       throw InvalidStateTransitionException("Checkin submission past due date", checkin)
     }
     validateCheckinUpdatable(checkin)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinService.kt
@@ -25,6 +25,7 @@ import java.net.URL
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
+import java.time.Period
 import java.util.Optional
 import java.util.UUID
 import kotlin.jvm.optionals.getOrElse
@@ -120,7 +121,7 @@ class OffenderCheckinService(
 
     val now = clock.instant()
     val submissionDate = now.atZone(clock.zone).toLocalDate()
-    val cutoff = checkin.dueDate.plus(checkinWindow)
+    val cutoff = checkin.dueDate.plus(Period.ofDays(checkinWindow.toDays().toInt()))
     if (cutoff <= submissionDate) {
       throw InvalidStateTransitionException("Checkin submission past due date", checkin)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinService.kt
@@ -83,7 +83,7 @@ class OffenderCheckinService(
       reviewedBy = null,
       status = CheckinStatus.CREATED,
       surveyResponse = null,
-      dueDate = createCheckin.dueDate.atStartOfDay(clock.zone),
+      dueDate = createCheckin.dueDate,
       autoIdCheck = null,
       manualIdCheck = null,
     )
@@ -120,8 +120,8 @@ class OffenderCheckinService(
 
     val now = clock.instant()
     val submissionDate = now.atZone(clock.zone).toLocalDate()
-    val cutoff = checkin.dueDate.withZoneSameLocal(clock.zone).plus(checkinWindow)
-    if (cutoff.toLocalDate() <= submissionDate) {
+    val cutoff = checkin.dueDate.plus(checkinWindow)
+    if (cutoff <= submissionDate) {
       throw InvalidStateTransitionException("Checkin submission past due date", checkin)
     }
     validateCheckinUpdatable(checkin)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderDto.kt
@@ -22,7 +22,7 @@ data class OffenderDto(
   // not every context requires the photo URL, so we only include when needed
   @Schema(description = "A presigned S3 URL")
   val photoUrl: URL?,
-  @JsonDeserialize(using = LocalDateDeserializer::class) val nextCheckinDate: LocalDate,
+  @JsonDeserialize(using = LocalDateDeserializer::class) val firstCheckin: LocalDate?,
   val checkinInterval: CheckinInterval,
 )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderDto.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.utils.LocalDateDeserializer
 import java.net.URL
 import java.time.Instant
 import java.time.LocalDate
+import java.time.ZoneId
 import java.util.UUID
 
 data class OffenderDto(
@@ -24,6 +25,7 @@ data class OffenderDto(
   val photoUrl: URL?,
   @JsonDeserialize(using = LocalDateDeserializer::class) val firstCheckin: LocalDate?,
   val checkinInterval: CheckinInterval,
+  val zoneId: ZoneId,
 )
 
 data class OffenderSetupDto(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderDto.kt
@@ -7,7 +7,6 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.utils.LocalDateDeserializer
 import java.net.URL
 import java.time.Instant
 import java.time.LocalDate
-import java.time.ZoneId
 import java.util.UUID
 
 data class OffenderDto(
@@ -25,7 +24,6 @@ data class OffenderDto(
   val photoUrl: URL?,
   @JsonDeserialize(using = LocalDateDeserializer::class) val firstCheckin: LocalDate?,
   val checkinInterval: CheckinInterval,
-  val zoneId: ZoneId,
 )
 
 data class OffenderSetupDto(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderDto.kt
@@ -22,6 +22,8 @@ data class OffenderDto(
   // not every context requires the photo URL, so we only include when needed
   @Schema(description = "A presigned S3 URL")
   val photoUrl: URL?,
+  @JsonDeserialize(using = LocalDateDeserializer::class) val nextCheckinDate: LocalDate,
+  val checkinInterval: CheckinInterval,
 )
 
 data class OffenderSetupDto(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderInfo.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderInfo.kt
@@ -9,17 +9,11 @@ import java.time.Duration
 import java.time.LocalDate
 import java.util.UUID
 
-enum class CheckinInterval {
-  WEEKLY,
-  TWO_WEEKS,
-  FOUR_WEEKS,
+enum class CheckinInterval(val duration: Duration) {
+  WEEKLY(Duration.ofDays(7)),
+  TWO_WEEKS(Duration.ofDays(14)),
+  FOUR_WEEKS(Duration.ofDays(28)),
   ;
-
-  fun toDuration(): Duration = when (this) {
-    WEEKLY -> Duration.ofDays(7)
-    TWO_WEEKS -> Duration.ofDays(14)
-    FOUR_WEEKS -> Duration.ofDays(28)
-  }
 
   companion object {
     fun fromDuration(duration: Duration): CheckinInterval = when (duration.toDays()) {
@@ -53,7 +47,7 @@ data class OffenderInfo(
   val phoneNumber: String? = null,
 
   @JsonDeserialize(using = LocalDateDeserializer::class)
-  val nextCheckinDate: LocalDate,
+  val firstCheckinDate: LocalDate,
 
   val checkinInterval: CheckinInterval,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderInfo.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderInfo.kt
@@ -5,8 +5,31 @@ import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.LocalDateDeserializer
+import java.time.Duration
 import java.time.LocalDate
 import java.util.UUID
+
+enum class CheckinInterval {
+  WEEKLY,
+  TWO_WEEKS,
+  FOUR_WEEKS,
+  ;
+
+  fun toDuration(): Duration = when (this) {
+    WEEKLY -> Duration.ofDays(7)
+    TWO_WEEKS -> Duration.ofDays(14)
+    FOUR_WEEKS -> Duration.ofDays(28)
+  }
+
+  companion object {
+    fun fromDuration(duration: Duration): CheckinInterval = when (duration.toDays()) {
+      7L -> WEEKLY
+      14L -> TWO_WEEKS
+      28L -> FOUR_WEEKS
+      else -> throw IllegalArgumentException("Invalid checkin interval duration: $duration")
+    }
+  }
+}
 
 /**
  * Minimal information required to start offender onboarding.
@@ -28,4 +51,9 @@ data class OffenderInfo(
   val email: String? = null,
 
   val phoneNumber: String? = null,
+
+  @JsonDeserialize(using = LocalDateDeserializer::class)
+  val nextCheckinDate: LocalDate,
+
+  val checkinInterval: CheckinInterval,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderInfo.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderInfo.kt
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.Size
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.LocalDateDeserializer
 import java.time.Duration
 import java.time.LocalDate
+import java.time.ZoneId
 import java.util.UUID
 
 enum class CheckinInterval(val duration: Duration) {
@@ -50,4 +51,6 @@ data class OffenderInfo(
   val firstCheckinDate: LocalDate,
 
   val checkinInterval: CheckinInterval,
+
+  val zoneId: ZoneId = ZoneId.of(System.getenv("TZ") ?: "Europe/London"),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderInfo.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderInfo.kt
@@ -7,7 +7,6 @@ import jakarta.validation.constraints.Size
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.LocalDateDeserializer
 import java.time.Duration
 import java.time.LocalDate
-import java.time.ZoneId
 import java.util.UUID
 
 enum class CheckinInterval(val duration: Duration) {
@@ -51,6 +50,4 @@ data class OffenderInfo(
   val firstCheckinDate: LocalDate,
 
   val checkinInterval: CheckinInterval,
-
-  val zoneId: ZoneId = ZoneId.of(System.getenv("TZ") ?: "Europe/London"),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderRepository.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.PhoneNumber
 import uk.gov.justice.digital.hmpps.esupervisionapi.practitioner.Practitioner
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.AEntity
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.ResourceLocator
+import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
 import java.util.Optional
@@ -67,6 +68,12 @@ open class Offender(
   @Column(name = "phone_number", nullable = true, unique = true)
   open var phoneNumber: String? = null,
 
+  @Column("next_checkin", nullable = false)
+  open val nextCheckin: LocalDate,
+
+  @Column("checkin_interval", nullable = false, columnDefinition = "interval")
+  open val checkinInterval: Duration,
+
   @ManyToOne(cascade = [CascadeType.DETACH], fetch = FetchType.LAZY)
   @JoinColumn(name = "practitioner_id", referencedColumnName = "id", nullable = false)
   open var practitioner: Practitioner,
@@ -82,6 +89,8 @@ open class Offender(
     phoneNumber = phoneNumber,
     createdAt = createdAt,
     photoUrl = resourceLocator.getOffenderPhoto(this),
+    nextCheckinDate = nextCheckin,
+    checkinInterval = CheckinInterval.fromDuration(checkinInterval),
   )
 
   override fun contactMethods(): Iterable<NotificationMethod> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderRepository.kt
@@ -23,7 +23,6 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.utils.ResourceLocator
 import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
-import java.time.ZonedDateTime
 import java.util.Optional
 import java.util.UUID
 import java.util.stream.Stream
@@ -80,7 +79,7 @@ open class Offender(
    * will be created.
    */
   @Column("first_checkin", nullable = true)
-  open val firstCheckin: ZonedDateTime? = null,
+  open val firstCheckin: LocalDate? = null,
 
   @Column("checkin_interval", nullable = false)
   open val checkinInterval: Duration,
@@ -100,7 +99,7 @@ open class Offender(
     phoneNumber = phoneNumber,
     createdAt = createdAt,
     photoUrl = resourceLocator.getOffenderPhoto(this),
-    firstCheckin = firstCheckin?.toLocalDate(),
+    firstCheckin = firstCheckin,
     checkinInterval = CheckinInterval.fromDuration(checkinInterval),
   )
 
@@ -147,12 +146,12 @@ interface OffenderRepository : org.springframework.data.jpa.repository.JpaReposi
                         and c.status = 'CREATED')
         """,
   )
-  fun findAllCheckinNotificationCandidates(lowerBoundInclusive: ZonedDateTime, upperBoundExclusive: ZonedDateTime): Stream<Offender>
+  fun findAllCheckinNotificationCandidates(lowerBoundInclusive: LocalDate, upperBoundExclusive: LocalDate): Stream<Offender>
 }
 
 /**
  * When a practitioner adds an offender, a record for the setup process is created.
- * This give us an UUID to use until the actual offender record can be created.
+ * This gives us a UUID to use until the actual offender record can be created.
  */
 @Entity
 @Table(name = "offender_setup")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderRepository.kt
@@ -23,6 +23,7 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.utils.ResourceLocator
 import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
+import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.util.Optional
 import java.util.UUID
@@ -72,7 +73,13 @@ open class Offender(
   open var phoneNumber: String? = null,
 
   @Column("first_checkin", nullable = true)
-  open val firstCheckin: LocalDate? = null,
+  open val firstCheckin: ZonedDateTime? = null,
+
+  /**
+   * Used for scheduling
+   */
+  @Column("zone_id", nullable = false)
+  open val zoneId: ZoneId,
 
   @Column("checkin_interval", nullable = false)
   open val checkinInterval: Duration,
@@ -92,8 +99,9 @@ open class Offender(
     phoneNumber = phoneNumber,
     createdAt = createdAt,
     photoUrl = resourceLocator.getOffenderPhoto(this),
-    firstCheckin = firstCheckin,
+    firstCheckin = firstCheckin?.toLocalDate(),
     checkinInterval = CheckinInterval.fromDuration(checkinInterval),
+    zoneId = zoneId,
   )
 
   override fun contactMethods(): Iterable<NotificationMethod> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderRepository.kt
@@ -72,6 +72,14 @@ open class Offender(
   @Column(name = "phone_number", nullable = true, unique = true)
   open var phoneNumber: String? = null,
 
+  /**
+   * Marks the current schedule's date of first checkin. The following checkin
+   * due dates will be calculated based on this property and `checkinInterval`
+   *
+   * When the schedule needs to change, this date will be updated, effectively
+   * marking the start of the new schedule. No checkins for the "old" schedule
+   * will be created.
+   */
   @Column("first_checkin", nullable = true)
   open val firstCheckin: ZonedDateTime? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderRepository.kt
@@ -23,7 +23,6 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.utils.ResourceLocator
 import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
-import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.util.Optional
 import java.util.UUID
@@ -83,12 +82,6 @@ open class Offender(
   @Column("first_checkin", nullable = true)
   open val firstCheckin: ZonedDateTime? = null,
 
-  /**
-   * Used for scheduling
-   */
-  @Column("zone_id", nullable = false)
-  open val zoneId: ZoneId,
-
   @Column("checkin_interval", nullable = false)
   open val checkinInterval: Duration,
 
@@ -109,7 +102,6 @@ open class Offender(
     photoUrl = resourceLocator.getOffenderPhoto(this),
     firstCheckin = firstCheckin?.toLocalDate(),
     checkinInterval = CheckinInterval.fromDuration(checkinInterval),
-    zoneId = zoneId,
   )
 
   override fun contactMethods(): Iterable<NotificationMethod> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderSetupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderSetupService.kt
@@ -12,8 +12,11 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.practitioner.PractitionerRep
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.BadArgumentException
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.S3UploadService
 import java.time.Clock
+import java.time.ZoneId
 import java.util.Optional
 import java.util.UUID
+
+private val defaultTimeZone = ZoneId.of(System.getenv("TZ") ?: "Europe/London")
 
 @Service
 class OffenderSetupService(
@@ -49,9 +52,8 @@ class OffenderSetupService(
       createdAt = now,
       updatedAt = now,
       status = OffenderStatus.INITIAL,
-      firstCheckin = offenderInfo.firstCheckinDate.atStartOfDay(offenderInfo.zoneId),
+      firstCheckin = offenderInfo.firstCheckinDate.atStartOfDay(defaultTimeZone),
       checkinInterval = offenderInfo.checkinInterval.duration,
-      zoneId = offenderInfo.zoneId,
     )
 
     raiseOnConstraintViolation("contact information already in use") {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderSetupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderSetupService.kt
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.NotificationService
 import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.RegistrationConfirmationMessage
-import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderInfo
 import uk.gov.justice.digital.hmpps.esupervisionapi.practitioner.PractitionerRepository
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.BadArgumentException
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.S3UploadService
@@ -49,6 +48,8 @@ class OffenderSetupService(
       createdAt = now,
       updatedAt = now,
       status = OffenderStatus.INITIAL,
+      nextCheckin = offenderInfo.nextCheckinDate,
+      checkinInterval = offenderInfo.checkinInterval.toDuration(),
     )
 
     raiseOnConstraintViolation("contact information already in use") {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderSetupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderSetupService.kt
@@ -53,7 +53,7 @@ class OffenderSetupService(
       createdAt = now,
       updatedAt = now,
       status = OffenderStatus.INITIAL,
-      firstCheckin = offenderInfo.firstCheckinDate.atStartOfDay(defaultTimeZone),
+      firstCheckin = offenderInfo.firstCheckinDate,
       checkinInterval = offenderInfo.checkinInterval.duration,
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderSetupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderSetupService.kt
@@ -91,7 +91,7 @@ class OffenderSetupService(
 
     // send registration confirmation message to PoP
     val confirmationMessage = RegistrationConfirmationMessage.fromSetup(setup.get())
-    this.notificationService.sendMessage(confirmationMessage, offender)
+    this.notificationService.sendMessage(confirmationMessage, offender, SingleNotificationContext(UUID.randomUUID()))
 
     return saved.dto(this.s3UploadService)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderSetupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderSetupService.kt
@@ -49,8 +49,9 @@ class OffenderSetupService(
       createdAt = now,
       updatedAt = now,
       status = OffenderStatus.INITIAL,
-      firstCheckin = offenderInfo.firstCheckinDate,
+      firstCheckin = offenderInfo.firstCheckinDate.atStartOfDay(offenderInfo.zoneId),
       checkinInterval = offenderInfo.checkinInterval.duration,
+      zoneId = offenderInfo.zoneId,
     )
 
     raiseOnConstraintViolation("contact information already in use") {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/ResourceDtos.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/ResourceDtos.kt
@@ -18,6 +18,9 @@ fun Pageable.toPagination(): Pagination = Pagination(pageNumber, pageSize)
 data class LocationInfo(
   val url: URL,
   val contentType: String,
+  /**
+   * How long the `url` will be valid for.
+   */
   val duration: String,
 )
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,5 +1,9 @@
 app:
   hostedAt: http://localhost:3000
+  scheduling:
+    checkin-notification:
+      cron: "0 */15 * * * *"  # Development schedule (every 15 minutes)
+      # cron: "*/30 * * * * *"  # Local development schedule (every 30 seconds)
 
 hmpps-auth:
   url: "http://localhost:8090/auth"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,10 @@ app:
   hostedAt: ${HOSTED_AT}
   # how long should the presigned S3 URLs be valid for?
   upload-ttl-minutes: 10
+  scheduling:
+    checkin-notification:
+      #cron: "0 0 3,5 * * *"  # Production schedule (3 AM and 5 AM daily)
+      cron: "0 */15 * * * *"  # Development schedule (every 15 minutes)
 
 spring:
   application:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,9 @@ app:
   upload-ttl-minutes: 10
   scheduling:
     checkin-notification:
+      # How long, starting from dueDate, do we accept checkin submissions.
+      # Afterward the checkin's status is updated to EXPIRED.
+      window: 72h
       #cron: "0 0 3,5 * * *"  # Production schedule (3 AM and 5 AM daily)
       cron: "0 */15 * * * *"  # Development schedule (every 15 minutes)
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,6 +53,8 @@ spring:
         dialect: org.hibernate.dialect.PostgreSQLDialect
         hbm2ddl:
           auto: update
+        type:
+          preferred_duration_jdbc_type: INTERVAL_SECOND
 
 server:
   port: 8080

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/IntegrationTestBase.kt
@@ -9,6 +9,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.esupervisionapi.integration.wiremock.HmppsAuthApiExtension
 import uk.gov.justice.digital.hmpps.esupervisionapi.integration.wiremock.HmppsAuthApiExtension.Companion.hmppsAuth
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderCheckinRepository
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderRepository
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderSetupRepository
 import uk.gov.justice.digital.hmpps.esupervisionapi.practitioner.PractitionerRepository
@@ -33,6 +34,8 @@ abstract class IntegrationTestBase {
   @Autowired protected lateinit var offenderSetupRepository: OffenderSetupRepository
 
   @Autowired protected lateinit var offenderRepository: OffenderRepository
+
+  @Autowired protected lateinit var checkinRepository: OffenderCheckinRepository
 
   internal fun setAuthorisation(
     username: String? = "AUTH_ADM",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/OffenderCheckinTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/OffenderCheckinTest.kt
@@ -62,7 +62,7 @@ class OffenderCheckinTest : IntegrationTestBase() {
     dateOfBirth = LocalDate.of(1980, 1, 1),
     email = "jim@example.com",
     practitionerId = "alice",
-    nextCheckinDate = LocalDate.now().plusDays(1),
+    firstCheckinDate = LocalDate.now().plusDays(1),
     checkinInterval = CheckinInterval.WEEKLY,
   )
   var offender: OffenderDto? = null

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/OffenderCheckinTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/OffenderCheckinTest.kt
@@ -100,7 +100,7 @@ class OffenderCheckinTest : IntegrationTestBase() {
 
     val notifInOrder = inOrder(notificationService)
     // verify offender checking invite was sent
-    notifInOrder.verify(notificationService).sendMessage(any(), any())
+    notifInOrder.verify(notificationService).sendMessage(any(), any(), any())
 
     Assertions.assertEquals(CheckinStatus.CREATED, createCheckin.status)
 
@@ -136,7 +136,7 @@ class OffenderCheckinTest : IntegrationTestBase() {
       .returnResult()
 
     // verify a notification to the practitioner was sent
-    notifInOrder.verify(notificationService).sendMessage(any(), any())
+    notifInOrder.verify(notificationService).sendMessage(any(), any(), any())
     notifInOrder.verifyNoMoreInteractions()
 
     val submittedCheckin = offenderCheckinRepository.findByUuid(submitCheckin.responseBody!!.uuid).get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/OffenderCheckinTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/OffenderCheckinTest.kt
@@ -18,6 +18,7 @@ import org.springframework.test.web.reactive.server.expectBody
 import org.springframework.test.web.reactive.server.returnResult
 import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.NotificationService
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.AutomatedIdVerificationResult
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.CheckinInterval
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.CheckinStatus
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.ManualIdVerificationResult
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderCheckinDto
@@ -61,6 +62,8 @@ class OffenderCheckinTest : IntegrationTestBase() {
     dateOfBirth = LocalDate.of(1980, 1, 1),
     email = "jim@example.com",
     practitionerId = "alice",
+    nextCheckinDate = LocalDate.now().plusDays(1),
+    checkinInterval = CheckinInterval.WEEKLY,
   )
   var offender: OffenderDto? = null
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/OffenderSetupTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/OffenderSetupTest.kt
@@ -12,6 +12,7 @@ import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.EntityExchangeResult
 import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.CheckinInterval
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderDto
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderInfo
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderSetupDto
@@ -173,6 +174,8 @@ fun createOffenderInfo() = OffenderInfo(
   "Offerman",
   LocalDate.of(1970, 1, 1),
   "bob@example.com",
+  nextCheckinDate = LocalDate.now().plusDays(1),
+  checkinInterval = CheckinInterval.WEEKLY,
 )
 
 /**

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/OffenderSetupTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/OffenderSetupTest.kt
@@ -52,7 +52,10 @@ class OffenderSetupTest : IntegrationTestBase() {
    */
   @Test
   fun `successfully add an offender to the system`() {
-    val offenderInfo = createOffenderInfo()
+    val offenderInfo = createOffenderInfo(
+      firstCheckinDate = LocalDate.now(),
+      checkinInterval = CheckinInterval.WEEKLY,
+    )
     val setup = setupStartRequest(offenderInfo)
       .exchange()
       .expectStatus().isOk
@@ -75,7 +78,10 @@ class OffenderSetupTest : IntegrationTestBase() {
 
   @Test
   fun `adding an offender fails in various ways`() {
-    val offenderInfo = createOffenderInfo()
+    val offenderInfo = createOffenderInfo(
+      firstCheckinDate = LocalDate.now(),
+      checkinInterval = CheckinInterval.WEEKLY,
+    )
     val setupOK = setupStartRequest(offenderInfo)
       .exchange()
       .expectStatus().isOk
@@ -123,7 +129,10 @@ class OffenderSetupTest : IntegrationTestBase() {
    */
   @Test
   fun `terminating an offender setup`() {
-    val offenderInfo = createOffenderInfo()
+    val offenderInfo = createOffenderInfo(
+      firstCheckinDate = LocalDate.now(),
+      checkinInterval = CheckinInterval.WEEKLY,
+    )
     val setupOK = setupStartRequest(offenderInfo)
       .exchange()
       .expectStatus().isOk
@@ -166,25 +175,3 @@ class OffenderSetupTest : IntegrationTestBase() {
       .thenReturn(URI("https://the-bucket/offender-1").toURL())
   }
 }
-
-fun createOffenderInfo() = OffenderInfo(
-  UUID.randomUUID(),
-  "alice",
-  "Bob",
-  "Offerman",
-  LocalDate.of(1970, 1, 1),
-  "bob@example.com",
-  nextCheckinDate = LocalDate.now().plusDays(1),
-  checkinInterval = CheckinInterval.WEEKLY,
-)
-
-/**
- * Creates an example practitioner instance. `name` should be unique.
- */
-fun Practitioner.Companion.create(name: String): Practitioner = Practitioner(
-  name.lowercase(),
-  name,
-  "Practitioner",
-  "${name.lowercase()}@example.com",
-  roles = listOf(),
-)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/TestUtils.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/TestUtils.kt
@@ -1,0 +1,104 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.integration
+
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.AutomatedIdVerificationResult
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.CheckinInterval
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.CheckinStatus
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.ManualIdVerificationResult
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.NotificationResults
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.Offender
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderCheckin
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderInfo
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderStatus
+import uk.gov.justice.digital.hmpps.esupervisionapi.practitioner.Practitioner
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.util.UUID
+
+fun createOffenderInfo(
+  name: String = "Bob Offerman",
+  dateOfBirth: LocalDate = LocalDate.of(1970, 1, 1),
+  practitionerId: String = "alice",
+  firstCheckinDate: LocalDate,
+  checkinInterval: CheckinInterval = CheckinInterval.WEEKLY,
+) = OffenderInfo(
+  UUID.randomUUID(),
+  practitionerId,
+  name.split(" ").first(),
+  name.split(" ").last(),
+  dateOfBirth,
+  "${name.split(" ").first()}@example.com",
+  firstCheckinDate = firstCheckinDate,
+  checkinInterval = checkinInterval,
+)
+
+/**
+ * Creates an example practitioner instance. `name` should be unique.
+ */
+fun Practitioner.Companion.create(name: String): Practitioner = Practitioner(
+  name.lowercase(),
+  name,
+  "Practitioner",
+  "${name.lowercase()}@example.com",
+  roles = listOf(),
+)
+
+fun Offender.Companion.create(
+  name: String,
+  dateOfBirth: LocalDate = LocalDate.of(1970, 1, 1),
+  firstCheckinDate: LocalDate,
+  checkinInterval: CheckinInterval = CheckinInterval.WEEKLY,
+  status: OffenderStatus = OffenderStatus.INITIAL,
+  email: String? = null,
+  phoneNumber: String? = null,
+  createdAt: Instant = Instant.now(),
+  updatedAt: Instant = Instant.now(),
+  practitioner: Practitioner,
+): Offender {
+  val firstName = name.split(" ").first()
+  val lastName = name.split(" ").last()
+
+  return Offender(
+    uuid = UUID.randomUUID(),
+    firstName = firstName,
+    lastName = lastName,
+    dateOfBirth = dateOfBirth,
+    status = status,
+    createdAt = createdAt,
+    updatedAt = updatedAt,
+    email = email ?: "${lastName.lowercase()}@example.com",
+    phoneNumber = phoneNumber,
+    firstCheckin = firstCheckinDate,
+    checkinInterval = checkinInterval.duration,
+    practitioner = practitioner,
+  )
+}
+
+fun OffenderCheckin.Companion.create(
+  uuid: UUID = UUID.randomUUID(),
+  offender: Offender,
+  submittedAt: Instant? = null,
+  createdAt: Instant = Instant.now(),
+  reviewedBy: Practitioner? = null,
+  createdBy: Practitioner,
+  status: CheckinStatus = CheckinStatus.CREATED,
+  surveyResponse: Map<String, Object>? = null,
+  notifications: NotificationResults? = null,
+  dueDate: ZonedDateTime = ZonedDateTime.now(ZoneId.of("UTC")),
+  autoIdCheck: AutomatedIdVerificationResult? = null,
+  manualIdCheck: ManualIdVerificationResult? = null,
+): OffenderCheckin = OffenderCheckin(
+  uuid = uuid,
+  offender = offender,
+  submittedAt = submittedAt,
+  createdAt = createdAt,
+  reviewedBy = reviewedBy,
+  createdBy = createdBy,
+  status = status,
+  surveyResponse = surveyResponse,
+  notifications = notifications,
+  dueDate = dueDate,
+  autoIdCheck = autoIdCheck,
+  manualIdCheck = manualIdCheck,
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/TestUtils.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/TestUtils.kt
@@ -99,7 +99,6 @@ fun OffenderCheckin.Companion.create(
   createdBy = createdBy,
   status = status,
   surveyResponse = surveyResponse,
-  notifications = notifications,
   dueDate = dueDate,
   autoIdCheck = autoIdCheck,
   manualIdCheck = manualIdCheck,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/TestUtils.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/TestUtils.kt
@@ -13,7 +13,6 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.practitioner.Practitioner
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
-import java.time.ZonedDateTime
 import java.util.UUID
 
 fun createOffenderInfo(
@@ -47,7 +46,7 @@ fun Practitioner.Companion.create(name: String): Practitioner = Practitioner(
 fun Offender.Companion.create(
   name: String,
   dateOfBirth: LocalDate = LocalDate.of(1970, 1, 1),
-  firstCheckinDate: ZonedDateTime,
+  firstCheckinDate: LocalDate,
   checkinInterval: CheckinInterval = CheckinInterval.WEEKLY,
   zoneId: ZoneId = ZoneId.of("Europe/London"),
   status: OffenderStatus = OffenderStatus.INITIAL,
@@ -86,7 +85,7 @@ fun OffenderCheckin.Companion.create(
   status: CheckinStatus = CheckinStatus.CREATED,
   surveyResponse: Map<String, Object>? = null,
   notifications: NotificationResults? = null,
-  dueDate: ZonedDateTime = ZonedDateTime.now(ZoneId.of("UTC")),
+  dueDate: LocalDate = LocalDate.now(),
   autoIdCheck: AutomatedIdVerificationResult? = null,
   manualIdCheck: ManualIdVerificationResult? = null,
 ): OffenderCheckin = OffenderCheckin(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/TestUtils.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/TestUtils.kt
@@ -72,7 +72,6 @@ fun Offender.Companion.create(
     phoneNumber = phoneNumber,
     firstCheckin = firstCheckinDate,
     checkinInterval = checkinInterval.duration,
-    zoneId = zoneId,
     practitioner = practitioner,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/TestUtils.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/TestUtils.kt
@@ -47,8 +47,9 @@ fun Practitioner.Companion.create(name: String): Practitioner = Practitioner(
 fun Offender.Companion.create(
   name: String,
   dateOfBirth: LocalDate = LocalDate.of(1970, 1, 1),
-  firstCheckinDate: LocalDate,
+  firstCheckinDate: ZonedDateTime,
   checkinInterval: CheckinInterval = CheckinInterval.WEEKLY,
+  zoneId: ZoneId = ZoneId.of("Europe/London"),
   status: OffenderStatus = OffenderStatus.INITIAL,
   email: String? = null,
   phoneNumber: String? = null,
@@ -71,6 +72,7 @@ fun Offender.Companion.create(
     phoneNumber = phoneNumber,
     firstCheckin = firstCheckinDate,
     checkinInterval = checkinInterval.duration,
+    zoneId = zoneId,
     practitioner = practitioner,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/offender/OffenderRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/offender/OffenderRepositoryTest.kt
@@ -14,7 +14,6 @@ import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
-import java.time.ZonedDateTime
 
 class OffenderRepositoryTest : IntegrationTestBase() {
 
@@ -25,12 +24,12 @@ class OffenderRepositoryTest : IntegrationTestBase() {
     practitionerRepository.saveAll(listOf(practitionerAlice, practitionerBob))
 
     val now = Instant.now()
-    val today = LocalDate.now().atStartOfDay(ZoneId.of("UTC"))
+    val today = LocalDate.now()
 
-    fun newOffender(name: String, status: OffenderStatus, firstCheckinDat: ZonedDateTime, practitioner: Practitioner = practitionerAlice): Offender = Offender.create(
+    fun newOffender(name: String, status: OffenderStatus, firstCheckinDate: LocalDate, practitioner: Practitioner = practitionerAlice): Offender = Offender.create(
       name = name,
       status = status,
-      firstCheckinDate = today,
+      firstCheckinDate = firstCheckinDate,
       createdAt = now.minus(Duration.ofDays(20)),
       updatedAt = now.minus(Duration.ofDays(10)),
       practitioner = practitioner,
@@ -54,7 +53,7 @@ class OffenderRepositoryTest : IntegrationTestBase() {
   @Test
   @Transactional
   fun `get offenders due for an invite`() {
-    val now = LocalDate.now().atStartOfDay(ZoneId.of("UTC"))
+    val now = LocalDate.now()
     var offenders = offenderRepository.findAllCheckinNotificationCandidates(
       now,
       now.plusDays(1),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/offender/OffenderRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/offender/OffenderRepositoryTest.kt
@@ -13,7 +13,6 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.practitioner.Practitioner
 import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
-import java.time.ZoneId
 
 class OffenderRepositoryTest : IntegrationTestBase() {
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/offender/OffenderRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/offender/OffenderRepositoryTest.kt
@@ -30,7 +30,7 @@ class OffenderRepositoryTest : IntegrationTestBase() {
     fun newOffender(name: String, status: OffenderStatus, firstCheckinDat: ZonedDateTime, practitioner: Practitioner = practitionerAlice): Offender = Offender.create(
       name = name,
       status = status,
-      firstCheckinDate = today.toLocalDate(),
+      firstCheckinDate = today,
       createdAt = now.minus(Duration.ofDays(20)),
       updatedAt = now.minus(Duration.ofDays(10)),
       practitioner = practitioner,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/offender/OffenderRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/offender/OffenderRepositoryTest.kt
@@ -1,0 +1,81 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.integration.offender
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.esupervisionapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.esupervisionapi.integration.create
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.Offender
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderCheckin
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderStatus
+import uk.gov.justice.digital.hmpps.esupervisionapi.practitioner.Practitioner
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+class OffenderRepositoryTest : IntegrationTestBase() {
+
+  @BeforeEach
+  fun setupOffenders() {
+    val practitionerAlice = Practitioner.create("alice")
+    val practitionerBob = Practitioner.create("dave")
+    practitionerRepository.saveAll(listOf(practitionerAlice, practitionerBob))
+
+    val now = Instant.now()
+    val today = LocalDate.now().atStartOfDay(ZoneId.of("UTC"))
+
+    fun newOffender(name: String, status: OffenderStatus, firstCheckinDat: ZonedDateTime, practitioner: Practitioner = practitionerAlice): Offender = Offender.create(
+      name = name,
+      status = status,
+      firstCheckinDate = today.toLocalDate(),
+      createdAt = now.minus(Duration.ofDays(20)),
+      updatedAt = now.minus(Duration.ofDays(10)),
+      practitioner = practitioner,
+    )
+
+    val offender1 = newOffender("Offender(active) First", OffenderStatus.VERIFIED, today)
+    val offender2 = newOffender("Offender(active) Second", OffenderStatus.VERIFIED, today.plusDays(1))
+    val offender3 = newOffender("Offender(inactive) Third", OffenderStatus.INACTIVE, today)
+    val offender4 = newOffender("Offender(inactive) Fourth", OffenderStatus.INITIAL, today)
+
+    offenderRepository.saveAll(listOf(offender1, offender2, offender3, offender4))
+
+    val checkinForOffender2 = OffenderCheckin.create(
+      offender = offender2,
+      createdBy = practitionerAlice,
+      dueDate = today.plusDays(1),
+    )
+    checkinRepository.saveAll(listOf(checkinForOffender2))
+  }
+
+  @Test
+  @Transactional
+  fun `get offenders due for an invite`() {
+    val now = LocalDate.now().atStartOfDay(ZoneId.of("UTC"))
+    var offenders = offenderRepository.findAllCheckinNotificationCandidates(
+      now,
+      now.plusDays(1),
+    )
+      .toList()
+
+    // NOTE: we should get two records: 2 offenders have the right status,
+    // and our query *does not* filter out records that already have
+    // checkins  scheduled outside the specified bounds.
+    // We could move the calculations to the query but
+    // at the moment this would make testing (with H2 DB) impossible
+    Assertions.assertEquals(2, offenders.size)
+
+    offenders = offenderRepository.findAllCheckinNotificationCandidates(
+      now.plusDays(1),
+      now.plusDays(2),
+    )
+      .toList()
+
+    // NOTE: this time we expect one record as a checkin  is already
+    // in place for the specified time bounds
+    Assertions.assertEquals(1, offenders.size)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/offender/SurveyTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/offender/SurveyTest.kt
@@ -43,7 +43,6 @@ class SurveyTest {
     videoUrl = null,
     autoIdCheck = AutomatedIdVerificationResult.MATCH,
     manualIdCheck = null,
-    notifications = null,
   )
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/offender/SurveyTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/offender/SurveyTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.esupervisionapi.integration.offender
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.AutomatedIdVerificationResult
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.CheckinInterval
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.CheckinStatus
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderCheckinDto
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderDto
@@ -10,6 +11,7 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderStatus
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.SurveyContents
 import java.time.Instant
 import java.time.LocalDate
+import java.time.ZoneId
 import java.util.UUID
 
 class SurveyTest {
@@ -23,12 +25,14 @@ class SurveyTest {
     createdAt = Instant.now(),
     "bob@example.com",
     photoUrl = null,
+    firstCheckin = LocalDate.now(ZoneId.of("UTC")).plusDays(10),
+    checkinInterval = CheckinInterval.FOUR_WEEKS,
   )
 
   val checkinTemplate = OffenderCheckinDto(
     UUID.randomUUID(),
     status = CheckinStatus.SUBMITTED,
-    dueDate = Instant.now(),
+    dueDate = LocalDate.now().atStartOfDay(ZoneId.of("UTC")),
     offender = offender,
     submittedOn = Instant.now(),
     surveyResponse = mapOf(),
@@ -38,6 +42,7 @@ class SurveyTest {
     videoUrl = null,
     autoIdCheck = AutomatedIdVerificationResult.MATCH,
     manualIdCheck = null,
+    notifications = null,
   )
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/offender/SurveyTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/offender/SurveyTest.kt
@@ -32,7 +32,7 @@ class SurveyTest {
   val checkinTemplate = OffenderCheckinDto(
     UUID.randomUUID(),
     status = CheckinStatus.SUBMITTED,
-    dueDate = LocalDate.now().atStartOfDay(ZoneId.of("UTC")),
+    dueDate = LocalDate.now(),
     offender = offender,
     submittedOn = Instant.now(),
     surveyResponse = mapOf(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/offender/SurveyTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/offender/SurveyTest.kt
@@ -27,7 +27,6 @@ class SurveyTest {
     photoUrl = null,
     firstCheckin = LocalDate.now(ZoneId.of("UTC")).plusDays(10),
     checkinInterval = CheckinInterval.FOUR_WEEKS,
-    zoneId = ZoneId.of("Europe/London"),
   )
 
   val checkinTemplate = OffenderCheckinDto(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/offender/SurveyTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/offender/SurveyTest.kt
@@ -27,6 +27,7 @@ class SurveyTest {
     photoUrl = null,
     firstCheckin = LocalDate.now(ZoneId.of("UTC")).plusDays(10),
     checkinInterval = CheckinInterval.FOUR_WEEKS,
+    zoneId = ZoneId.of("Europe/London"),
   )
 
   val checkinTemplate = OffenderCheckinDto(

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -35,6 +35,8 @@ spring:
         dialect: org.hibernate.dialect.H2Dialect
         hbm2ddl:
           auto: update
+        type:
+          preferred_duration_jdbc_type: INTERVAL_SECOND
   h2:
     console:
       enabled: true


### PR DESCRIPTION
Adds a job executed on a schedule to create checkin records and send notifications to offenders.

Currently, the notifications are coupled to `NotificationService.createCheckin`. It's possible that a checkin record was created but notification was unsuccessful: it could be on our end, but also on GOV.UK Notify end or the receiving end. Determining what happened, in general case, can't happen immediately so a followup task is needed.

## Followup

We need another scheduled job that takes care of checkins for which the notification failed (for whatever reason) and attempts to send them again. 

This PR should be deployed along with  a corresponding UI PR: https://github.com/ministryofjustice/hmpps-esupervision-ui/pull/66

## Summary of changes

### model changes

- Adds date of first checkin to the Offender model along with a duration for the checkin frequency. At present only weekly, bi-weekly and every four weeks are supported within the UI and API. Add a CheckinFrequency enum for the supported cases and map to/from this type for persistance. The checkin duration is mapped to an interval column type within postgres.

### added CheckinNotifier class

The class uses the introduced scheduler lock to prevent from more than one instance of the job running.

The job goes over all relevant offender records, checks if it's time for a checkin, then creates the checkin (and that triggers a notification).

### added `unscheduledNotification` method

Meant to be uses by practitioners/admins to send notifications manually.

### update NotificationService to return notificaiton IDs

The notification IDs are then stored in`OffenderCheckin.notifications` to enable us to follow up on the notification status (that part is not implemented yet, it would probably be another scheduled job).
