### PR TITLE
expiry job tweaks

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,7 +19,7 @@ app:
       cron: "0 0 7,8,11 * * *"  # Production schedule (7 AM and 8 AM daily)
       # cron: "0 */15 * * * *"  # Development schedule (every 15 minutes)
     offender-checkin-expiry:
-      cron: "0 */10 * * * *"
+      cron: "0 15 9 * * *"
       #cron: "0 0 1,10 * * *"  # Production schedule (1 AM and 10 AM daily)
     offender-checkin-notification-status:
       cron: "0 30 * * * *"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,7 +19,7 @@ app:
       cron: "0 0 7,8,11 * * *"  # Production schedule (7 AM and 8 AM daily)
       # cron: "0 */15 * * * *"  # Development schedule (every 15 minutes)
     offender-checkin-expiry:
-      cron: "0 15 9 * * *"
+      cron: "0 */10 * * * *"
       #cron: "0 0 1,10 * * *"  # Production schedule (1 AM and 10 AM daily)
     offender-checkin-notification-status:
       cron: "0 30 * * * *"


### PR DESCRIPTION
This PR modifies the checkin expiry job:
- narrows down the bounds for checkins considered for expiry
- adds logging to help find the bug
- adds a cache for practitioners (scoped to the duration of the job)
