### PR TITLE
add deactivationEntry to OffenderDto

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderDto.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.Email
 import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.NotificationMethod
 import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.PhoneNumber
 import uk.gov.justice.digital.hmpps.esupervisionapi.practitioner.ExternalUserId
+import uk.gov.justice.digital.hmpps.esupervisionapi.utils.DeactivationEntry
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.LocalDateDeserializer
 import java.net.URL
 import java.time.Instant
@@ -31,6 +32,8 @@ data class OffenderDto(
   val photoUrl: URL?,
   @JsonDeserialize(using = LocalDateDeserializer::class) val firstCheckin: LocalDate?,
   val checkinInterval: CheckinInterval,
+  // OFFENDER_DEACTIVATED log entry, included when explicitly requested
+  val deactivationEntry: DeactivationEntry? = null,
 ) : Contactable {
   override fun contactMethods(): Iterable<NotificationMethod> {
     val methods = mutableListOf<NotificationMethod>()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderEventLogRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/offender/OffenderEventLogRepository.kt
@@ -97,6 +97,8 @@ interface OffenderEventLogRepository : org.springframework.data.jpa.repository.J
   )
   fun findAllByOffender(offender: Offender, pageable: Pageable): Page<IOffenderEventLogDto>
 
+  fun findByOffenderAndLogEntryTypeOrderByCreatedAtDesc(offender: Offender, logEntryType: LogEntryType): List<IOffenderEventLogDto>
+
   @Query(
     """
     select

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/ResourceDtos.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/ResourceDtos.kt
@@ -3,9 +3,11 @@ package uk.gov.justice.digital.hmpps.esupervisionapi.utils
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import jakarta.validation.constraints.NotBlank
 import org.springframework.data.domain.Pageable
+import uk.gov.justice.digital.hmpps.esupervisionapi.offender.IOffenderEventLogDto
 import uk.gov.justice.digital.hmpps.esupervisionapi.offender.ManualIdVerificationResult
 import uk.gov.justice.digital.hmpps.esupervisionapi.practitioner.ExternalUserId
 import java.net.URL
+import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
 
@@ -66,3 +68,14 @@ data class CheckinReviewRequest(
    */
   val missedCheckinComment: String? = null,
 )
+
+/**
+ * Represents a subset of a log entry for an offender deactivation.
+ */
+data class DeactivationEntry(
+  val uuid: UUID,
+  val comment: String,
+  val createdAt: Instant,
+)
+
+fun IOffenderEventLogDto.toDeactivationEntry() = DeactivationEntry(this.uuid, this.comment, this.createdAt)


### PR DESCRIPTION
Frontend needs to display the reason why offender account was deactivated. The practitioner submits the reason in the `comment` column of the `OffenderEventLog`. This PR adds a `deactivationEntry` property to the `OffenderDto` - it contains the minimal subset of the log entry record.
