### PR TITLE
`GET /offenders` endpoint requires practitioner uuid param now

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderRepository.kt
@@ -9,6 +9,8 @@ import jakarta.persistence.FetchType
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.Contactable
 import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.Email
@@ -95,6 +97,7 @@ interface OffenderRepository : org.springframework.data.jpa.repository.JpaReposi
   fun findByEmail(email: String): Optional<Offender>
   fun findByPhoneNumber(phoneNumber: String): Optional<Offender>
   fun findByUuid(uuid: UUID): Optional<Offender>
+  fun findAllByPractitioner(practitioner: Practitioner, pageable: Pageable): Page<Offender>
 }
 
 /**

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderResource.kt
@@ -25,12 +25,13 @@ class OffenderResource(
   @Operation(summary = "Returns a collection of offender records")
   @GetMapping
   fun getOffenders(
+    @RequestParam(required = true) practitionerUuid: String,
     @Parameter(description = "Zero-based page index")
     @RequestParam(defaultValue = "0") page: Int,
     @RequestParam(defaultValue = "20") @Max(100) size: Int,
   ): ResponseEntity<CollectionDto<OffenderDto>> {
     val pageRequest = PageRequest.of(page, size)
-    val offenders = offenderService.getOffenders(pageable = pageRequest)
+    val offenders = offenderService.getOffenders(practitionerUuid, pageable = pageRequest)
     return ResponseEntity.ok(
       CollectionDto(
         pagination = pageRequest.toPagination(),


### PR DESCRIPTION
This will allow the dashboard to show only the offenders assigned to a particular practitioner.
