### PR TITLE
Count "NO_MATCH" or missing auto id check as a flag in practitioner email

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/PractitionerCheckinSubmittedMessage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/PractitionerCheckinSubmittedMessage.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.esupervisionapi.notifications
 
 import uk.gov.justice.digital.hmpps.esupervisionapi.config.AppConfig
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.AutomatedIdVerificationResult
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderCheckin
 import uk.gov.justice.digital.hmpps.esupervisionapi.practitioner.Practitioner
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.NullResourceLocator
@@ -12,13 +13,17 @@ data class PractitionerCheckinSubmittedMessage(
   val offenderLastName: String,
   val numFlags: Int,
   val checkinUuid: UUID,
+  val autoIdCheck: AutomatedIdVerificationResult?
 ) : Message {
   override fun personalisationData(appConfig: AppConfig): Map<String, String> = mapOf(
     "practitionerName" to practitionerName,
     "name" to "$offenderFirstName $offenderLastName",
-    "number" to numFlags.toString(),
+    "number" to totalFlags().toString(),
     "dashboardSubmissionUrl" to appConfig.checkinDashboardUrl(checkinUuid).toString(),
   )
+
+  // we count a failed/missing automated ID check as a flag
+  private fun totalFlags(): Int = numFlags + (if (autoIdCheck == AutomatedIdVerificationResult.NO_MATCH || autoIdCheck == null) 1 else 0)
 
   override val messageType: NotificationType
     get() = NotificationType.PractitionerCheckinSubmitted
@@ -33,6 +38,7 @@ data class PractitionerCheckinSubmittedMessage(
         offenderLastName = checkin.offender.lastName,
         numFlags = flags.size,
         checkinUuid = checkin.uuid,
+        autoIdCheck = checkin.autoIdCheck
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/PractitionerCheckinSubmittedMessage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/PractitionerCheckinSubmittedMessage.kt
@@ -13,7 +13,7 @@ data class PractitionerCheckinSubmittedMessage(
   val offenderLastName: String,
   val numFlags: Int,
   val checkinUuid: UUID,
-  val autoIdCheck: AutomatedIdVerificationResult?
+  val autoIdCheck: AutomatedIdVerificationResult?,
 ) : Message {
   override fun personalisationData(appConfig: AppConfig): Map<String, String> = mapOf(
     "practitionerName" to practitionerName,
@@ -38,7 +38,7 @@ data class PractitionerCheckinSubmittedMessage(
         offenderLastName = checkin.offender.lastName,
         numFlags = flags.size,
         checkinUuid = checkin.uuid,
-        autoIdCheck = checkin.autoIdCheck
+        autoIdCheck = checkin.autoIdCheck,
       )
     }
   }


### PR DESCRIPTION
As in the title. 