### PR TITLE
ESUP-619: consider other checkin statuses when looking for notification candidates.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderRepository.kt
@@ -167,9 +167,9 @@ interface OffenderRepository : org.springframework.data.jpa.repository.JpaReposi
         and  o.firstCheckin is not null
         and o.checkinInterval is not null
         and not exists (select 1 from OffenderCheckin c
-                        where c.offender = o 
+                        where c.offender = o
                         and :lowerBoundInclusive <= c.dueDate and c.dueDate < :upperBoundExclusive
-                        and c.status = 'CREATED')
+                        and c.status in ('CREATED', 'SUBMITTED', 'REVIEWED', 'CANCELLED'))
         """,
   )
   fun findAllCheckinNotificationCandidates(lowerBoundInclusive: LocalDate, upperBoundExclusive: LocalDate): Stream<Offender>


### PR DESCRIPTION
This PR updates the query that produces a stream candidates for notifications and makes sure we skip those that already had a checkin created, submitted, reviewed, or cancelled.
