### PR TITLE
cron job to mark checkins as expired

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/OffenderCheckinExpiryJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/OffenderCheckinExpiryJob.kt
@@ -1,0 +1,42 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.jobs
+
+import jakarta.transaction.Transactional
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderCheckinRepository
+import java.time.Clock
+import java.time.Duration
+import java.time.Period
+
+@Component
+class OffenderCheckinExpiryJob(
+  private val clock: Clock,
+  private val checkinRepository: OffenderCheckinRepository,
+  @Value("\${app.scheduling.checkin-notification.window:72h}") val checkinWindow: Duration,
+) {
+
+  @Scheduled(cron = "\${app.scheduling.offender-checkin-expiry.cron}")
+  @SchedulerLock(
+    name = "CheckinNotifier - mark checkins as expired",
+    lockAtLeastFor = "PT5S",
+    lockAtMostFor = "PT10M",
+  )
+  @Transactional
+  fun process() {
+    val now = clock.instant()
+    val today = now.atZone(clock.zone).toLocalDate()
+    val cutoff = today.minus(Period.ofDays(checkinWindow.toDays().toInt()))
+
+    LOG.info("processing starts. checkins below cutoff=$cutoff will be marked as expired.")
+
+    val result = checkinRepository.updateStatusToExpired(cutoff, lowerBound = now.minus(Period.ofDays(28)))
+
+    LOG.info("processing ends. result={}, took={}", result, Duration.between(now, clock.instant()))
+  }
+
+  companion object {
+    private val LOG = org.slf4j.LoggerFactory.getLogger(OffenderCheckinExpiryJob::class.java)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinRepository.kt
@@ -115,6 +115,7 @@ interface OffenderCheckinRepository : org.springframework.data.jpa.repository.Jp
   @Modifying
   fun updateStatusToExpired(cutoff: LocalDate, lowerBound: Instant): Int
 
+  /**
    * To be used when we want to cancel all outstanding checkins for an offender
    */
   @Query(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderService.kt
@@ -97,6 +97,8 @@ class OffenderService(
    * or the practitioner decided it's not working out).
    *
    * The method will attempt to update the offender's record and clean up any related data.
+   *
+   * @param uuid the offender's UUID
    */
   @Transactional
   fun cancelCheckins(uuid: UUID, body: DeactivateOffenderCheckinRequest): OffenderDto {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -4,6 +4,9 @@ app:
     checkin-notification:
       cron: "0 */15 * * * *"  # Development schedule (every 15 minutes)
       # cron: "*/30 * * * * *"  # Local development schedule (every 30 seconds)
+    offender-checkin-expiry:
+      cron: "0 */17 * * * *"  # Development schedule (every 17 minutes)
+      # cron: "*/40 * * * * *"  # Local development schedule (every 40 seconds)
 
 hmpps-auth:
   url: "http://localhost:8090/auth"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,8 +11,10 @@ app:
       # How long, starting from dueDate, do we accept checkin submissions.
       # Afterward the checkin's status is updated to EXPIRED.
       window: 72h
-      #cron: "0 0 3,5 * * *"  # Production schedule (3 AM and 5 AM daily)
-      cron: "0 */15 * * * *"  # Development schedule (every 15 minutes)
+      cron: "0 0 3,5 * * *"  # Production schedule (3 AM and 5 AM daily)
+      # cron: "0 */15 * * * *"  # Development schedule (every 15 minutes)
+    offender-checkin-expiry:
+      cron: "0 0 1,10 * * *"  # Production schedule (1 AM and 10 AM daily)
 
 spring:
   application:


### PR DESCRIPTION
Adds a cron job that goes marks checkins as expired. It uses existing configuration to determine the cutoff date.

The test schedule in application.yaml was updated to something more realistic.