### PR TITLE
Checkin upload location endpoint(s) cleanup

### DIFF
--- a/docs/http/full-checkin-flow.http
+++ b/docs/http/full-checkin-flow.http
@@ -1,7 +1,7 @@
 @practitioner_uuid = 1ba848cf-0fb8-4d24-868c-390a8c0bdb00
 
-## Get offender info
-GET {{HOST}}/offenders
+### Get offender info
+GET {{HOST}}/offenders?practitionerUuid={{practitioner_uuid}}
 Authorization: Bearer {{hmpps_auth.token}}
 
 > {%
@@ -29,7 +29,7 @@ Content-Type: application/json
 {
     "practitioner": "{{practitioner_uuid}}",
     "offender": "{{offender_uuid}}",
-    "dueDate": "2025-07-14"
+    "dueDate": "2025-07-20"
 }
 
 > {%
@@ -41,7 +41,10 @@ Content-Type: application/json
 %}
 
 ### Request upload location for the offender
-POST {{HOST}}/offender_checkins/{{checkin_uuid}}/upload_location?content-type=image/png
+POST {{HOST}}/offender_checkins/{{checkin_uuid}}/upload_location
+    ?video=video/mp4
+    &snapshots=image/png
+    &reference=image/png
 Authorization: Bearer {{hmpps_auth.token}}
 
 > {%

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/HmppsESupervisionExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/HmppsESupervisionExceptionHandler.kt
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.AccessDeniedException
+import org.springframework.web.bind.MissingServletRequestParameterException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.server.ResponseStatusException
@@ -21,6 +22,17 @@ import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 @RestControllerAdvice
 class HmppsESupervisionExceptionHandler {
+
+  @ExceptionHandler(MissingServletRequestParameterException::class)
+  fun missingServletRequestParameterException(e: MissingServletRequestParameterException): ResponseEntity<ErrorResponse> = ResponseEntity
+    .status(BAD_REQUEST)
+    .body(
+      ErrorResponse(
+        status = BAD_REQUEST,
+        userMessage = e.message,
+        developerMessage = e.message,
+      ),
+    )
 
   @ExceptionHandler(MissingVideoException::class)
   fun handleMissingVideoException(e: MissingVideoException): ResponseEntity<ErrorResponse> = ResponseEntity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/ResourceDtos.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/ResourceDtos.kt
@@ -30,6 +30,12 @@ data class UploadLocationResponse(
   val errorMessage: String? = null,
 )
 
+data class CheckinUploadLocationResponse(
+  val references: List<LocationInfo>? = null,
+  val snapshots: List<LocationInfo>? = null,
+  val video: LocationInfo? = null,
+)
+
 data class CollectionDto<ElemDto>(
   val pagination: Pagination,
   val content: List<ElemDto>,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,8 @@ info.app:
 
 app:
   hostedAt: ${HOSTED_AT}
+  # how long should the presigned S3 URLs be valid for?
+  upload-ttl-minutes: 10
 
 spring:
   application:


### PR DESCRIPTION
The client will no longer need to make separate requests to get upload URLs for the snapshot, video and reference photos. Only one call is needed now and the response is self describing and won't need awkward handling logic.

Additionally:
- added a 400 exception handler for missing required params
- moved the TTL value of presigned S3 URLs to configuration (see `upload-ttl-minutes`)
- updated tests

Relevant UI PR: https://github.com/ministryofjustice/hmpps-esupervision-ui/pull/71