### PR TITLE
Create controller for usage statistics

### DIFF
--- a/helm_deploy/hmpps-esupervision-api/values.yaml
+++ b/helm_deploy/hmpps-esupervision-api/values.yaml
@@ -60,6 +60,9 @@ generic-service:
     hmpps-domain-events-topic:
       HMPPS_SQS_TOPICS_HMPPSEVENTTOPIC_ARN: "topic_arn"
 
+    practitioner-sites:
+      PRACTITIONER_SITE_ASSIGNMENTS: "assignments"
+
   allowlist:
     groups:
       - internal

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/PractitionerSiteConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/PractitionerSiteConfiguration.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import uk.gov.justice.digital.hmpps.esupervisionapi.practitioner.InMemoryPractitionerSiteRepository
+import uk.gov.justice.digital.hmpps.esupervisionapi.practitioner.PractitionerSiteRepository
+
+@Configuration
+class PractitionerSiteConfiguration(
+  @Value("\${practitioner.site.assignments:}") val siteAssignments: String,
+) {
+  @Bean
+  fun practitionerSiteRepository(): PractitionerSiteRepository = InMemoryPractitionerSiteRepository.fromConfig(siteAssignments)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderRepository.kt
@@ -179,7 +179,21 @@ interface OffenderRepository : org.springframework.data.jpa.repository.JpaReposi
         """,
   )
   fun findAllCheckinNotificationCandidates(lowerBoundInclusive: LocalDate, upperBoundExclusive: LocalDate): Stream<Offender>
+
+  @Query(
+    """
+      select o.practitioner, count(o) from Offender o
+      where o.status != 'INITIAL'
+      group by o.practitioner
+    """,
+  )
+  fun findPractitionerRegistrations(): List<PractitionerRegistrationCount>
 }
+
+open class PractitionerRegistrationCount(
+  val practitioner: ExternalUserId,
+  val registrationCount: Long,
+)
 
 /**
  * When a practitioner adds an offender, a record for the setup process is created.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/practitioner/InMemoryPractitionerSiteRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/practitioner/InMemoryPractitionerSiteRepository.kt
@@ -1,0 +1,35 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.practitioner
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.slf4j.LoggerFactory
+
+class InMemoryPractitionerSiteRepository(
+  val siteAssignments: Map<ExternalUserId, String>,
+) : PractitionerSiteRepository {
+  override fun findLocation(practitionerId: ExternalUserId): PractitionerSite? {
+    val siteName = siteAssignments[practitionerId]
+    return if (siteName != null) {
+      PractitionerSite(name = siteName)
+    } else {
+      null
+    }
+  }
+
+  companion object {
+    val LOGGER = LoggerFactory.getLogger(this::class.java)
+
+    fun fromConfig(siteAssignmentsConfig: String): InMemoryPractitionerSiteRepository {
+      LOGGER.info("Site assignments: {}", siteAssignmentsConfig)
+
+      val mapping: Map<ExternalUserId, String> = if (siteAssignmentsConfig.isNotBlank()) {
+        val objectMapper = ObjectMapper()
+        objectMapper.readValue(siteAssignmentsConfig, object : TypeReference<Map<String, String>>() {})
+      } else {
+        emptyMap()
+      }
+
+      return InMemoryPractitionerSiteRepository(mapping)
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/practitioner/PractitionerSiteRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/practitioner/PractitionerSiteRepository.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.practitioner
+
+data class PractitionerSite(
+  val name: String,
+)
+
+interface PractitionerSiteRepository {
+  fun findLocation(practitionerId: ExternalUserId): PractitionerSite?
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/stats/StatsResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/stats/StatsResource.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.stats
+
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/stats", produces = [APPLICATION_JSON_VALUE])
+class StatsResource(private val statsService: StatsService) {
+  @PreAuthorize("hasRole('ROLE_ESUPERVISION__ESUPERVISION_UI')")
+  @Tag(name = "practitioner")
+  @GetMapping("/practitioner/registrations")
+  fun practitionerRegistrations(): ResponseEntity<List<PractitionerRegistrationInfo>> {
+    val registrations = statsService.practitionerRegistrations()
+    return ResponseEntity.ok(registrations)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/stats/StatsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/stats/StatsService.kt
@@ -1,0 +1,36 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.stats
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderRepository
+import uk.gov.justice.digital.hmpps.esupervisionapi.practitioner.ExternalUserId
+import uk.gov.justice.digital.hmpps.esupervisionapi.practitioner.PractitionerSiteRepository
+
+data class PractitionerRegistrationInfo(
+  val practitioner: ExternalUserId,
+  val siteName: String,
+  val registrationCount: Long,
+)
+
+@Service
+class StatsService(val offenderRepository: OffenderRepository, val siteRepository: PractitionerSiteRepository) {
+  fun practitionerRegistrations(): List<PractitionerRegistrationInfo> {
+    // get registration counts by practitioner
+    val registrations = offenderRepository.findPractitionerRegistrations()
+
+    return registrations.map {
+      val practitioner = it.practitioner
+      val site = siteRepository.findLocation(practitioner)
+      val siteName = site?.name ?: UNKNOWN_LOCATION_NAME
+
+      PractitionerRegistrationInfo(
+        practitioner,
+        siteName,
+        registrationCount = it.registrationCount,
+      )
+    }.toList()
+  }
+
+  companion object {
+    const val UNKNOWN_LOCATION_NAME = "UNKNOWN"
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/TestUtils.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/TestUtils.kt
@@ -47,6 +47,7 @@ fun createNewPractitioner(username: ExternalUserId): Practitioner {
 
 val PRACTITIONER_ALICE = createNewPractitioner("Alice.Smith")
 val PRACTITIONER_BOB = createNewPractitioner("Bob.Jones")
+val PRACTITIONER_DAVE = createNewPractitioner("Dave.Allen")
 
 fun Offender.Companion.create(
   name: String,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/stats/StatsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/stats/StatsServiceTest.kt
@@ -1,0 +1,116 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.integration.stats
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.esupervisionapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.esupervisionapi.integration.PRACTITIONER_ALICE
+import uk.gov.justice.digital.hmpps.esupervisionapi.integration.PRACTITIONER_BOB
+import uk.gov.justice.digital.hmpps.esupervisionapi.integration.PRACTITIONER_DAVE
+import uk.gov.justice.digital.hmpps.esupervisionapi.integration.create
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.Offender
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderStatus
+import uk.gov.justice.digital.hmpps.esupervisionapi.practitioner.InMemoryPractitionerSiteRepository
+import uk.gov.justice.digital.hmpps.esupervisionapi.stats.StatsService
+import java.time.LocalDate
+
+class StatsServiceTest : IntegrationTestBase() {
+  @AfterEach
+  fun tearDown() {
+    this.offenderRepository.deleteAll()
+  }
+
+  @Test
+  fun `known practitioner location registrations`() {
+    // register 3 PoPs - 2 for practitioner alice, one for bob
+    val offender1 = Offender.create("Offender One", "o111111", firstCheckinDate = LocalDate.now(), email = "offender1@example.com", status = OffenderStatus.VERIFIED, practitioner = PRACTITIONER_ALICE)
+    val offender2 = Offender.create("Offender Two", "o222222", firstCheckinDate = LocalDate.now(), email = "offender2@example.com", status = OffenderStatus.VERIFIED, practitioner = PRACTITIONER_ALICE)
+    val offender3 = Offender.create("Offender Three", "o333333", firstCheckinDate = LocalDate.now(), email = "offender3@example.com", status = OffenderStatus.VERIFIED, practitioner = PRACTITIONER_BOB)
+
+    this.offenderRepository.saveAll(listOf(offender1, offender2, offender3))
+
+    // get stats
+    val locationMapping = mapOf(
+      PRACTITIONER_ALICE.externalUserId() to "Narnia",
+      PRACTITIONER_BOB.externalUserId() to "Utopia",
+    )
+
+    val locations = InMemoryPractitionerSiteRepository(locationMapping)
+    val statsService = StatsService(this.offenderRepository, locations)
+
+    val stats = statsService.practitionerRegistrations()
+
+    // should be one summary record for each practitioner
+    Assertions.assertEquals(2, stats.size)
+
+    val aliceStats = stats.find { it.practitioner == PRACTITIONER_ALICE.externalUserId() }!!
+    Assertions.assertEquals(2, aliceStats.registrationCount, "Unexpected count for Alice")
+    Assertions.assertEquals("Narnia", aliceStats.siteName, "Unexpected location for Alice")
+
+    val bobStats = stats.find { it.practitioner == PRACTITIONER_BOB.externalUserId() }!!
+    Assertions.assertEquals(1, bobStats.registrationCount, "Unexpected count for Bob")
+    Assertions.assertEquals("Utopia", bobStats.siteName, "Unexpected location for Bob")
+  }
+
+  @Test
+  fun `unknown practitioner location registrations`() {
+    // register 3 PoPs to different practitioners
+    val offender1 = Offender.create("Offender One", "o111111", firstCheckinDate = LocalDate.now(), email = "offender1@example.com", status = OffenderStatus.VERIFIED, practitioner = PRACTITIONER_ALICE)
+    val offender2 = Offender.create("Offender Two", "o222222", firstCheckinDate = LocalDate.now(), email = "offender2@example.com", status = OffenderStatus.VERIFIED, practitioner = PRACTITIONER_BOB)
+    val offender3 = Offender.create("Offender Three", "o333333", firstCheckinDate = LocalDate.now(), email = "offender3@example.com", status = OffenderStatus.VERIFIED, practitioner = PRACTITIONER_DAVE)
+
+    this.offenderRepository.saveAll(listOf(offender1, offender2, offender3))
+
+    // only location of one practitioner is known
+    val locationMapping = mapOf(
+      PRACTITIONER_ALICE.externalUserId() to "Burnley",
+    )
+
+    val locations = InMemoryPractitionerSiteRepository(locationMapping)
+    val statsService = StatsService(this.offenderRepository, locations)
+
+    val stats = statsService.practitionerRegistrations()
+
+    // should be one summary record for each practitioner
+    Assertions.assertEquals(3, stats.size, "Unexpected practitioner stats count")
+
+    val aliceStats = stats.find { it.practitioner == PRACTITIONER_ALICE.externalUserId() }!!
+    Assertions.assertEquals(1, aliceStats.registrationCount, "Unexpected count for Alice")
+    Assertions.assertEquals("Burnley", aliceStats.siteName, "Unexpected location for Alice")
+
+    val bobStats = stats.find { it.practitioner == PRACTITIONER_BOB.externalUserId() }!!
+    Assertions.assertEquals(1, bobStats.registrationCount, "Unexpected count for Bob")
+    Assertions.assertEquals(StatsService.UNKNOWN_LOCATION_NAME, bobStats.siteName, "Unexpected location for Bob")
+
+    val daveStats = stats.find { it.practitioner == PRACTITIONER_DAVE.externalUserId() }!!
+    Assertions.assertEquals(1, daveStats.registrationCount, "Unexpected count for Dave")
+    Assertions.assertEquals(StatsService.UNKNOWN_LOCATION_NAME, daveStats.siteName, "Unexpected location for Dave")
+  }
+
+  @Test
+  fun `incomplete registrations ignored`() {
+    // register 3 PoPs with different statuses
+    // verified and inactive registrations are counted in the stats, incomplete registrations are ignored
+    val offender1 = Offender.create("Offender One", "o111111", firstCheckinDate = LocalDate.now(), email = "offender1@example.com", status = OffenderStatus.INITIAL, practitioner = PRACTITIONER_ALICE)
+    val offender2 = Offender.create("Offender Two", "o222222", firstCheckinDate = LocalDate.now(), email = "offender2@example.com", status = OffenderStatus.VERIFIED, practitioner = PRACTITIONER_ALICE)
+    val offender3 = Offender.create("Offender Three", "o333333", firstCheckinDate = LocalDate.now(), email = "offender3@example.com", status = OffenderStatus.INACTIVE, practitioner = PRACTITIONER_ALICE)
+
+    this.offenderRepository.saveAll(listOf(offender1, offender2, offender3))
+
+    val locationMapping = mapOf(
+      PRACTITIONER_ALICE.externalUserId() to "Cambridge",
+    )
+
+    val locations = InMemoryPractitionerSiteRepository(locationMapping)
+    val statsService = StatsService(this.offenderRepository, locations)
+
+    val stats = statsService.practitionerRegistrations()
+
+    // only one practitioner
+    Assertions.assertEquals(1, stats.size, "Unexpected practitioner stats count")
+
+    val aliceStats = stats.first()
+    Assertions.assertEquals(2, aliceStats.registrationCount, "Unexpected count for Alice")
+    Assertions.assertEquals("Cambridge", aliceStats.siteName, "Unexpected location for Alice")
+  }
+}


### PR DESCRIPTION
Issue ESUP-746 - Add StatsResource containing routes returning usage stats information.

Add query which fetches the number of PoPs actively registered for each practitioner in the system.

Add PractitionerSitesRepository which returns the named location for a practitioner if known. Add in-memory implementation which loads a mapping of username -> location name from a JSON string.

Add /stats/practitioner/registrations route which returns the number of PoP registrations for each practitioner along with their location if known.