### PR TITLE
Send practitioner notification when offender checkin expires

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/JobLog.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/JobLog.kt
@@ -21,6 +21,12 @@ enum class JobType {
    * by fetching the appropriate status from GOV.UK Notify
    */
   CHECKIN_NOTIFICATION_STATUS_UPDATE_JOB,
+
+  /**
+   * Runs daily, sends notification to the practitioner about checkins that
+   * expired (e.g., the offender failed to submit a checkin in the agreed time window).
+   */
+  CHECKIN_EXIPIRED_NOTIFICATIONS_JOB,
 }
 
 @Entity


### PR DESCRIPTION
Note: we're not tracking status of individual notifications and rely on the 'reference' we can obtain from the `job_log` to resolve issues. This seems reasonable as the practitioner can use the dashboard to see status of relevant checkins.