### PR TITLE
Fix checkin day calculation in invites job

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/CheckinNotifier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/CheckinNotifier.kt
@@ -19,6 +19,7 @@ import java.time.Clock
 import java.time.Duration
 import java.time.LocalDate
 import java.time.Period
+import java.time.temporal.ChronoUnit
 import kotlin.streams.asSequence
 
 internal data class NotifierContext(
@@ -31,9 +32,16 @@ internal data class NotifierContext(
   fun isCheckinDay(offender: Offender): Boolean {
     val firstCheckin = offender.firstCheckin
     if (firstCheckin != null && offender.checkinInterval.toDays() > 0) {
-      val delta = Period.between(firstCheckin, checkinDate)
+      // not checkin day until first checkin
+      if (checkinDate < firstCheckin) {
+        return false
+      }
+
+      // get the number of days between first checkin and the candidate checkin date
+      // if this is a multiple of the checkin frequency it's a checkin day
+      val delta = firstCheckin.until(checkinDate, ChronoUnit.DAYS)
       val interval = offender.checkinInterval.toDays()
-      return delta.days % interval == 0L
+      return delta % interval == 0L
     }
     return false
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/TestUtils.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/TestUtils.kt
@@ -105,3 +105,18 @@ fun OffenderCheckin.Companion.create(
   autoIdCheck = autoIdCheck,
   manualIdCheck = manualIdCheck,
 )
+
+/**
+ * Returns a range of dates [startDate endDate]
+ */
+fun datesBetweenExclusive(startDate: LocalDate, endDate: LocalDate): List<LocalDate> {
+  var d = startDate.plusDays(1)
+  val dates = mutableListOf<LocalDate>()
+
+  while (d.isBefore(endDate)) {
+    dates.add(d)
+    d = d.plusDays(1)
+  }
+
+  return dates
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/jobs/CheckinNotifierTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/jobs/CheckinNotifierTest.kt
@@ -2,8 +2,10 @@ package uk.gov.justice.digital.hmpps.esupervisionapi.integration.jobs
 
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.esupervisionapi.integration.PRACTITIONER_ALICE
 import uk.gov.justice.digital.hmpps.esupervisionapi.integration.create
 import uk.gov.justice.digital.hmpps.esupervisionapi.integration.createNewPractitioner
+import uk.gov.justice.digital.hmpps.esupervisionapi.integration.datesBetweenExclusive
 import uk.gov.justice.digital.hmpps.esupervisionapi.jobs.NotifierContext
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.CheckinInterval
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.Offender
@@ -11,7 +13,9 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.offender.SingleNotificationC
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
+import java.time.Period
 import java.time.ZoneId
+import java.util.UUID
 
 class CheckinNotifierTest {
 
@@ -46,5 +50,92 @@ class CheckinNotifierTest {
       notificationContext = SingleNotificationContext.from(java.util.UUID.randomUUID()),
     )
     Assertions.assertTrue(context.isCheckinDay(offender))
+  }
+
+  @Test
+  fun `is checkin day on first checkin date`() {
+    val today = LocalDate.now()
+    val isCheckinDay = isCheckinDayOn(today, today, CheckinInterval.WEEKLY)
+    Assertions.assertTrue(isCheckinDay, "Should be checkin day on date of first checkin")
+  }
+
+  @Test
+  fun `is checkin day on first interval after first checkin`() {
+    val firstCheckinDate = LocalDate.of(2025, 8, 27)
+
+    CheckinInterval.entries.forEach { interval ->
+      val jobDate = firstCheckinDate.plusDays(interval.duration.toDays())
+      val isCheckinDay = isCheckinDayOn(jobDate, firstCheckinDate, interval)
+      Assertions.assertTrue(isCheckinDay, "Expected checkin date on interval")
+    }
+  }
+
+  @Test
+  fun `is checkin day on interval multiple after first checkin`() {
+    val firstCheckinDate = LocalDate.now()
+
+    CheckinInterval.entries.forEach { interval ->
+      (2..4).forEach { checkin ->
+        val jobExecDate = firstCheckinDate.plusDays(checkin * interval.duration.toDays())
+        val isCheckinDay = isCheckinDayOn(jobExecDate, firstCheckinDate, interval)
+        Assertions.assertTrue(isCheckinDay, "Should be checkin day on interval multiple")
+      }
+    }
+  }
+
+  @Test
+  fun `is not checkin day on interval before first checkin`() {
+    val jobExecDate = LocalDate.now()
+
+    CheckinInterval.entries.forEach { interval ->
+      val firstCheckinDate = jobExecDate.plusDays(interval.duration.toDays())
+      val isCheckinDate = isCheckinDayOn(jobExecDate, firstCheckinDate, interval)
+      Assertions.assertFalse(isCheckinDate, "Should not be checkin date before first checkin")
+    }
+  }
+
+  @Test
+  fun `is not checkin day between first checkin and interval`() {
+    val firstCheckinDate = LocalDate.now()
+
+    CheckinInterval.entries.forEach { interval ->
+      val nextCheckinDate = firstCheckinDate.plusDays(interval.duration.toDays())
+
+      datesBetweenExclusive(firstCheckinDate, nextCheckinDate).forEach { jobExecDate ->
+        val isCheckinDay = isCheckinDayOn(jobExecDate, firstCheckinDate, interval)
+        Assertions.assertFalse(isCheckinDay, "Should not be checkin day between first checkin and interval")
+      }
+    }
+  }
+
+  /**
+   * Returns whether it's checkin day for a PoP if the checkin invites job runs on the given date for a PoP with
+   * the specified first checkin date and checkin interval
+   */
+  fun isCheckinDayOn(jobExecDate: LocalDate, firstCheckinDate: LocalDate, checkinInterval: CheckinInterval): Boolean {
+    val zone = ZoneId.of("Europe/London")
+
+    val jobTime = jobExecDate.atTime(10, 17)
+    val clock = Clock.fixed(jobTime.atZone(zone).toInstant(), zone)
+
+    val notificationContext = SingleNotificationContext.from(UUID.randomUUID())
+
+    val context = NotifierContext(
+      clock,
+      jobExecDate,
+      notificationLeadTime = Period.ofDays(0),
+      checkinDate = jobExecDate,
+      notificationContext = notificationContext,
+    )
+
+    val offender = Offender.create(
+      "Bob Smith",
+      dateOfBirth = LocalDate.of(1980, 6, 3),
+      firstCheckinDate,
+      checkinInterval = checkinInterval,
+      practitioner = PRACTITIONER_ALICE,
+    )
+
+    return context.isCheckinDay(offender)
   }
 }


### PR DESCRIPTION
Fixes ESUP-607 - Prevent checkin invites being created before a PoP's first checkin date.

Fix calculation of checkin days based on the PoP first checkin date and interval. Period.toDays() returns only the residual number of days in the period, not the total number. So for example a 6-week period (42 days) is represented as 1 month and 11 days. The toDays() method returns 11 in this case, not 42 as required. Use LocalDate.until to get the total number of days between the first checkin date and job execution date.

Add tests for calculating checkin days to CheckinNotifierTest.