### PR TITLE
update notif. status updater job to include one-off notif. statuses

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/CheckinNotificationStatusUpdater.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/CheckinNotificationStatusUpdater.kt
@@ -8,9 +8,24 @@ import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.NotificationInfo
 import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.NotificationService
 import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.NotificationStatusCollection
+import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.Referencable
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.CheckinNotificationRepository
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.SingleNotificationContext
 import java.time.Clock
 import java.time.Duration
+import java.time.Instant
+
+private data class QueryParams(val ref: Referencable, val createdAt: Instant)
+
+/**
+ * For bulk notifications we use the reference string we passed to the notification service
+ * and stored in the JobLog. For one-off notification we use a convention of having a
+ * common prefix and including the date in the reference string. This job processes
+ * jobs and one-off notifications from a particular time interval (up to a given number of days back).
+ */
+private data class OneOffNotification(
+  override val reference: String,
+) : Referencable
 
 @Service
 class CheckinNotificationStatusUpdater(
@@ -36,41 +51,49 @@ class CheckinNotificationStatusUpdater(
     LOG.info("processing starts")
 
     val now = clock.instant()
-    val newerThan = now.atZone(clock.zone).toLocalDate().atStartOfDay().minusDays(5)
+    val daysBack = 5L
+    val newerThan = now.atZone(clock.zone).toLocalDate().atStartOfDay().minusDays(daysBack)
+    val days: List<java.time.LocalDate> =
+      (0L..daysBack).map { newerThan.toLocalDate().plusDays(it) }
     val newerThanInstant = newerThan.toInstant(clock.zone.rules.getOffset(now))
-    val jobs = jobLogRepository.findByCreatedAtGreaterThanAndJobType(
+    val bulk = jobLogRepository.findByCreatedAtGreaterThanAndJobType(
       newerThanInstant,
       JobType.CHECKIN_NOTIFICATIONS_JOB,
-    )
-    LOG.info("Processing {} jobs, newer than {}", jobs.size, newerThanInstant.toString())
+    ).map { QueryParams(it, it.createdAt) }
+    val oneOffs = days.map {
+      val day = it.atStartOfDay(clock.zone)
+      val ctx = SingleNotificationContext.forCheckin(it)
+      QueryParams(OneOffNotification(ctx.reference), day.toInstant())
+    }
+    LOG.info("Processing {} bulk jobs, newer than {}, {} potential one-off jobs", bulk.size, newerThanInstant.toString(), oneOffs.size)
 
     try {
-      for (job in jobs) {
+      for (notificationAttempt in bulk + oneOffs) {
         // GOV.UK Notify returns up to 250 results per call, so we fetch till there are no more results
         val batches = mutableListOf<NotificationStatusCollection>()
         do {
           val olderThan = batches.lastOrNull()?.previousPageParam
-          val batch = notificationService.notificationStatus(job, olderThan)
-          LOG.info("job reference={}, got batch with {} notifications, older than {}", job.reference(), batch.notifications.size, olderThan)
+          val batch = notificationService.notificationStatus(notificationAttempt.ref, olderThan)
+          LOG.info("job reference={}, got batch with {} notifications, older than {}", notificationAttempt.ref.reference, batch.notifications.size, olderThan)
           batches.add(batch)
         } while (batches.isNotEmpty() && batch.hasNextPage)
 
         // query notifications with terminal failure, filter them out of what
         // we received from the notification service - we don't need to update them anymore
-        val terminal = checkinNotificationRepository.findByJobAndStatus(job, terminalStatuses, lowerBound = job.createdAt)
+        val terminal = checkinNotificationRepository.findByJobAndStatus(notificationAttempt.ref, terminalStatuses, lowerBound = notificationAttempt.createdAt)
         val terminalIds = terminal.map { it.notificationId }.toSet()
         val notifications = batches
           .flatMap(NotificationStatusCollection::notifications)
           .filter { !terminalIds.contains(it.uuid) }
           .toList()
 
-        LOG.debug("job reference={}, {} records to update", job.reference(), notifications.size)
+        LOG.debug("job reference={}, {} records to update", notificationAttempt.ref.reference, notifications.size)
 
         // update the remaining notification's status
         try {
           updateNotificationStatus(notifications)
         } catch (e: Exception) {
-          LOG.warn("Failed to update notification statuses for job reference=${job.reference()}: ${e.message}", e)
+          LOG.warn("Failed to update notification statuses for job reference=${notificationAttempt.ref.reference}: ${e.message}", e)
         }
       }
     } catch (e: Exception) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/CheckinNotifier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/CheckinNotifier.kt
@@ -86,7 +86,7 @@ class CheckinNotifier(
 
     val logEntry = JobLog(JobType.CHECKIN_NOTIFICATIONS_JOB, now)
     jobLogRepository.saveAndFlush(logEntry)
-    val notificationContext = BulkNotificationContext(logEntry.reference())
+    val notificationContext = BulkNotificationContext(logEntry.reference)
 
     val context = NotifierContext(
       clock,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/JobLog.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/JobLog.kt
@@ -6,6 +6,7 @@ import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.persistence.Index
 import jakarta.persistence.Table
+import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.Referencable
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.AEntity
 import java.time.Instant
 
@@ -48,13 +49,15 @@ open class JobLog(
 
   @Column(name = "ended_at", nullable = true)
   open var endedAt: Instant? = null,
-) : AEntity() {
-  fun dto() = JobLogDto(reference = reference(), jobType = jobType, createdAt = createdAt, endedAt = endedAt)
+) : AEntity(),
+  Referencable {
+  fun dto() = JobLogDto(reference = reference, jobType = jobType, createdAt = createdAt, endedAt = endedAt)
 
   /**
    * An identifier that can be used with external systems.
    *
    * Note: Should be treated as an opaque value.
    */
-  fun reference() = "BLK-${String.format("%05d", id)}"
+  @Transient
+  override val reference = "BLK-${String.format("%05d", id)}"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/OffenderCheckinExpiryJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/OffenderCheckinExpiryJob.kt
@@ -57,7 +57,7 @@ class OffenderCheckinExpiryJob(
       val lowerBound = now.minus(Period.ofDays(28))
 
       val chunkSize = 100
-      val context = BulkNotificationContext(logEntry.reference())
+      val context = BulkNotificationContext(logEntry.reference)
       checkinRepository.findAllAboutToExpire(cutoff, lowerBound = lowerBound)
         .asSequence()
         .chunked(chunkSize)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/GovNotifyNotificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/GovNotifyNotificationService.kt
@@ -46,9 +46,10 @@ class GovNotifyNotificationService(
     return null
   }
 
-  override fun notificationStatus(job: JobLog, olderThan: String?): NotificationStatusCollection {
-    val list = notifyClient.getNotifications(null, null, job.reference(), olderThan)
-    LOGGER.info("Got {} notifications, reference={}, jobType={}", list.notifications.size, job.reference(), job.jobType)
+  override fun notificationStatus(ref: Referencable, olderThan: String?): NotificationStatusCollection {
+    val list = notifyClient.getNotifications(null, null, ref.reference, olderThan)
+    val jobType = if (ref is JobLog) ref.jobType else null
+    LOGGER.info("Got {} notifications, reference={}, jobType={}", list.notifications.size, ref.reference, jobType)
     val notifications = list.notifications.map { NotificationInfo(it.id, it.status) }
     return StatusCollection(notifications, list.nextPageOlderThan())
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/NotificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/NotificationService.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.esupervisionapi.notifications
 
-import uk.gov.justice.digital.hmpps.esupervisionapi.jobs.JobLog
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.NotificationContext
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.NotificationResults
 import java.util.UUID
@@ -17,8 +16,8 @@ interface NotificationService {
   fun sendMessage(message: Message, recipient: Contactable, context: NotificationContext): NotificationResults
 
   /**
-   * @param job job which sent the notification
+   * @param ref job which sent the notification
    * @param olderThan notification id
    */
-  fun notificationStatus(job: JobLog, olderThan: String? = null): NotificationStatusCollection
+  fun notificationStatus(ref: Referencable, olderThan: String? = null): NotificationStatusCollection
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/Referencable.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/Referencable.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.notifications
+
+/**
+ * A reference that we can use to look up notifications (in bulk) via GOV.UK Notify API.
+ */
+interface Referencable {
+  val reference: String
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/CheckinNotificationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/CheckinNotificationRepository.kt
@@ -12,6 +12,7 @@ import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.jobs.JobLog
+import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.Referencable
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.AEntity
 import java.time.Instant
 import java.util.UUID
@@ -72,13 +73,12 @@ interface CheckinNotificationRepository : org.springframework.data.jpa.repositor
 
   @Query(
     """
-    SELECT cn FROM CheckinNotification cn WHERE cn.reference = :#{#job.reference()}
+    SELECT cn FROM CheckinNotification cn WHERE cn.reference = :#{#ref.reference}
     AND cn.status IN (:statuses)
-    AND cn.job = :job
     AND cn.createdAt >= :lowerBound
     """,
   )
-  fun findByJobAndStatus(job: JobLog, statuses: List<String>, lowerBound: Instant): List<CheckinNotification>
+  fun findByJobAndStatus(ref: Referencable, statuses: List<String>, lowerBound: Instant): List<CheckinNotification>
 
   @Query(
     """

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/IntegrationTestBase.kt
@@ -12,6 +12,7 @@ import org.springframework.test.context.DynamicPropertySource
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.esupervisionapi.integration.wiremock.HmppsAuthApiExtension
 import uk.gov.justice.digital.hmpps.esupervisionapi.integration.wiremock.HmppsAuthApiExtension.Companion.hmppsAuth
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.CheckinNotificationRepository
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderCheckinRepository
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderEventLogRepository
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderRepository
@@ -40,6 +41,8 @@ abstract class IntegrationTestBase {
   @Autowired protected lateinit var offenderEventLogRepository: OffenderEventLogRepository
 
   @Autowired protected lateinit var practitionerRepository: PractitionerRepository
+
+  @Autowired protected lateinit var checkinNotificationRepository: CheckinNotificationRepository
 
   internal fun setAuthorisation(
     username: String? = "AUTH_ADM",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/jobs/CheckinNotificationStatusUpdaterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/jobs/CheckinNotificationStatusUpdaterTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.esupervisionapi.integration.jobs
 
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
@@ -20,6 +21,7 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.offender.CheckinInterval
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.CheckinNotification
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.Offender
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderCheckin
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderCheckinRepository
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.SingleNotificationContext
 import java.time.Clock
 import java.time.LocalDate
@@ -28,11 +30,21 @@ import java.util.UUID
 @Import(MockS3Config::class)
 class CheckinNotificationStatusUpdaterTest : IntegrationTestBase() {
 
+  @Autowired lateinit var offenderCheckinRepository: OffenderCheckinRepository
+
   @Autowired private lateinit var notificationService: NotificationService
 
   @Autowired private lateinit var statusUpdater: CheckinNotificationStatusUpdater
 
   private val clock: Clock = Clock.systemUTC()
+
+  @AfterEach
+  fun cleanUp() {
+    offenderEventLogRepository.deleteAll()
+    offenderSetupRepository.deleteAll()
+    offenderCheckinRepository.deleteAll()
+    offenderRepository.deleteAll()
+  }
 
   @Test
   fun `verify that one-off notifications are processed`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/jobs/CheckinNotificationStatusUpdaterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/jobs/CheckinNotificationStatusUpdaterTest.kt
@@ -1,0 +1,70 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.integration.jobs
+
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Import
+import uk.gov.justice.digital.hmpps.esupervisionapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.esupervisionapi.integration.MockS3Config
+import uk.gov.justice.digital.hmpps.esupervisionapi.integration.PRACTITIONER_ALICE
+import uk.gov.justice.digital.hmpps.esupervisionapi.integration.create
+import uk.gov.justice.digital.hmpps.esupervisionapi.jobs.CheckinNotificationStatusUpdater
+import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.NotificationService
+import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.StatusCollection
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.CheckinInterval
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.CheckinNotification
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.Offender
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderCheckin
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.SingleNotificationContext
+import java.time.Clock
+import java.time.LocalDate
+import java.util.UUID
+
+@Import(MockS3Config::class)
+class CheckinNotificationStatusUpdaterTest : IntegrationTestBase() {
+
+  @Autowired private lateinit var notificationService: NotificationService
+
+  @Autowired private lateinit var statusUpdater: CheckinNotificationStatusUpdater
+
+  private val clock: Clock = Clock.systemUTC()
+
+  @Test
+  fun `verify that one-off notifications are processed`() {
+    reset(notificationService)
+    whenever(notificationService.notificationStatus(any(), anyOrNull()))
+      .thenReturn(StatusCollection(listOf(), null))
+
+    val instant = clock.instant()
+    val today = LocalDate.now(clock)
+    val practitioner = PRACTITIONER_ALICE
+    val offender = Offender.create("Bob Smith", "B090901", LocalDate.of(1980, 1, 1), today, CheckinInterval.WEEKLY, practitioner = practitioner)
+    offenderRepository.save(offender)
+
+    val checkin = OffenderCheckin.create(
+      uuid = UUID.randomUUID(),
+      offender = offender,
+      createdBy = practitioner.externalUserId(),
+    )
+    checkinRepository.save(checkin)
+    val singleNotifContext = SingleNotificationContext.forCheckin(today)
+    val checkinNotification = CheckinNotification(
+      notificationId = UUID.randomUUID(),
+      checkin = checkin.uuid,
+      reference = singleNotifContext.reference,
+      job = null,
+      status = null,
+      createdAt = instant.minusSeconds(50),
+    )
+    checkinNotificationRepository.save(checkinNotification)
+
+    statusUpdater.process()
+
+    verify(notificationService, times(6)).notificationStatus(any(), anyOrNull())
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/offender/OffenderRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/offender/OffenderRepositoryTest.kt
@@ -1,8 +1,10 @@
 package uk.gov.justice.digital.hmpps.esupervisionapi.integration.offender
 
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.esupervisionapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.esupervisionapi.integration.PRACTITIONER_ALICE
@@ -12,6 +14,7 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.offender.CheckinInterval
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.CheckinStatus
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.Offender
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderCheckin
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderCheckinRepository
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderStatus
 import uk.gov.justice.digital.hmpps.esupervisionapi.practitioner.Practitioner
 import java.time.Duration
@@ -19,6 +22,8 @@ import java.time.Instant
 import java.time.LocalDate
 
 class OffenderRepositoryTest : IntegrationTestBase() {
+
+  @Autowired lateinit var offenderCheckinRepository: OffenderCheckinRepository
 
   @BeforeEach
   fun setupOffenders() {
@@ -48,6 +53,14 @@ class OffenderRepositoryTest : IntegrationTestBase() {
       dueDate = today.plusDays(1),
     )
     checkinRepository.saveAll(listOf(checkinForOffender2))
+  }
+
+  @AfterEach
+  fun cleanUp() {
+    offenderEventLogRepository.deleteAll()
+    offenderSetupRepository.deleteAll()
+    offenderCheckinRepository.deleteAll()
+    offenderRepository.deleteAll()
   }
 
   @Test


### PR DESCRIPTION
Modifies the notification status update job to also fetch the status for one off notifications. One off notifications are saved with a reference of 'CHK-YYYY-MM-dd' and we use that to fetch one-offs sent on a particular day. 

Also: save checkin notification in `createCheckin` when called with a 'single' notification context.