### PR TITLE
add one_checkin_per_day constraint

### DIFF
--- a/src/main/resources/db/changelog/changesets/2_one_checkin_per_day.sql
+++ b/src/main/resources/db/changelog/changesets/2_one_checkin_per_day.sql
@@ -1,0 +1,6 @@
+-- liquibase formatted sql
+
+-- changeset roland.sadowski:2_one_checkin_per_day-1 splitStatements:false
+CREATE UNIQUE INDEX "one_checkin_per_day"
+ON offender_checkin (offender_id, due_date)
+WHERE status not in ('CANCELLED');

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,3 +1,5 @@
 databaseChangeLog:
   - include:
       file: db/changelog/changesets/1_initial_import.sql
+  - include:
+      file: db/changelog/changesets/2_one_checkin_per_day.sql

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/OffenderCheckinTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/OffenderCheckinTest.kt
@@ -252,6 +252,20 @@ class OffenderCheckinTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `only one checkin per day allowed`() {
+    val (offender, checkinRequest) = checkinRequestDto()
+    val checkinDto1 = createCheckinRequest(checkinRequest)
+      .exchange()
+      .expectStatus().isOk
+      .expectBody(OffenderCheckinDto::class.java)
+      .returnResult().responseBody!!
+
+    createCheckinRequest(checkinRequest)
+      .exchange()
+      .expectStatus().is4xxClientError
+  }
+
+  @Test
   fun `terminating checkins for an offender removes any outstanding checkin records`() {
     val (offender, checkinRequest) = checkinRequestDto()
     val createCheckin = createCheckinRequest(checkinRequest)


### PR DESCRIPTION
We don't want more than one "in-flight" checkin per day.

- If the invite job tires to add a second one, it will log warning but continue (which is what we want)
- If client tries to add 2nd checkin, a 4xx error is returned (there's probably insufficient handling for that on the front-end, but at least it won't result in confusing the offender)