### PR TITLE
Include snapshot URL in checkin response.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinDto.kt
@@ -54,6 +54,7 @@ data class OffenderCheckinDto(
    * Will be set to pre-signed S3 URL
    */
   val videoUrl: URL?,
+  val snapshotUrl: URL?,
   val autoIdCheck: AutomatedIdVerificationResult?,
   val manualIdCheck: ManualIdVerificationResult?,
 ) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinRepository.kt
@@ -85,6 +85,7 @@ open class OffenderCheckin(
     createdBy = createdBy.uuid,
     createdAt = createdAt,
     videoUrl = resourceLocator.getCheckinVideo(this),
+    snapshotUrl = resourceLocator.getCheckinSnapshot(this),
     autoIdCheck = autoIdCheck,
     manualIdCheck = manualIdCheck,
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/NullResourceLocator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/NullResourceLocator.kt
@@ -10,4 +10,5 @@ import java.net.URL
 class NullResourceLocator : ResourceLocator {
   override fun getOffenderPhoto(offender: Offender): URL? = null
   override fun getCheckinVideo(checkin: OffenderCheckin): URL? = null
+  override fun getCheckinSnapshot(checkin: OffenderCheckin): URL? = null
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/ResourceLocator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/ResourceLocator.kt
@@ -7,4 +7,5 @@ import java.net.URL
 interface ResourceLocator {
   fun getOffenderPhoto(offender: Offender): URL?
   fun getCheckinVideo(checkin: OffenderCheckin): URL?
+  fun getCheckinSnapshot(checkin: OffenderCheckin): URL?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/S3UploadService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/S3UploadService.kt
@@ -231,4 +231,13 @@ class S3UploadService(
       return null
     }
   }
+
+  override fun getCheckinSnapshot(checkin: OffenderCheckin): URL? {
+    if (checkin.submittedAt != null) {
+      val photoKey = CheckinPhotoKey(checkin.uuid, 1)
+      return presignedGetUrlFor(photoKey)
+    } else {
+      return null
+    }
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/offender/SurveyTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/offender/SurveyTest.kt
@@ -41,6 +41,7 @@ class SurveyTest {
     createdAt = Instant.now(),
     reviewedBy = null,
     videoUrl = null,
+    snapshotUrl = null,
     autoIdCheck = AutomatedIdVerificationResult.MATCH,
     manualIdCheck = null,
   )


### PR DESCRIPTION
Adds `snapshotUrl` property to the `OffenderCheckinDto` and a method to the `ResourceLocator` interface to populate that property.