### PR TITLE
adds a job_log table

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/JobLog.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/JobLog.kt
@@ -1,0 +1,44 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.jobs
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Table
+import uk.gov.justice.digital.hmpps.esupervisionapi.utils.AEntity
+import java.time.Instant
+import java.util.UUID
+
+enum class JobType {
+  /**
+   * Runs daily and finds candidates to send checkin invites to. See
+   *
+   *  @see CheckinNotifier
+   */
+  CHECKIN_NOTIFICATIONS_JOB,
+
+  /**
+   * Runs daily, updates notification status of sent checkin invites
+   * by fetching the appropriate status from GOV.UK Notify
+   */
+  CHECKIN_NOTIFICATION_STATUS_UPDATE_JOB,
+}
+
+@Entity
+@Table(name = "job_log")
+open class JobLog(
+  @Column(name = "reference", nullable = false, unique = true)
+  open var reference: UUID,
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "job_type", nullable = false)
+  open var jobType: JobType,
+
+  @Column(name = "created_at", nullable = false)
+  open var createdAt: Instant,
+
+  @Column(name = "ended_at", nullable = true)
+  open var endedAt: Instant? = null,
+) : AEntity() {
+  fun dto() = JobLogDto(reference = reference, jobType = jobType, createdAt = createdAt, endedAt = endedAt)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/JobLogDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/JobLogDto.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.jobs
+
+import java.time.Instant
+import java.util.UUID
+
+data class JobLogDto(
+  val reference: UUID,
+  val jobType: JobType,
+  val createdAt: Instant,
+  val endedAt: Instant? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/JobLogRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/JobLogRepository.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.jobs
+
+import org.springframework.stereotype.Repository
+import java.lang.Long
+
+@Repository
+interface JobLogRepository : org.springframework.data.jpa.repository.JpaRepository<JobLog, Long>


### PR DESCRIPTION
Adds a log for scheduled/batch jobs, saving basic metadata about the job (currently, type, start/stop time and a reference).

Motivation: to be able to easily get notification status relevant to a job (we're using the job's 'reference' as the reference string passed to GOV.UK Notify). 

Relevant JIRA ticket: https://dsdmoj.atlassian.net/browse/ESUP-444