### PR TITLE
Load AWS rekognition bucket name and region from secrets

### DIFF
--- a/helm_deploy/hmpps-esupervision-api/values.yaml
+++ b/helm_deploy/hmpps-esupervision-api/values.yaml
@@ -42,6 +42,8 @@ generic-service:
       S3_DATA_BUCKET_NAME: "bucket_name"
 
     hmpps-esupervision-rekog-aws:
+      REKOG_AWS_REGION: 'region'
+      REKOG_S3_DATA_BUCKET: 'bucket_name'
       REKOG_AWS_ACCESS_KEY_ID: "aws_access_key_id"
       REKOG_AWS_SECRET_ACCESS_KEY: "aws_secret_access_key"
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -104,7 +104,7 @@ notify:
     POP_REGISTRATION_CONFIRMATION: e33c74e6-467c-41f4-993f-697c65405622
 
 rekognition:
-  region: eu-west-2
+  region: ${REKOG_AWS_REGION}
   access_key_id: ${REKOG_AWS_ACCESS_KEY_ID}
   secret_access_key: ${REKOG_AWS_SECRET_ACCESS_KEY}
-  s3_bucket_name: user-ids-rekognition-d-2
+  s3_bucket_name: ${REKOG_S3_DATA_BUCKET}


### PR DESCRIPTION
The hmpps-esupervision-rekog-aws secret has been configured with the region and bucket name for rekognition in each enviornment. Load these from the environment in application.yml and configure then in the serivce environment within the helm service config.