### PR TITLE
save metadata for notifications sent via a scheduled job

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/CheckinNotifier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/CheckinNotifier.kt
@@ -7,9 +7,11 @@ import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.BulkNotificationContext
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.CheckinCreationInfo
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.CheckinNotification
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.CheckinNotificationRepository
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.NotificationContext
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.Offender
-import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderCheckinDto
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderCheckinService
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderRepository
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.CreateCheckinRequest
@@ -18,6 +20,7 @@ import java.time.Duration
 import java.time.LocalDate
 import java.time.Period
 import java.util.UUID
+import kotlin.streams.asSequence
 
 internal data class NotifierContext(
   val clock: Clock,
@@ -42,11 +45,14 @@ class CheckinNotifier(
   private val offenderRepository: OffenderRepository,
   private val offenderCheckinService: OffenderCheckinService,
   private val jobLogRepository: JobLogRepository,
+  private val notificationRepository: CheckinNotificationRepository,
   private val clock: Clock,
   @Value("\${app.scheduling.checkin-notification.window:72h}") val checkinWindow: Duration,
 ) {
 
   val notificationLeadTime: Period = Period.ofDays(0)
+
+  val batchSize: Int = 100
 
   /**
    * This method is meant to be called via a scheduling mechanism and not directly.
@@ -89,37 +95,63 @@ class CheckinNotifier(
     var numProcessed = 0
     var numErrors = 0
     var numNotifAttempts = 0
+    var numChunks = 0
 
-    for (offender in offenders) {
-      try {
-        val checkin = processOffender(offender, context)
-        numProcessed += 1
-        numNotifAttempts += if (checkin != null) 1 else 0
-      } catch (e: Exception) {
-        LOG.warn("Error processing offender=${offender.uuid}", e)
-        numErrors += 1
+    val chunkSize = 100
+    offenders.asSequence()
+      .chunked(chunkSize)
+      .forEach { offenderChunk ->
+        numChunks += 1
+        LOG.info("processing chunk $numChunks}")
+        val notificationStatuses = ArrayList<CheckinNotification>(offenderChunk.size)
+        for (offender in offenderChunk) {
+          try {
+            numProcessed += 1
+            val checkinInfo = processOffender(offender, context)
+            if (checkinInfo != null) {
+              numNotifAttempts += 1
+              for (result in checkinInfo.notifications.results) {
+                notificationStatuses.add(
+                  CheckinNotification(
+                    notificationId = result.notificationId,
+                    reference = result.context.value,
+                    checkin = checkinInfo.checkin.uuid,
+                    status = null,
+                  ),
+                )
+              }
+            }
+          } catch (e: Exception) {
+            LOG.warn("Error processing offender=${offender.uuid}", e)
+            numErrors += 1
+            null
+          }
+        }
+        if (notificationStatuses.isNotEmpty()) {
+          notificationRepository.saveAll(notificationStatuses)
+        }
       }
-    }
 
     logEntry.endedAt = clock.instant()
     jobLogRepository.saveAndFlush(logEntry)
 
     LOG.info(
-      "processing ends. total processed={}, failed={}, notifications={}, took={}",
+      "processing ends. total processed={} in {} batches, failed={}, notifications={}, took={}",
       numProcessed,
+      numChunks,
       numErrors,
       numNotifAttempts,
       Duration.between(now, clock.instant()),
     )
   }
 
-  internal fun processOffender(offender: Offender, context: NotifierContext): OffenderCheckinDto? {
+  internal fun processOffender(offender: Offender, context: NotifierContext): CheckinCreationInfo? {
     // assumptions:
     // - no `OffenderCheckin` records with due date between `context.today`, context.potentialCheckin
     val isCheckinDay = context.isCheckinDay(offender)
     LOG.debug("is offender={} due for a checkin? {}", offender.uuid, if (isCheckinDay) "yes" else "no")
     if (isCheckinDay) {
-      val checkin = offenderCheckinService.createCheckin(
+      val checkinCreated = offenderCheckinService.createCheckin(
         CreateCheckinRequest(
           offender.practitioner.uuid,
           offender.uuid,
@@ -127,7 +159,7 @@ class CheckinNotifier(
         ),
         context.notificationContext,
       )
-      return checkin
+      return checkinCreated
     }
 
     return null

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/CheckinNotifier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/CheckinNotifier.kt
@@ -19,7 +19,6 @@ import java.time.Clock
 import java.time.Duration
 import java.time.LocalDate
 import java.time.Period
-import java.util.UUID
 import kotlin.streams.asSequence
 
 internal data class NotifierContext(
@@ -77,9 +76,9 @@ class CheckinNotifier(
     val now = clock.instant()
     val lowerBound = now.atZone(clock.zone).toLocalDate()
 
-    val notificationContext = BulkNotificationContext(UUID.randomUUID())
-    val logEntry = JobLog(notificationContext.value, JobType.CHECKIN_NOTIFICATIONS_JOB, now)
+    val logEntry = JobLog(JobType.CHECKIN_NOTIFICATIONS_JOB, now)
     jobLogRepository.saveAndFlush(logEntry)
+    val notificationContext = BulkNotificationContext(logEntry.reference())
 
     val context = NotifierContext(
       clock,
@@ -114,7 +113,8 @@ class CheckinNotifier(
                 notificationStatuses.add(
                   CheckinNotification(
                     notificationId = result.notificationId,
-                    reference = result.context.value,
+                    reference = result.context.reference,
+                    job = logEntry,
                     checkin = checkinInfo.checkin.uuid,
                     status = null,
                   ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/JobLog.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/JobLog.kt
@@ -7,7 +7,6 @@ import jakarta.persistence.Enumerated
 import jakarta.persistence.Table
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.AEntity
 import java.time.Instant
-import java.util.UUID
 
 enum class JobType {
   /**
@@ -27,9 +26,6 @@ enum class JobType {
 @Entity
 @Table(name = "job_log")
 open class JobLog(
-  @Column(name = "reference", nullable = false, unique = true)
-  open var reference: UUID,
-
   @Enumerated(EnumType.STRING)
   @Column(name = "job_type", nullable = false)
   open var jobType: JobType,
@@ -40,5 +36,12 @@ open class JobLog(
   @Column(name = "ended_at", nullable = true)
   open var endedAt: Instant? = null,
 ) : AEntity() {
-  fun dto() = JobLogDto(reference = reference, jobType = jobType, createdAt = createdAt, endedAt = endedAt)
+  fun dto() = JobLogDto(reference = reference(), jobType = jobType, createdAt = createdAt, endedAt = endedAt)
+
+  /**
+   * An identifier that can be used with external systems.
+   *
+   * Note: Should be treated as an opaque value.
+   */
+  fun reference() = "BLK-${String.format("%05d", id)}"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/JobLogDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/JobLogDto.kt
@@ -1,10 +1,9 @@
 package uk.gov.justice.digital.hmpps.esupervisionapi.jobs
 
 import java.time.Instant
-import java.util.UUID
 
 data class JobLogDto(
-  val reference: UUID,
+  val reference: String,
   val jobType: JobType,
   val createdAt: Instant,
   val endedAt: Instant? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/CheckinNotificationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/CheckinNotificationRepository.kt
@@ -3,13 +3,18 @@ package uk.gov.justice.digital.hmpps.esupervisionapi.offender
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Index
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.UpdateTimestamp
 import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.esupervisionapi.jobs.JobLog
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.AEntity
 import java.time.Instant
 import java.util.UUID
+
+typealias CheckiNotificationReference = String
 
 @Entity
 @Table(
@@ -25,9 +30,25 @@ open class CheckinNotification(
   @Column(nullable = false)
   open var checkin: UUID,
 
+  /**
+   * Should be used for single-shot notifications (e.g., notification not sent
+   * via a scheduled job). For notification sent from a job, see `job` property.
+   */
   @Column(nullable = false)
-  open var reference: UUID,
+  open var reference: CheckiNotificationReference,
 
+  /**
+   * If the notification was sent as a part of scheduled job,
+   * this column will reference that job's log entry.
+   */
+  @ManyToOne()
+  @JoinColumn(name = "job_log", nullable = true)
+  open var job: JobLog? = null,
+
+  /**
+   * Set to one of the relevant statuses obtained from
+   * from GOV.UK Notify
+   */
   @Column
   open var status: String? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/CheckinNotificationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/CheckinNotificationRepository.kt
@@ -1,0 +1,44 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.offender
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.esupervisionapi.utils.AEntity
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(
+  name = "offender_checkin_notification",
+  indexes = [
+    Index(name = "idx_checkin_notification_reference", columnList = "reference"),
+  ],
+)
+open class CheckinNotification(
+  @Column("notification_id", unique = true, nullable = false)
+  open var notificationId: UUID,
+
+  @Column(nullable = false)
+  open var checkin: UUID,
+
+  @Column(nullable = false)
+  open var reference: UUID,
+
+  @Column
+  open var status: String? = null,
+
+  @Column
+  @CreationTimestamp
+  open var createdAt: Instant? = null,
+
+  @Column
+  @UpdateTimestamp
+  open var updatedAt: Instant? = null,
+) : AEntity()
+
+@Repository
+interface CheckinNotificationRepository : org.springframework.data.jpa.repository.JpaRepository<CheckinNotification, Long>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/CheckinNotificationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/CheckinNotificationRepository.kt
@@ -16,11 +16,15 @@ import java.util.UUID
 
 typealias CheckiNotificationReference = String
 
+/**
+ * Used to track status of notifications sent to the `Offender`.
+ */
 @Entity
 @Table(
   name = "offender_checkin_notification",
   indexes = [
     Index(name = "idx_checkin_notification_reference", columnList = "reference"),
+    Index(name = "idx_chckin_notification_created_at", columnList = "created_at"),
   ],
 )
 open class CheckinNotification(
@@ -52,11 +56,11 @@ open class CheckinNotification(
   @Column
   open var status: String? = null,
 
-  @Column
+  @Column(name = "created_at")
   @CreationTimestamp
   open var createdAt: Instant? = null,
 
-  @Column
+  @Column(name = "updated_at")
   @UpdateTimestamp
   open var updatedAt: Instant? = null,
 ) : AEntity()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinDto.kt
@@ -120,7 +120,7 @@ enum class NotificationContextType {
   SINGLE,
 }
 
-sealed class NotificationContext {
+sealed class NotificationContext(val value: UUID) {
   /**
    * Answers *why* are we sending the notification
    */
@@ -136,7 +136,7 @@ sealed class NotificationContext {
  * To be used for bulk notifications (e.g., in a scheduled job, so that we can link
  * are notifications to that job).
  */
-data class BulkNotificationContext(val value: UUID) : NotificationContext() {
+data class BulkNotificationContext(val uuid: UUID) : NotificationContext(value = uuid) {
   override val type: NotificationContextType = NotificationContextType.SCHEDULED_JOB
   override val reference: String = value.toString()
 }
@@ -144,14 +144,14 @@ data class BulkNotificationContext(val value: UUID) : NotificationContext() {
 /**
  * To be used for one-off notification.
  */
-data class SingleNotificationContext(val value: UUID) : NotificationContext() {
+data class SingleNotificationContext(val uuid: UUID) : NotificationContext(uuid) {
   override val type: NotificationContextType = NotificationContextType.SINGLE
   override val reference: String = value.toString()
 }
 
 data class NotificationResultSummary(
   val notificationId: UUID,
-  val reference: NotificationContext,
+  val context: NotificationContext,
   val timestamp: ZonedDateTime,
   val status: String?,
   val error: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinDto.kt
@@ -120,33 +120,28 @@ enum class NotificationContextType {
   SINGLE,
 }
 
-sealed class NotificationContext(val value: UUID) {
+sealed class NotificationContext(
+  val reference: String,
   /**
    * Answers *why* are we sending the notification
    */
-  abstract val type: NotificationContextType
-
-  /**
-   * Allows us to link it to other information
-   */
-  abstract val reference: String
-}
+  val type: NotificationContextType,
+)
 
 /**
  * To be used for bulk notifications (e.g., in a scheduled job, so that we can link
  * are notifications to that job).
  */
-data class BulkNotificationContext(val uuid: UUID) : NotificationContext(value = uuid) {
-  override val type: NotificationContextType = NotificationContextType.SCHEDULED_JOB
-  override val reference: String = value.toString()
-}
+data class BulkNotificationContext(val ref: String) : NotificationContext(ref, NotificationContextType.SCHEDULED_JOB)
 
 /**
  * To be used for one-off notification.
  */
-data class SingleNotificationContext(val uuid: UUID) : NotificationContext(uuid) {
-  override val type: NotificationContextType = NotificationContextType.SINGLE
-  override val reference: String = value.toString()
+data class SingleNotificationContext(val ref: String) : NotificationContext(ref, NotificationContextType.SINGLE) {
+
+  companion object {
+    fun from(notificationId: UUID) = SingleNotificationContext("SNGL-$notificationId")
+  }
 }
 
 data class NotificationResultSummary(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinResource.kt
@@ -73,7 +73,7 @@ class OffenderCheckinResource(
     if (bindingResult.hasErrors()) {
       throw intoResponseStatusException(bindingResult)
     }
-    val created = offenderCheckinService.createCheckin(createCheckin, SingleNotificationContext(UUID.randomUUID()))
+    val created = offenderCheckinService.createCheckin(createCheckin, SingleNotificationContext.from(UUID.randomUUID()))
     return ResponseEntity.ok(created.checkin)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinResource.kt
@@ -73,8 +73,8 @@ class OffenderCheckinResource(
     if (bindingResult.hasErrors()) {
       throw intoResponseStatusException(bindingResult)
     }
-    val checkin = offenderCheckinService.createCheckin(createCheckin, SingleNotificationContext(UUID.randomUUID()))
-    return ResponseEntity.ok(checkin)
+    val created = offenderCheckinService.createCheckin(createCheckin, SingleNotificationContext(UUID.randomUUID()))
+    return ResponseEntity.ok(created.checkin)
   }
 
   @PostMapping("/{uuid}/upload_location")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinService.kt
@@ -154,11 +154,11 @@ class OffenderCheckinService(
 
     // notify practitioner that checkin was submitted
     val submissionMessage = PractitionerCheckinSubmittedMessage.fromCheckin(checkin)
-    this.notificationService.sendMessage(submissionMessage, checkin.createdBy, SingleNotificationContext(UUID.randomUUID()))
+    this.notificationService.sendMessage(submissionMessage, offender.practitioner, SingleNotificationContext.from(UUID.randomUUID()))
 
     // notify PoP that checkin was received
     val popConfirmationMessage = OffenderCheckinSubmittedMessage.fromCheckin(checkin)
-    this.notificationService.sendMessage(popConfirmationMessage, checkin.offender, SingleNotificationContext(UUID.randomUUID()))
+    this.notificationService.sendMessage(popConfirmationMessage, checkin.offender, SingleNotificationContext.from(UUID.randomUUID()))
 
     return checkin.dto(this.s3UploadService)
   }
@@ -266,7 +266,7 @@ class OffenderCheckinService(
     this.notificationService.sendMessage(
       inviteMessage,
       checkin.offender,
-      SingleNotificationContext(UUID.randomUUID()),
+      SingleNotificationContext.from(UUID.randomUUID()),
     )
 
     val saved = checkinRepository.save(checkin)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderSetupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderSetupService.kt
@@ -91,7 +91,7 @@ class OffenderSetupService(
 
     // send registration confirmation message to PoP
     val confirmationMessage = RegistrationConfirmationMessage.fromSetup(setup.get())
-    this.notificationService.sendMessage(confirmationMessage, offender, SingleNotificationContext(UUID.randomUUID()))
+    this.notificationService.sendMessage(confirmationMessage, offender, SingleNotificationContext.from(UUID.randomUUID()))
 
     return saved.dto(this.s3UploadService)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/OffenderCheckinTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/OffenderCheckinTest.kt
@@ -22,6 +22,8 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.offender.CheckinInterval
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.CheckinStatus
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.DeactivateOffenderCheckinRequest
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.ManualIdVerificationResult
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.NotificationResultSummary
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.NotificationResults
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderCheckinDto
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderCheckinRepository
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderCheckinService
@@ -33,6 +35,7 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderService
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderSetupDto
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderSetupService
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderStatus
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.SingleNotificationContext
 import uk.gov.justice.digital.hmpps.esupervisionapi.practitioner.Practitioner
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.CheckinReviewRequest
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.CheckinUploadLocationResponse
@@ -41,6 +44,7 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.utils.S3UploadService
 import java.net.URI
 import java.time.Duration
 import java.time.LocalDate
+import java.time.ZonedDateTime
 import java.util.UUID
 
 @Import(MockS3Config::class)
@@ -91,6 +95,8 @@ class OffenderCheckinTest : IntegrationTestBase() {
     offender = offenderSetupService.completeOffenderSetup(setup.uuid)
 
     reset(notificationService)
+    whenever(notificationService.sendMessage(any(), any(), any())).thenReturn(notifResults())
+
     reset(s3UploadService)
   }
 
@@ -334,3 +340,15 @@ class OffenderCheckinTest : IntegrationTestBase() {
     }
   }
 }
+
+fun notifResults() = NotificationResults(
+  listOf(
+    NotificationResultSummary(
+      java.util.UUID.randomUUID(),
+      SingleNotificationContext(UUID.randomUUID()),
+      timestamp = ZonedDateTime.now(),
+      null,
+      null,
+    ),
+  ),
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/OffenderCheckinTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/OffenderCheckinTest.kt
@@ -345,7 +345,7 @@ fun notifResults() = NotificationResults(
   listOf(
     NotificationResultSummary(
       java.util.UUID.randomUUID(),
-      SingleNotificationContext(UUID.randomUUID()),
+      SingleNotificationContext.from(UUID.randomUUID()),
       timestamp = ZonedDateTime.now(),
       null,
       null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/jobs/CheckinNotifierTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/jobs/CheckinNotifierTest.kt
@@ -22,28 +22,28 @@ class CheckinNotifierTest {
 
   @Test
   fun `is checkin works`() {
-    val notificationContext = SingleNotificationContext(java.util.UUID.randomUUID())
+    val notificationContext = SingleNotificationContext.from(java.util.UUID.randomUUID())
     var context = NotifierContext(clock, today = today, notificationContext = notificationContext)
     Assertions.assertTrue(context.isCheckinDay(offender))
 
     context = NotifierContext(
       clock,
       today = today.plusDays(1),
-      notificationContext = SingleNotificationContext(java.util.UUID.randomUUID()),
+      notificationContext = SingleNotificationContext.from(java.util.UUID.randomUUID()),
     )
     Assertions.assertFalse(context.isCheckinDay(offender))
 
     context = NotifierContext(
       clock,
       today = today.plusDays(6),
-      notificationContext = SingleNotificationContext(java.util.UUID.randomUUID()),
+      notificationContext = SingleNotificationContext.from(java.util.UUID.randomUUID()),
     )
     Assertions.assertFalse(context.isCheckinDay(offender))
 
     context = NotifierContext(
       clock,
       today = today.plusDays(7),
-      notificationContext = SingleNotificationContext(java.util.UUID.randomUUID()),
+      notificationContext = SingleNotificationContext.from(java.util.UUID.randomUUID()),
     )
     Assertions.assertTrue(context.isCheckinDay(offender))
   }


### PR DESCRIPTION
Second piece of #47 

- adds `CheckinNotification` entity and repo - holds a record for each notification passed to GOV.UK Notify
  - for notifications sent as part of a job, the `job` column will point to corresponding job log entry
  - for on-off notification, the `reference` column should be used
- updates `CheckinNotifier` to process records in batches and insert `OffenderCheckin` records - this will allow us to find records for a job and request status from GOV.UK notify later, via `reference` col

Part of https://dsdmoj.atlassian.net/browse/ESUP-444