### PR TITLE
make Referencable.reference a method

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/CheckinNotificationStatusUpdater.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/CheckinNotificationStatusUpdater.kt
@@ -24,8 +24,10 @@ private data class QueryParams(val ref: Referencable, val createdAt: Instant)
  * jobs and one-off notifications from a particular time interval (up to a given number of days back).
  */
 private data class OneOffNotification(
-  override val reference: String,
-) : Referencable
+  private val ref: String,
+) : Referencable {
+  override fun reference(): String = ref
+}
 
 @Service
 class CheckinNotificationStatusUpdater(
@@ -74,7 +76,7 @@ class CheckinNotificationStatusUpdater(
         do {
           val olderThan = batches.lastOrNull()?.previousPageParam
           val batch = notificationService.notificationStatus(notificationAttempt.ref, olderThan)
-          LOG.info("job reference={}, got batch with {} notifications, older than {}", notificationAttempt.ref.reference, batch.notifications.size, olderThan)
+          LOG.info("job reference={}, got batch with {} notifications, older than {}", notificationAttempt.ref.reference(), batch.notifications.size, olderThan)
           batches.add(batch)
         } while (batches.isNotEmpty() && batch.hasNextPage)
 
@@ -87,13 +89,13 @@ class CheckinNotificationStatusUpdater(
           .filter { !terminalIds.contains(it.uuid) }
           .toList()
 
-        LOG.debug("job reference={}, {} records to update", notificationAttempt.ref.reference, notifications.size)
+        LOG.debug("job reference={}, {} records to update", notificationAttempt.ref.reference(), notifications.size)
 
         // update the remaining notification's status
         try {
           updateNotificationStatus(notifications)
         } catch (e: Exception) {
-          LOG.warn("Failed to update notification statuses for job reference=${notificationAttempt.ref.reference}: ${e.message}", e)
+          LOG.warn("Failed to update notification statuses for job reference=${notificationAttempt.ref.reference()}: ${e.message}", e)
         }
       }
     } catch (e: Exception) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/CheckinNotifier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/CheckinNotifier.kt
@@ -86,7 +86,7 @@ class CheckinNotifier(
 
     val logEntry = JobLog(JobType.CHECKIN_NOTIFICATIONS_JOB, now)
     jobLogRepository.saveAndFlush(logEntry)
-    val notificationContext = BulkNotificationContext(logEntry.reference)
+    val notificationContext = BulkNotificationContext(logEntry.reference())
 
     val context = NotifierContext(
       clock,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/JobLog.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/JobLog.kt
@@ -51,13 +51,12 @@ open class JobLog(
   open var endedAt: Instant? = null,
 ) : AEntity(),
   Referencable {
-  fun dto() = JobLogDto(reference = reference, jobType = jobType, createdAt = createdAt, endedAt = endedAt)
+  fun dto() = JobLogDto(reference = reference(), jobType = jobType, createdAt = createdAt, endedAt = endedAt)
 
   /**
    * An identifier that can be used with external systems.
    *
    * Note: Should be treated as an opaque value.
    */
-  @Transient
-  override val reference = "BLK-${String.format("%05d", id)}"
+  override fun reference(): String = "BLK-${String.format("%05d", id)}"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/OffenderCheckinExpiryJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/jobs/OffenderCheckinExpiryJob.kt
@@ -57,7 +57,7 @@ class OffenderCheckinExpiryJob(
       val lowerBound = now.minus(Period.ofDays(28))
 
       val chunkSize = 100
-      val context = BulkNotificationContext(logEntry.reference)
+      val context = BulkNotificationContext(logEntry.reference())
       checkinRepository.findAllAboutToExpire(cutoff, lowerBound = lowerBound)
         .asSequence()
         .chunked(chunkSize)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/GovNotifyNotificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/GovNotifyNotificationService.kt
@@ -47,9 +47,9 @@ class GovNotifyNotificationService(
   }
 
   override fun notificationStatus(ref: Referencable, olderThan: String?): NotificationStatusCollection {
-    val list = notifyClient.getNotifications(null, null, ref.reference, olderThan)
+    val list = notifyClient.getNotifications(null, null, ref.reference(), olderThan)
     val jobType = if (ref is JobLog) ref.jobType else null
-    LOGGER.info("Got {} notifications, reference={}, jobType={}", list.notifications.size, ref.reference, jobType)
+    LOGGER.info("Got {} notifications, reference={}, jobType={}", list.notifications.size, ref.reference(), jobType)
     val notifications = list.notifications.map { NotificationInfo(it.id, it.status) }
     return StatusCollection(notifications, list.nextPageOlderThan())
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/Referencable.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/notifications/Referencable.kt
@@ -4,5 +4,5 @@ package uk.gov.justice.digital.hmpps.esupervisionapi.notifications
  * A reference that we can use to look up notifications (in bulk) via GOV.UK Notify API.
  */
 interface Referencable {
-  val reference: String
+  fun reference(): String
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/CheckinNotificationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/CheckinNotificationRepository.kt
@@ -73,7 +73,7 @@ interface CheckinNotificationRepository : org.springframework.data.jpa.repositor
 
   @Query(
     """
-    SELECT cn FROM CheckinNotification cn WHERE cn.reference = :#{#ref.reference}
+    SELECT cn FROM CheckinNotification cn WHERE cn.reference = :#{#ref.reference()}
     AND cn.status IN (:statuses)
     AND cn.createdAt >= :lowerBound
     """,


### PR DESCRIPTION
The `reference` member is being initialised with null when handled by Spring/Hibernate. This PR makes it a method so the reference can be passed correctly to the notification service.