### PR TITLE
fix: expiry date off-by-one calc. bug

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/OffenderCheckinExpiryJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/OffenderCheckinExpiryJob.kt
@@ -20,6 +20,7 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.offender.OffenderCheckinRepo
 import uk.gov.justice.digital.hmpps.esupervisionapi.practitioner.PractitionerRepository
 import java.time.Clock
 import java.time.Duration
+import java.time.LocalDate
 import java.time.Period
 import kotlin.streams.asSequence
 
@@ -44,8 +45,7 @@ class OffenderCheckinExpiryJob(
   @Transactional
   fun process() {
     val now = clock.instant()
-    val today = now.atZone(clock.zone).toLocalDate()
-    val cutoff = today.minus(Period.ofDays(checkinWindow.toDays().toInt()))
+    val cutoff = cutoffDate(clock, checkinWindow)
 
     LOG.info("processing starts. checkins below cutoff=$cutoff will be marked as expired.")
 
@@ -114,4 +114,14 @@ class OffenderCheckinExpiryJob(
   companion object {
     private val LOG = org.slf4j.LoggerFactory.getLogger(OffenderCheckinExpiryJob::class.java)
   }
+}
+
+/**
+ * Returns the upper inclusive bound for checkins that should be marked as expired.
+ */
+internal fun cutoffDate(clock: Clock, checkinWindow: Duration): LocalDate {
+  val now = clock.instant()
+  val today = now.atZone(clock.zone).toLocalDate()
+  val cutoff = today.minus(Period.ofDays(checkinWindow.toDays().toInt()))
+  return cutoff
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinRepository.kt
@@ -111,7 +111,7 @@ interface OffenderCheckinRepository : org.springframework.data.jpa.repository.Jp
   @Query(
     """
     SELECT c FROM OffenderCheckin c  
-    WHERE c.dueDate < :cutoff
+    WHERE c.dueDate <= :cutoff
     AND c.createdAt >= :lowerBound
     AND c.status = 'CREATED'
  """,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderCheckinService.kt
@@ -465,9 +465,8 @@ class OffenderCheckinService(
 }
 
 fun OffenderCheckin.isPastSubmissionDate(clock: Clock, checkinWindow: Period): Boolean {
+  assert(checkinWindow.days > 1)
   val submissionDate = clock.instant().atZone(clock.zone).toLocalDate()
-  // dueDate + window -- last day when checkin can be submitted (till midnight),
-  // the next day is when checkin submissions are no longer accepted
-  val finalCheckinDate = this.dueDate.plus(checkinWindow)
+  val finalCheckinDate = this.dueDate.plus(checkinWindow.minusDays(1))
   return finalCheckinDate < submissionDate
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/jobs/OffenderCheckinExpiryJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/jobs/OffenderCheckinExpiryJobTest.kt
@@ -1,0 +1,22 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.integration.jobs
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.esupervisionapi.jobs.cutoffDate
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+
+class OffenderCheckinExpiryJobTest {
+
+  @Test
+  fun `cutoff date calculation`() {
+    val clock = Clock.fixed(Instant.parse("2025-09-13T14:30:00Z"), ZoneId.systemDefault())
+    val checkinWindow = Duration.ofHours(72)
+    val actual = cutoffDate(clock, checkinWindow)
+
+    Assertions.assertEquals(LocalDate.of(2025, 9, 10), actual)
+  }
+}


### PR DESCRIPTION
- Updated the expiry job checkin query to treat the upper bound as inclusive
- Fixed the same bug in Checkin.isPastSubmissionDate()
- Added unit tests
