### PR TITLE
Use Postgres in a test container instead of H2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,8 @@ dependencies {
   testImplementation("io.swagger.parser.v3:swagger-parser:2.1.29") {
     exclude(group = "io.swagger.core.v3")
   }
-  testRuntimeOnly("com.h2database:h2")
+  testImplementation("org.testcontainers:postgresql")
+  testImplementation("org.junit.platform:junit-platform-launcher:1.12.2")
 }
 
 kotlin {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/IntegrationTestBase.kt
@@ -7,6 +7,8 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDO
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpHeaders
 import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.esupervisionapi.integration.wiremock.HmppsAuthApiExtension
 import uk.gov.justice.digital.hmpps.esupervisionapi.integration.wiremock.HmppsAuthApiExtension.Companion.hmppsAuth
@@ -47,5 +49,17 @@ abstract class IntegrationTestBase {
 
   protected fun stubPingWithResponse(status: Int) {
     hmppsAuth.stubHealthPing(status)
+  }
+
+  companion object {
+    @DynamicPropertySource
+    @JvmStatic
+    fun configureProperties(registry: DynamicPropertyRegistry) {
+      val postgres = TestContainersSessionListener.postgres
+
+      registry.add("spring.datasource.url") { postgres.jdbcUrl }
+      registry.add("spring.datasource.username") { postgres.username }
+      registry.add("spring.datasource.password") { postgres.password }
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/TestContainersSessionListener.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/TestContainersSessionListener.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.integration
+
+import org.junit.platform.launcher.LauncherSession
+import org.junit.platform.launcher.LauncherSessionListener
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.containers.wait.strategy.Wait
+
+class TestContainersSessionListener : LauncherSessionListener {
+  override fun launcherSessionOpened(session: LauncherSession?) {
+    postgres.start()
+  }
+
+  override fun launcherSessionClosed(session: LauncherSession?) {
+    postgres.stop()
+  }
+
+  companion object {
+    val postgres: PostgreSQLContainer<Nothing> = PostgreSQLContainer<Nothing>("postgres:17.5").apply {
+      withNetworkAliases("postgres-test")
+      withDatabaseName("testcontainers")
+      withUsername("postgres")
+      withExposedPorts(5432)
+      setWaitStrategy(Wait.forListeningPort())
+    }
+  }
+}

--- a/src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener
+++ b/src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener
@@ -1,0 +1,1 @@
+uk.gov.justice.digital.hmpps.esupervisionapi.integration.TestContainersSessionListener

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -16,37 +16,6 @@ api:
     url:
       manage-users-api: "http://example.com/users"
 
-spring:
-  datasource:
-    url: jdbc:h2:mem:esupervision;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
-    hikari:
-      maximum-pool-size: 10
-      minimum-idle: 5
-      idle-timeout: 60000
-      connection-timeout: 30000
-      pool-name: HikariPool-esupervision
-  jpa:
-    database-platform: org.hibernate.dialect.H2Dialect
-    show-sql: true
-    hibernate:
-      ddl-auto: update
-    properties:
-      hibernate:
-        format_sql: true
-        use_sql_comments: true
-        dialect: org.hibernate.dialect.H2Dialect
-        hbm2ddl:
-          auto: update
-        type:
-          preferred_duration_jdbc_type: INTERVAL_SECOND
-  h2:
-    console:
-      enabled: true
-      path: /h2-console
-
 aws:
   region-name: eu-west-2
   endpoint-url: "http://localhost:4566"


### PR DESCRIPTION
Issue ESUP-636 - Add testcontainers dependency and use it to run a Postgres container for the duration of the tests. Remove the test H2 configuration so the Postgres configuration from the default Spring profile is used. The URL, database and password for the data source are provided by the IntegrationTestBase which dynamically registers the properties from the running container.

The container is started before the first test is executed and stopped after the last test run. This is done via a listener for the JUnit test session which is registered as a service provider.