### PR TITLE
optionally force video/snapshot URLs when requesting checkin details

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinResource.kt
@@ -57,14 +57,10 @@ class OffenderCheckinResource(
   @GetMapping("/{uuid}")
   @Tag(name = "offender")
   @PreAuthorize("hasRole('ROLE_ESUPERVISION__ESUPERVISION_UI')")
-  fun getCheckin(@PathVariable uuid: UUID): ResponseEntity<OffenderCheckinDto> {
-    val checkin = offenderCheckinService.getCheckin(uuid)
-    if (checkin.isPresent) {
-      return ResponseEntity.ok(checkin.get())
-    }
-
-    return ResponseEntity.notFound().build()
-  }
+  fun getCheckin(
+    @PathVariable uuid: UUID,
+    @RequestParam(name = "include-uploads", required = false, defaultValue = "false") includeUploads: Boolean,
+  ): ResponseEntity<OffenderCheckinDto> = ResponseEntity.ok(offenderCheckinService.getCheckin(uuid, includeUploads))
 
   @PostMapping
   @Tag(name = "practitioner")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/NullResourceLocator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/NullResourceLocator.kt
@@ -9,6 +9,6 @@ import java.net.URL
  */
 class NullResourceLocator : ResourceLocator {
   override fun getOffenderPhoto(offender: Offender): URL? = null
-  override fun getCheckinVideo(checkin: OffenderCheckin): URL? = null
-  override fun getCheckinSnapshot(checkin: OffenderCheckin): URL? = null
+  override fun getCheckinVideo(checkin: OffenderCheckin, force: Boolean): URL? = null
+  override fun getCheckinSnapshot(checkin: OffenderCheckin, force: Boolean): URL? = null
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/ResourceLocator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/ResourceLocator.kt
@@ -6,6 +6,6 @@ import java.net.URL
 
 interface ResourceLocator {
   fun getOffenderPhoto(offender: Offender): URL?
-  fun getCheckinVideo(checkin: OffenderCheckin): URL?
-  fun getCheckinSnapshot(checkin: OffenderCheckin): URL?
+  fun getCheckinVideo(checkin: OffenderCheckin, force: Boolean = false): URL?
+  fun getCheckinSnapshot(checkin: OffenderCheckin, force: Boolean = false): URL?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/S3UploadService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/S3UploadService.kt
@@ -223,8 +223,8 @@ class S3UploadService(
     }
   }
 
-  override fun getCheckinVideo(checkin: OffenderCheckin): URL? {
-    if (checkin.submittedAt != null) {
+  override fun getCheckinVideo(checkin: OffenderCheckin, force: Boolean): URL? {
+    if (checkin.submittedAt != null || force) {
       val videoKey = CheckinVideoKey(checkin.uuid)
       return presignedGetUrlFor(videoKey)
     } else {
@@ -232,8 +232,8 @@ class S3UploadService(
     }
   }
 
-  override fun getCheckinSnapshot(checkin: OffenderCheckin): URL? {
-    if (checkin.submittedAt != null) {
+  override fun getCheckinSnapshot(checkin: OffenderCheckin, force: Boolean): URL? {
+    if (checkin.submittedAt != null || force) {
       val photoKey = CheckinPhotoKey(checkin.uuid, 1)
       return presignedGetUrlFor(photoKey)
     } else {


### PR DESCRIPTION
Adds an optional query param to `GET /offender_checkins/:uuid:?include-uploads=false`

which will force the response to include the video/snapshot URLs.