### PR TITLE
ESUP-521: offender update bug

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderRepository.kt
@@ -120,11 +120,11 @@ open class Offender(
   }
 
   fun applyUpdate(update: OffenderDetailsUpdate) {
-    this.firstName = update.firstName
-    this.lastName = update.lastName
+    this.firstName = update.firstName.trim()
+    this.lastName = update.lastName.trim()
     this.dateOfBirth = update.dateOfBirth
-    this.email = update.email
-    this.phoneNumber = update.phoneNumber
+    this.email = update.email?.trim()
+    this.phoneNumber = update.phoneNumber?.trim()
     this.updatedAt = Instant.now()
     this.firstCheckin = update.firstCheckin
     this.checkinInterval = update.checkinInterval.duration

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderService.kt
@@ -4,6 +4,7 @@ import jakarta.transaction.Transactional
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.esupervisionapi.practitioner.PractitionerRepository


### PR DESCRIPTION
- use `saveAndFlush` to ensure errors triggered immediately
- return a 4xx error when unique constraint violated (e.g. contact info already in use)