### PR TITLE
consistent naming

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinDto.kt
@@ -47,7 +47,7 @@ data class OffenderCheckinDto(
   val status: CheckinStatus,
   val dueDate: LocalDate,
   val offender: OffenderDto,
-  val submittedOn: Instant?,
+  val submittedAt: Instant?,
   val surveyResponse: SurveyContents?,
   val createdBy: String,
   val createdAt: Instant,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinRepository.kt
@@ -84,7 +84,7 @@ open class OffenderCheckin(
     status = status,
     dueDate = dueDate,
     offender = offender.dto(resourceLocator), // TODO: don't return whole dto, just the uuid
-    submittedOn = submittedAt,
+    submittedAt = submittedAt,
     surveyResponse = surveyResponse,
     reviewedBy = reviewedBy?.uuid,
     reviewedAt = reviewedAt,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/offender/SurveyTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/offender/SurveyTest.kt
@@ -35,7 +35,7 @@ class SurveyTest {
     status = CheckinStatus.SUBMITTED,
     dueDate = LocalDate.now(),
     offender = offender,
-    submittedOn = Instant.now(),
+    submittedAt = Instant.now(),
     surveyResponse = mapOf(),
     createdBy = "alice",
     createdAt = Instant.now(),


### PR DESCRIPTION
Rename DTO's `checkin.submitOn` to `checkin.submitAt` - to be consistent with the entity and what the client expects.