### PR TITLE
API endpoint to stop checkins for an offender

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinRepository.kt
@@ -94,10 +94,12 @@ interface OffenderCheckinRepository : org.springframework.data.jpa.repository.Jp
   /**
    * To be used when we want to cancel all outstanding checkins for an offender
    */
-  @Query("""
+  @Query(
+    """
     UPDATE OffenderCheckin c SET c.status = 'CANCELLED'
     WHERE c.offender = :offender AND c.status IN ('CREATED', 'SUBMITTED')
-  """)
+  """,
+  )
   @Modifying
   fun updateStatusToCancelled(offender: Offender): Int
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinRepository.kt
@@ -12,6 +12,8 @@ import org.hibernate.annotations.JdbcTypeCode
 import org.hibernate.type.SqlTypes
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.practitioner.Practitioner
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.AEntity
@@ -85,8 +87,17 @@ open class OffenderCheckin(
 @Repository
 interface OffenderCheckinRepository : org.springframework.data.jpa.repository.JpaRepository<OffenderCheckin, Long> {
   fun findByUuid(uuid: UUID): Optional<OffenderCheckin>
-  fun findByOffender(offender: Offender): Optional<OffenderCheckin>
 
   // returns checkins created by a practitioner with the given uuid
   fun findAllByCreatedByUuid(practitionerUuid: String, pageable: Pageable): Page<OffenderCheckin>
+
+  /**
+   * To be used when we want to cancel all outstanding checkins for an offender
+   */
+  @Query("""
+    UPDATE OffenderCheckin c SET c.status = 'CANCELLED'
+    WHERE c.offender = :offender AND c.status IN ('CREATED', 'SUBMITTED')
+  """)
+  @Modifying
+  fun updateStatusToCancelled(offender: Offender): Int
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinResource.kt
@@ -7,7 +7,6 @@ import jakarta.validation.constraints.Max
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.domain.PageRequest
-import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
@@ -20,12 +19,12 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
-import org.springframework.web.server.ResponseStatusException
 import software.amazon.awssdk.services.s3.S3Client
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.CheckinReviewRequest
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.CheckinUploadLocationResponse
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.CollectionDto
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.CreateCheckinRequest
+import uk.gov.justice.digital.hmpps.esupervisionapi.utils.intoResponseStatusException
 import java.time.Duration
 import java.util.UUID
 
@@ -127,10 +126,5 @@ class OffenderCheckinResource(
   fun automatedIdentityCheck(@PathVariable uuid: UUID, @RequestParam result: AutomatedIdVerificationResult): ResponseEntity<OffenderCheckinDto> {
     val checkin = offenderCheckinService.setAutomatedIdCheckStatus(uuid, result)
     return ResponseEntity.ok(checkin)
-  }
-
-  private fun intoResponseStatusException(bindingResult: BindingResult): ResponseStatusException {
-    val errors = bindingResult.fieldErrors.associateBy({ it.field }, { it.defaultMessage })
-    return ResponseStatusException(HttpStatus.BAD_REQUEST, errors.toString())
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinService.kt
@@ -267,6 +267,14 @@ class OffenderCheckinService(
     return saved.dto(this.s3UploadService)
   }
 
+  fun cancelCheckins(offenderUuid: UUID, logEntry: OffenderEventLog) {
+    val offender = offenderRepository.findByUuid(offenderUuid).getOrElse {
+      throw BadArgumentException("Offender $offenderUuid not found")
+    }
+    val result = checkinRepository.updateStatusToCancelled(offender)
+    LOG.info("Cancelling checkins for offender={}, result={}, logEntry={}", offenderUuid, result, logEntry.uuid)
+  }
+
   companion object {
     // checkin has been SUBMITTED so we no longer allow to overwrite the associated files
     private fun validateCheckinUpdatable(checkin: OffenderCheckin) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderDto.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.esupervisionapi.offender
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
+import uk.gov.justice.digital.hmpps.esupervisionapi.practitioner.PractitionerUuid
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.LocalDateDeserializer
 import java.net.URL
 import java.time.Instant
@@ -15,6 +16,7 @@ data class OffenderDto(
   val lastName: String,
   @JsonDeserialize(using = LocalDateDeserializer::class) val dateOfBirth: LocalDate?,
   val status: OffenderStatus = OffenderStatus.INITIAL,
+  val practitioner: PractitionerUuid,
   val createdAt: Instant,
   // val updatedAt: Instant,
   val email: String? = null,
@@ -30,7 +32,7 @@ data class OffenderSetupDto(
   val uuid: UUID,
   @Schema(description = "Practitioner's unique ID (this can be NDelius ID)", required = true)
   @field:NotBlank
-  val practitioner: String,
+  val practitioner: PractitionerUuid,
   @Schema(description = "Offender's unique ID", required = true)
   val offender: UUID,
   val createdAt: Instant,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderEventLogDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderEventLogDto.kt
@@ -15,7 +15,7 @@ data class OffenderEventLogDto(
   val createdAt: Instant,
 )
 
-data class TerminateOffenderCheckinRequest(
+data class DeactivateOffenderCheckinRequest(
   @Schema()
   @field:NotBlank
   val requestedBy: PractitionerUuid,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderEventLogDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderEventLogDto.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.offender
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+import uk.gov.justice.digital.hmpps.esupervisionapi.practitioner.PractitionerUuid
+import java.time.Instant
+import java.util.UUID
+
+data class OffenderEventLogDto(
+  val uuid: UUID,
+  val logEntryType: LogEntryType,
+  val comment: String,
+  val practitioner: PractitionerUuid,
+  val offender: UUID,
+  val createdAt: Instant,
+)
+
+data class TerminateOffenderCheckinRequest(
+  @Schema()
+  @field:NotBlank
+  val requestedBy: PractitionerUuid,
+
+  @Schema()
+  @field:NotBlank
+  val reason: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderEventLogRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderEventLogRepository.kt
@@ -14,7 +14,7 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.utils.AEntity
 import java.util.UUID
 
 enum class LogEntryType {
-  CHECKINS_TERMINATED,
+  OFFENDER_DEACTIVATED,
 }
 
 /**

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderEventLogRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderEventLogRepository.kt
@@ -1,0 +1,63 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.offender
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import uk.gov.justice.digital.hmpps.esupervisionapi.practitioner.Practitioner
+import uk.gov.justice.digital.hmpps.esupervisionapi.utils.AEntity
+import java.util.UUID
+
+enum class LogEntryType {
+  CHECKINS_TERMINATED,
+}
+
+/**
+ * Log of notable events during the offender's time on the platform.
+ * Practitioners are required to provide reason/comment for
+ * certain events (e.g., terminating an offender account).
+ */
+@Entity
+@Table(name = "offender_event_log")
+open class OffenderEventLog(
+  @Column(unique = true, nullable = false)
+  open var uuid: UUID,
+
+  @Column(name = "log_entry_type", nullable = false)
+  @Enumerated(EnumType.STRING)
+  open var logEntryType: LogEntryType,
+
+  @Column
+  open var comment: String,
+
+  @ManyToOne(fetch = jakarta.persistence.FetchType.EAGER)
+  open var practitioner: Practitioner,
+
+  @ManyToOne(fetch = jakarta.persistence.FetchType.EAGER)
+  open var offender: Offender,
+
+  @Column("created_at", updatable = false)
+  @CreationTimestamp
+  open var createdAt: java.time.Instant? = null,
+) : AEntity() {
+  fun dto(): OffenderEventLogDto {
+    assert(createdAt != null, { "You should not be creating DTOs without creation timestamp" })
+    return OffenderEventLogDto(
+      uuid = uuid,
+      logEntryType = logEntryType,
+      comment = comment,
+      practitioner = practitioner.uuid,
+      offender = offender.uuid,
+      createdAt = createdAt!!,
+    )
+  }
+}
+
+interface OffenderEventLogRepository : org.springframework.data.jpa.repository.JpaRepository<OffenderEventLog, Long> {
+  fun findAllByOffenderUuid(offenderUuid: UUID, pageable: Pageable): Page<OffenderEventLog>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderEventLogService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderEventLogService.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.offender
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+@Service
+class OffenderEventLogService(
+  private val offenderEventLogRepository: OffenderEventLogRepository,
+) {
+  fun eventsForOffender(uuid: UUID, pageable: Pageable): Page<OffenderEventLogDto> = offenderEventLogRepository.findAllByOffenderUuid(uuid, pageable).map { it.dto() }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderRepository.kt
@@ -79,10 +79,10 @@ open class Offender(
    * will be created.
    */
   @Column("first_checkin", nullable = true)
-  open val firstCheckin: LocalDate? = null,
+  open var firstCheckin: LocalDate? = null,
 
   @Column("checkin_interval", nullable = false)
-  open val checkinInterval: Duration,
+  open var checkinInterval: Duration,
 
   @ManyToOne(cascade = [CascadeType.DETACH], fetch = FetchType.LAZY)
   @JoinColumn(name = "practitioner_id", referencedColumnName = "id", nullable = false)
@@ -101,6 +101,7 @@ open class Offender(
     photoUrl = resourceLocator.getOffenderPhoto(this),
     firstCheckin = firstCheckin,
     checkinInterval = CheckinInterval.fromDuration(checkinInterval),
+    practitioner = practitioner.uuid,
   )
 
   override fun contactMethods(): Iterable<NotificationMethod> {
@@ -118,7 +119,15 @@ open class Offender(
     this.updatedAt = Instant.now()
   }
 
+  fun canTransitionTo(newStatus: OffenderStatus): Boolean = offenderStatusTransition(status, newStatus)
+
   companion object {}
+}
+
+fun offenderStatusTransition(current: OffenderStatus, new: OffenderStatus): Boolean = when (current) {
+  OffenderStatus.INITIAL -> true
+  OffenderStatus.VERIFIED -> new != OffenderStatus.INITIAL
+  OffenderStatus.INACTIVE -> false
 }
 
 @Repository

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderResource.kt
@@ -74,15 +74,18 @@ class OffenderResource(
 
   @PreAuthorize("hasRole('ROLE_ESUPERVISION__ESUPERVISION_UI')")
   @Tag(name = "practitioner")
-  @PostMapping("/{uuid}/terminate")
+  @Operation(
+    summary = "Stops ",
+  )
+  @PostMapping("/{uuid}/deactivate")
   fun terminateCheckins(
     @PathVariable uuid: UUID,
-    @RequestBody body: TerminateOffenderCheckinRequest,
+    @RequestBody body: DeactivateOffenderCheckinRequest,
     bindingResult: org.springframework.validation.BindingResult,
   ): ResponseEntity<OffenderDto> {
     if (bindingResult.hasErrors()) {
       throw intoResponseStatusException(bindingResult)
     }
-    return ResponseEntity.ok(offenderService.terminateCheckins(uuid, body))
+    return ResponseEntity.ok(offenderService.cancelCheckins(uuid, body))
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderResource.kt
@@ -8,6 +8,7 @@ import jakarta.validation.constraints.Max
 import org.springframework.data.domain.PageRequest
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -17,11 +18,13 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.CollectionDto
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.LocationInfo
+import uk.gov.justice.digital.hmpps.esupervisionapi.utils.intoResponseStatusException
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.toPagination
 import java.util.UUID
 
 @RestController
 @RequestMapping("/offenders", produces = ["application/json"])
+@Validated
 class OffenderResource(
   private val offenderService: OffenderService,
 ) {
@@ -68,4 +71,18 @@ class OffenderResource(
   @Tag(name = "practitioner")
   @GetMapping("/{uuid}/upload_location")
   fun getPhotoUploadLocation(@PathVariable uuid: UUID, @RequestParam(name = "content-type") contentType: String): ResponseEntity<LocationInfo> = ResponseEntity.ok(offenderService.photoUploadLocation(uuid, contentType))
+
+  @PreAuthorize("hasRole('ROLE_ESUPERVISION__ESUPERVISION_UI')")
+  @Tag(name = "practitioner")
+  @PostMapping("/{uuid}/terminate")
+  fun terminateCheckins(
+    @PathVariable uuid: UUID,
+    @RequestBody body: TerminateOffenderCheckinRequest,
+    bindingResult: org.springframework.validation.BindingResult,
+  ): ResponseEntity<OffenderDto> {
+    if (bindingResult.hasErrors()) {
+      throw intoResponseStatusException(bindingResult)
+    }
+    return ResponseEntity.ok(offenderService.terminateCheckins(uuid, body))
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/practitioner/PractitionerDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/practitioner/PractitionerDto.kt
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.NotBlank
 data class PractitionerDto(
   @Schema(description = "Practitioner's unique ID (this can be NDelius ID)", required = true)
   @field:NotBlank
-  val uuid: String,
+  val uuid: PractitionerUuid,
   val firstName: String,
   val lastName: String,
   val email: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/practitioner/PractitionerRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/practitioner/PractitionerRepository.kt
@@ -11,11 +11,13 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.PhoneNumber
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.AEntity
 import java.util.Optional
 
+typealias PractitionerUuid = String
+
 @Entity
 @Table(name = "practitioner")
 open class Practitioner(
   @Column(unique = true, nullable = false)
-  open var uuid: String,
+  open var uuid: PractitionerUuid,
   @Column("first_name")
   open var firstName: String,
   @Column("last_name")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/RequestValidation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/RequestValidation.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.utils
+
+import org.springframework.http.HttpStatus
+import org.springframework.validation.BindingResult
+import org.springframework.web.server.ResponseStatusException
+
+internal fun intoResponseStatusException(bindingResult: BindingResult): ResponseStatusException {
+  val errors = bindingResult.fieldErrors.associateBy({ it.field }, { it.defaultMessage })
+  return ResponseStatusException(HttpStatus.BAD_REQUEST, errors.toString())
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/IntegrationTestBase.kt
@@ -10,6 +10,7 @@ import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.esupervisionapi.integration.wiremock.HmppsAuthApiExtension
 import uk.gov.justice.digital.hmpps.esupervisionapi.integration.wiremock.HmppsAuthApiExtension.Companion.hmppsAuth
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderCheckinRepository
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderEventLogRepository
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderRepository
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderSetupRepository
 import uk.gov.justice.digital.hmpps.esupervisionapi.practitioner.PractitionerRepository
@@ -36,6 +37,8 @@ abstract class IntegrationTestBase {
   @Autowired protected lateinit var offenderRepository: OffenderRepository
 
   @Autowired protected lateinit var checkinRepository: OffenderCheckinRepository
+
+  @Autowired protected lateinit var offenderEventLogRepository: OffenderEventLogRepository
 
   internal fun setAuthorisation(
     username: String? = "AUTH_ADM",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/OffenderCheckinTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/OffenderCheckinTest.kt
@@ -16,12 +16,11 @@ import org.springframework.data.domain.PageRequest
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.WebTestClient
-import org.springframework.test.web.reactive.server.expectBody
-import org.springframework.test.web.reactive.server.returnResult
 import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.NotificationService
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.AutomatedIdVerificationResult
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.CheckinInterval
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.CheckinStatus
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.DeactivateOffenderCheckinRequest
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.ManualIdVerificationResult
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderCheckinDto
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderCheckinRepository
@@ -34,7 +33,6 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderService
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderSetupDto
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderSetupService
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderStatus
-import uk.gov.justice.digital.hmpps.esupervisionapi.offender.TerminateOffenderCheckinRequest
 import uk.gov.justice.digital.hmpps.esupervisionapi.practitioner.Practitioner
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.CheckinReviewRequest
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.CheckinUploadLocationResponse
@@ -229,13 +227,13 @@ class OffenderCheckinTest : IntegrationTestBase() {
       .returnResult().responseBody!!
 
     Assertions.assertEquals(CheckinStatus.CREATED, createCheckin.status)
-    
+
     webTestClient.post()
-      .uri("/offenders/${offender.uuid}/terminate")
+      .uri("/offenders/${offender.uuid}/deactivate")
       .contentType(MediaType.APPLICATION_JSON)
       .headers(practitionerRoleAuthHeaders)
       .bodyValue(
-        TerminateOffenderCheckinRequest(
+        DeactivateOffenderCheckinRequest(
           offender.practitioner,
           reason = "probation ended",
         ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/OffenderCheckinTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/OffenderCheckinTest.kt
@@ -12,6 +12,7 @@ import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.context.annotation.Import
+import org.springframework.data.domain.PageRequest
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.WebTestClient
@@ -24,11 +25,16 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.offender.CheckinStatus
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.ManualIdVerificationResult
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderCheckinDto
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderCheckinRepository
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderCheckinService
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderCheckinSubmission
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderDto
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderEventLogService
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderInfo
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderService
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderSetupDto
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderSetupService
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderStatus
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.TerminateOffenderCheckinRequest
 import uk.gov.justice.digital.hmpps.esupervisionapi.practitioner.Practitioner
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.CheckinReviewRequest
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.CheckinUploadLocationResponse
@@ -42,6 +48,12 @@ import java.util.UUID
 @Import(MockS3Config::class)
 class OffenderCheckinTest : IntegrationTestBase() {
 
+  @Autowired
+  private lateinit var offenderCheckinService: OffenderCheckinService
+
+  @Autowired
+  private lateinit var offenderService: OffenderService
+
   @Qualifier("mockNotificationService")
   @Autowired
   private lateinit var notificationService: NotificationService
@@ -52,6 +64,8 @@ class OffenderCheckinTest : IntegrationTestBase() {
   @Autowired lateinit var s3UploadService: S3UploadService
 
   @Autowired lateinit var offenderCheckinRepository: OffenderCheckinRepository
+
+  @Autowired lateinit var offenderEventLogService: OffenderEventLogService
 
   /**
    * Used to setup an offender for tests
@@ -84,6 +98,7 @@ class OffenderCheckinTest : IntegrationTestBase() {
 
   @AfterEach
   fun tearDown() {
+    offenderEventLogRepository.deleteAll()
     offenderSetupRepository.deleteAll()
     offenderCheckinRepository.deleteAll()
     offenderRepository.deleteAll()
@@ -202,6 +217,52 @@ class OffenderCheckinTest : IntegrationTestBase() {
     submitCheckinRequest(checkinDto, submission)
       .exchange()
       .expectStatus().is4xxClientError
+  }
+
+  @Test
+  fun `terminating checkins for an offender removes any outstanding checkin records`() {
+    val (offender, checkinRequest) = checkinRequestDto()
+    val createCheckin = createCheckinRequest(checkinRequest)
+      .exchange()
+      .expectStatus().isOk
+      .expectBody(OffenderCheckinDto::class.java)
+      .returnResult().responseBody!!
+
+    Assertions.assertEquals(CheckinStatus.CREATED, createCheckin.status)
+
+    // offenderService.terminateCheckins(offender.uuid, )
+
+    webTestClient.post()
+      .uri("/offenders/${offender.uuid}/terminate")
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(practitionerRoleAuthHeaders)
+      .bodyValue(
+        TerminateOffenderCheckinRequest(
+          offender.practitioner,
+          reason = "probation ended",
+        ),
+      )
+      .exchange()
+      .expectStatus().isOk
+
+    val page = offenderCheckinService.getCheckins(offender.practitioner, PageRequest.of(0, 10))
+    val checkins = page.content
+
+    Assertions.assertEquals(1, checkins.size)
+    Assertions.assertEquals(CheckinStatus.CANCELLED, checkins[0].status)
+
+    val updatedOffender = offenderRepository.findByUuid(offender.uuid).get()
+    Assertions.assertNull(updatedOffender.firstCheckin)
+    Assertions.assertNull(updatedOffender.email)
+    Assertions.assertNull(updatedOffender.phoneNumber)
+    Assertions.assertEquals(OffenderStatus.INACTIVE, updatedOffender.status)
+
+    val entries = offenderEventLogService.eventsForOffender(offender.uuid, PageRequest.of(0, 10))
+
+    Assertions.assertEquals(1, entries.content.size)
+    val entry = entries.content[0]
+    Assertions.assertEquals("probation ended", entry.comment)
+    Assertions.assertEquals("alice", entry.practitioner)
   }
 
   private fun checkinRequestDto(): Pair<OffenderDto, CreateCheckinRequest> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/OffenderCheckinTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/OffenderCheckinTest.kt
@@ -229,9 +229,7 @@ class OffenderCheckinTest : IntegrationTestBase() {
       .returnResult().responseBody!!
 
     Assertions.assertEquals(CheckinStatus.CREATED, createCheckin.status)
-
-    // offenderService.terminateCheckins(offender.uuid, )
-
+    
     webTestClient.post()
       .uri("/offenders/${offender.uuid}/terminate")
       .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/offender/SurveyTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/offender/SurveyTest.kt
@@ -23,10 +23,11 @@ class SurveyTest {
     LocalDate.of(1990, 1, 1),
     OffenderStatus.VERIFIED,
     createdAt = Instant.now(),
-    "bob@example.com",
+    email = "bob@example.com",
     photoUrl = null,
     firstCheckin = LocalDate.now(ZoneId.of("UTC")).plusDays(10),
     checkinInterval = CheckinInterval.FOUR_WEEKS,
+    practitioner = "alice",
   )
 
   val checkinTemplate = OffenderCheckinDto(


### PR DESCRIPTION
Adds new endpoint `POST /offenders/:uuid/deactivate`. After calling that endpoint

- the offender's state is set to INACTIVE
- the offender's contact info is set to null
- the offender's first_checkin column is set to null
- any outstanding checkin records have status set to CANCELLED
- an entry in new table `offender_event_log` gets added, contains the reason for stopping the checkins provided by practitioner