### PR TITLE
fix: correct location for video snapshot location

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinService.kt
@@ -318,6 +318,13 @@ class OffenderCheckinService(
       faceSimilarityThreshold,
     )
 
+    try {
+      checkinImages.snapshots.map(s3UploadService::copyPreservingKeyToImageBucket)
+    } catch (e: Exception) {
+      // the images are used only for presentation, we can proceed if copy fails
+      LOG.warn("Failed to copy checkin snapshots to image bucket, checkin={}", checkin.uuid, e)
+    }
+
     LOG.info("updating checking with automated id check result: {}, checkin={}", verificationResult, checkinUuid)
     checkin.autoIdCheck = verificationResult
     checkinRepository.save(checkin)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/S3UploadService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/S3UploadService.kt
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.CopyObjectRequest
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException
@@ -164,6 +165,43 @@ class S3UploadService(
       .build()
     return s3Presigner.presignPutObject(presignRequest).url()
   }
+
+  /**
+   * Copies the given S3 object into this service's image bucket, preserving the original key.
+   * @return the destination coordinate.
+   */
+  fun copyPreservingKeyToImageBucket(source: S3ObjectCoordinate): S3ObjectCoordinate {
+    // Uses the same key under the primary image bucket controlled by this service
+    val target = S3ObjectCoordinate(
+      bucket = this.imageUploadBucket, // same bucket resolved by this service for images
+      key = source.key,
+    )
+
+    // Perform server-side copy in S3 (no download/upload roundtrip)
+    val request = CopyObjectRequest.builder()
+      .sourceBucket("${source.bucket}/${source.key}")
+      .destinationBucket(target.bucket)
+      .destinationKey(target.key)
+      // .metadataDirective("COPY") // default is to copy metadata; uncomment to be explicit
+      .build()
+
+    s3uploadClient.copyObject(request)
+    return target
+  }
+
+//  /**
+//   * Copies from a source coordinate to an explicit target coordinate.
+//   */
+//  fun copyObject(source: S3ObjectCoordinate, target: S3ObjectCoordinate): S3ObjectCoordinate {
+//    val request = CopyObjectRequest.builder()
+//      .sourceBucket("${source.bucket}/${source.key}")
+//      .destinationBucket(target.bucket)
+//      .destinationKey(target.key)
+//      .build()
+//
+//    s3uploadClient.copyObject(request)
+//    return target
+//  }
 
   private fun bucketFor(key: S3Keyable): String {
     when (key) {


### PR DESCRIPTION
We copy the snapshots from rekognition bucket to MOJ bucket since we don't want to mix them when using data just for display.