### PR TITLE
Esup 1563 add stopped checkin event

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/DomainEventService.kt
@@ -35,7 +35,7 @@ class DomainEventService(
     additionalInformation: AdditionalInformation? = null,
   ) {
     LOGGER.debug(">>> Initiating {} event for uuid={}, crn={}", eventType.eventTypeName, uuid, crn)
-    val detailUrl = "$apiBaseUrl/v2/events/${eventType.pathSegment}/$uuid"
+    val detailUrl = eventType.pathSegment?.let { "$apiBaseUrl/v2/events/$it/$uuid" }
 
     try {
       val event = DomainEvent(
@@ -48,7 +48,7 @@ class DomainEventService(
       )
 
       eventPublisher.publish(event)
-      LOGGER.info("Published domain event: eventType={}, crn={}, detailUrl={}", eventType.type, crn, detailUrl)
+      LOGGER.info("Published domain event: eventType={}, crn={}", eventType.type, crn)
     } catch (e: Exception) {
       LOGGER.error(
         "Failed to publish domain event: {}",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/DomainEventService.kt
@@ -48,7 +48,7 @@ class DomainEventService(
       )
 
       eventPublisher.publish(event)
-      LOGGER.info("Published domain event: eventType={}, crn={}", eventType.type, crn)
+      LOGGER.info("Published domain event: eventType={}, crn={}, detailUrl={}", eventType.type, crn, detailUrl)
     } catch (e: Exception) {
       LOGGER.error(
         "Failed to publish domain event: {}",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/EventDetailV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/EventDetailV2Service.kt
@@ -166,6 +166,9 @@ class EventDetailV2Service(
           sb.appendLine("${logEntry.notes}")
         }
       }
+      DomainEventType.V2_SETUP_COMPLETED,
+      DomainEventType.V2_SETUP_REMOVED,
+      -> {}
     }
 
     return sb.toString().trimEnd('\n')

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/EventDetailV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/EventDetailV2Service.kt
@@ -15,7 +15,6 @@ import kotlin.jvm.optionals.getOrNull
 
 @Service
 class EventDetailV2Service(
-  private val offenderRepository: OffenderV2Repository,
   private val checkinRepository: OffenderCheckinV2Repository,
   private val eventLogRepository: OffenderEventLogV2Repository,
   private val proxyLinkCreator: ProxyLinkCreator,
@@ -42,39 +41,20 @@ class EventDetailV2Service(
     }
 
     return when (val domainEventType = DomainEventType.fromPath(eventType)) {
-      DomainEventType.V2_SETUP_COMPLETED -> getRegistrationCompletedDetail(uuid)
       DomainEventType.V2_CHECKIN_CREATED,
       DomainEventType.V2_CHECKIN_SUBMITTED,
       DomainEventType.V2_CHECKIN_REVIEWED,
       DomainEventType.V2_CHECKIN_EXPIRED,
       -> getCheckinEventDetail(uuid, domainEventType)
       DomainEventType.V2_CHECKIN_ANNOTATED -> getCheckinAnnotatedEventDetail(uuid)
-      null -> {
+      DomainEventType.V2_SETUP_COMPLETED,
+      DomainEventType.V2_SETUP_REMOVED,
+      null,
+      -> {
         LOGGER.warn("Unknown event type in detail URL: {}", detailUrl)
         null
       }
     }
-  }
-
-  private fun getRegistrationCompletedDetail(offenderUuid: UUID): EventDetailResponse? {
-    val offender = offenderRepository.findByUuid(offenderUuid).orElse(null)
-    if (offender == null) {
-      LOGGER.warn("Offender not found for UUID: {}", offenderUuid)
-      return null
-    }
-
-    val notes = formatSetupCompletedNotes(offender)
-
-    val eventType = DomainEventType.V2_SETUP_COMPLETED
-    return EventDetailResponse(
-      eventReferenceId = "${eventType.eventTypeName}-$offenderUuid",
-      eventType = eventType.eventTypeName,
-      notes = notes,
-      crn = offender.crn,
-      offenderUuid = offenderUuid,
-      checkinUuid = null,
-      timestamp = offender.createdAt,
-    )
   }
 
   private fun getCheckinEventDetail(checkinUuid: UUID, eventType: DomainEventType): EventDetailResponse? {
@@ -130,26 +110,9 @@ class EventDetailV2Service(
     )
   }
 
-  private fun formatSetupCompletedNotes(offender: OffenderV2): String {
-    val lines = mutableListOf<String>()
-    lines.add("Registration Completed")
-    lines.add("Offender UUID: ${offender.uuid}")
-    lines.add("CRN: ${offender.crn}")
-    lines.add("Practitioner: ${offender.practitionerId}")
-    lines.add("Status: ${offender.status}")
-    lines.add("First check-in: ${offender.firstCheckin}")
-    lines.add("Check-in interval: ${offender.checkinInterval}")
-    lines.add("Created at: ${offender.createdAt}")
-    lines.add("Created by: ${offender.createdBy}")
-    return lines.joinToString("\n")
-  }
-
   private fun formatCheckinNotes(checkin: OffenderCheckinV2, eventType: DomainEventType, logEntry: IOffenderCheckinLogEntryV2Dto? = null): String {
     val sb = StringBuilder()
     when (eventType) {
-      DomainEventType.V2_SETUP_COMPLETED -> {
-        sb.appendLine("Check in: ${formatHumanReadableDateTime(checkin.createdAt)}")
-      }
       DomainEventType.V2_CHECKIN_CREATED -> {
         sb.appendLine("Check in created: ${formatHumanReadableDateTime(checkin.createdAt)}")
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorV2Service.kt
@@ -51,14 +51,13 @@ class NotificationOrchestratorV2Service(
     contactDetails: ContactDetails? = null,
   ) {
     val details = contactDetails ?: ndiliusApiClient.getContactDetails(offender.crn)
-    val eventNumber = details?.let { activeEventNumber(offender, it) }
 
     domainEventService.publishDomainEvent(
       eventType = DomainEventType.V2_SETUP_COMPLETED,
       uuid = offender.uuid,
       crn = offender.crn,
       description = "Practitioner completed setup for offender ${offender.crn}",
-      additionalInformation = eventNumber?.let { AdditionalInformation(eventNumber = it) },
+      additionalInformation = details?.let { activeEventNumber(offender, it) }?.let { AdditionalInformation(eventNumber = it) },
     )
 
     eventAuditService.recordSetupCompleted(offender, details)
@@ -142,14 +141,13 @@ class NotificationOrchestratorV2Service(
     contactDetails: ContactDetails? = null,
   ) {
     val details = contactDetails ?: ndiliusApiClient.getContactDetails(offender.crn)
-    val eventNumber = details?.let { activeEventNumber(offender, it) }
 
     domainEventService.publishDomainEvent(
       eventType = DomainEventType.V2_SETUP_REMOVED,
       uuid = offender.uuid,
       crn = offender.crn,
       description = "Online check-ins stopped for offender ${offender.crn}",
-      additionalInformation = eventNumber?.let { AdditionalInformation(eventNumber = it) },
+      additionalInformation = details?.let { activeEventNumber(offender, it) }?.let { AdditionalInformation(eventNumber = it) },
     )
 
     if (details != null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorV2Service.kt
@@ -16,6 +16,7 @@ import java.time.Clock
 import java.time.Duration
 import java.time.Period
 import java.time.format.DateTimeFormatter
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.events.AdditionalInformation
 import java.util.UUID
 
 /**
@@ -49,14 +50,17 @@ class NotificationOrchestratorV2Service(
     offender: OffenderV2,
     contactDetails: ContactDetails? = null,
   ) {
+    val details = contactDetails ?: ndiliusApiClient.getContactDetails(offender.crn)
+    val eventNumber = details?.let { activeEventNumber(offender, it) }
+
     domainEventService.publishDomainEvent(
       eventType = DomainEventType.V2_SETUP_COMPLETED,
       uuid = offender.uuid,
       crn = offender.crn,
       description = "Practitioner completed setup for offender ${offender.crn}",
+      additionalInformation = eventNumber?.let { AdditionalInformation(eventNumber = it) },
     )
 
-    val details = contactDetails ?: ndiliusApiClient.getContactDetails(offender.crn)
     eventAuditService.recordSetupCompleted(offender, details)
 
     if (details != null) {
@@ -138,6 +142,15 @@ class NotificationOrchestratorV2Service(
     contactDetails: ContactDetails? = null,
   ) {
     val details = contactDetails ?: ndiliusApiClient.getContactDetails(offender.crn)
+    val eventNumber = details?.let { activeEventNumber(offender, it) }
+
+    domainEventService.publishDomainEvent(
+      eventType = DomainEventType.V2_SETUP_REMOVED,
+      uuid = offender.uuid,
+      crn = offender.crn,
+      description = "Online check-ins stopped for offender ${offender.crn}",
+      additionalInformation = eventNumber?.let { AdditionalInformation(eventNumber = it) },
+    )
 
     if (details != null) {
       try {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorV2Service.kt
@@ -10,13 +10,13 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.audit.EventAuditV2Service
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.checkin.activeEventNumber
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.AutomatedIdVerificationResult
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.CheckinInterval
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.events.AdditionalInformation
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.events.DomainEventType
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.security.PiiSanitizer
 import java.time.Clock
 import java.time.Duration
 import java.time.Period
 import java.time.format.DateTimeFormatter
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.events.AdditionalInformation
 import java.util.UUID
 
 /**

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/EventV2Resource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/EventV2Resource.kt
@@ -23,24 +23,6 @@ class EventV2Resource(
   private val notificationService: NotificationV2Service,
 ) {
   @PreAuthorize("hasAnyRole('ROLE_ESUPERVISION__CHECK_IN__RO', 'ROLE_ESUPERVISION__ESUPERVISION_UI')")
-  @GetMapping("/setup-completed/{uuid}")
-  @Operation(
-    summary = "Get setup completed event details",
-    description =
-    "Callback URL for Ndilius to query formatted notes for setup completed event",
-  )
-  fun getSetupCompletedEvent(
-    @Parameter(description = "Offender UUID", required = true) @PathVariable uuid: UUID,
-  ): ResponseEntity<EventDetailResponse> {
-    val detailUrl = "/v2/events/setup-completed/$uuid"
-    val event =
-      notificationService.getEventDetail(detailUrl)
-        ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Event not found")
-
-    return ResponseEntity.ok(event)
-  }
-
-  @PreAuthorize("hasAnyRole('ROLE_ESUPERVISION__CHECK_IN__RO', 'ROLE_ESUPERVISION__ESUPERVISION_UI')")
   @GetMapping("/checkin-created/{uuid}")
   @Operation(
     summary = "Get checkin created event details",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/events/DomainEventType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/events/DomainEventType.kt
@@ -5,12 +5,11 @@ internal const val V2_PREFIX = "esupervision"
 enum class DomainEventType(
   val type: String,
   val description: String,
-  val pathSegment: String,
+  val pathSegment: String? = null,
 ) {
   V2_SETUP_COMPLETED(
     "$V2_PREFIX.setup.completed",
     "An e-Supervision V2 offender setup was completed by practitioner",
-    "setup-completed",
   ),
   V2_CHECKIN_CREATED(
     "$V2_PREFIX.check-in.created",
@@ -31,6 +30,11 @@ enum class DomainEventType(
     "$V2_PREFIX.check-in.expired",
     "An e-Supervision V2 remote check-in was expired",
     "checkin-expired",
+  ),
+
+  V2_SETUP_REMOVED(
+    "$V2_PREFIX.setup.removed",
+    "An e-Supervision V2 offender's online check-ins were stopped",
   ),
 
   /** In esupervision we talk about "annotating a check-in" rather than "updating it",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/events/Model.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/events/Model.kt
@@ -6,7 +6,7 @@ data class AdditionalInformation(val eventNumber: Long? = null)
 
 data class DomainEvent(
   val eventType: String,
-  val detailUrl: String,
+  val detailUrl: String? = null,
   val occurredAt: ZonedDateTime,
   val description: String,
   val personReference: PersonReference?,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/DomainEventServiceTest.kt
@@ -7,6 +7,7 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.events.AdditionalInformation
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.events.DomainEvent
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.events.DomainEventPublisher
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.events.DomainEventType
@@ -29,7 +30,7 @@ class DomainEventServiceTest {
   }
 
   @Test
-  fun `publishDomainEvent - constructs correct detail URL for setup completed`() {
+  fun `publishDomainEvent - does not include detailUrl for setup completed`() {
     val uuid = UUID.randomUUID()
 
     service.publishDomainEvent(
@@ -43,7 +44,7 @@ class DomainEventServiceTest {
     verify(eventPublisher).publish(captor.capture())
 
     val event = captor.firstValue
-    assertThat(event.detailUrl).isEqualTo("$apiBaseUrl/v2/events/setup-completed/$uuid")
+    assertThat(event.detailUrl).isNull()
     assertThat(event.eventType).isEqualTo("esupervision.setup.completed")
   }
 
@@ -64,6 +65,27 @@ class DomainEventServiceTest {
     val event = captor.firstValue
     assertThat(event.detailUrl).isEqualTo("$apiBaseUrl/v2/events/checkin-submitted/$uuid")
     assertThat(event.eventType).isEqualTo("esupervision.check-in.received")
+  }
+
+  @Test
+  fun `publishDomainEvent - does not include detailUrl for setup removed`() {
+    val uuid = UUID.randomUUID()
+
+    service.publishDomainEvent(
+      eventType = DomainEventType.V2_SETUP_REMOVED,
+      uuid = uuid,
+      crn = "X123456",
+      description = "Test description",
+      additionalInformation = AdditionalInformation(eventNumber = 1),
+    )
+
+    val captor = argumentCaptor<DomainEvent>()
+    verify(eventPublisher).publish(captor.capture())
+
+    val event = captor.firstValue
+    assertThat(event.detailUrl).isNull()
+    assertThat(event.eventType).isEqualTo("esupervision.setup.removed")
+    assertThat(event.additionalInformation?.eventNumber).isEqualTo(1)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/EventDetailV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/EventDetailV2ServiceTest.kt
@@ -20,7 +20,6 @@ import java.util.UUID
 
 class EventDetailV2ServiceTest {
 
-  private val offenderRepository: OffenderV2Repository = mock()
   private val checkinRepository: OffenderCheckinV2Repository = mock()
   private val eventLogRepository: OffenderEventLogV2Repository = mock()
   private val proxyLinkCreator: ProxyLinkCreator = mock()
@@ -30,25 +29,11 @@ class EventDetailV2ServiceTest {
 
   @BeforeEach
   fun setUp() {
-    service = EventDetailV2Service(offenderRepository, checkinRepository, eventLogRepository, proxyLinkCreator, appConfig)
+    service = EventDetailV2Service(checkinRepository, eventLogRepository, proxyLinkCreator, appConfig)
   }
 
   @Nested
   inner class GetEventDetail {
-
-    @Test
-    fun `returns setup-completed event detail`() {
-      val uuid = UUID.randomUUID()
-      val offender = createOffender(uuid)
-      whenever(offenderRepository.findByUuid(uuid)).thenReturn(Optional.of(offender))
-
-      val result = service.getEventDetail("/v2/events/setup-completed/$uuid")
-
-      assertThat(result).isNotNull
-      assertThat(result!!.eventType).isEqualTo("SETUP_COMPLETED")
-      assertThat(result.crn).isEqualTo("X123456")
-      assertThat(result.offenderUuid).isEqualTo(uuid)
-    }
 
     @Test
     fun `returns checkin-submitted event detail with submittedAt timestamp`() {
@@ -318,24 +303,6 @@ class EventDetailV2ServiceTest {
 
     assertThat(result).isNotNull
     assertThat(result!!.notes).contains("Some note")
-  }
-
-  @Nested
-  inner class SetupCompletedNotesFormatting {
-
-    @Test
-    fun `formats setup completed notes`() {
-      val uuid = UUID.randomUUID()
-      val offender = createOffender(uuid)
-      whenever(offenderRepository.findByUuid(uuid)).thenReturn(Optional.of(offender))
-
-      val result = service.getEventDetail("/v2/events/setup-completed/$uuid")
-
-      assertThat(result).isNotNull
-      assertThat(result!!.notes).contains("Registration Completed")
-      assertThat(result.notes).contains("CRN: X123456")
-      assertThat(result.notes).contains("Practitioner: PRACT001")
-    }
   }
 
   @Nested

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorV2ServiceTest.kt
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
-import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorV2ServiceTest.kt
@@ -228,6 +228,26 @@ class NotificationOrchestratorV2ServiceTest {
   }
 
   @Test
+  fun `sendSetupCompletedNotifications - publishes event without additionalInformation when no events`() {
+    val offender = createOffender()
+    val contactDetails = createContactDetails()
+
+    whenever(notificationPersistence.buildOffenderNotifications(any(), any(), any())).thenReturn(emptyList())
+    whenever(notificationPersistence.saveNotifications(any())).thenReturn(emptyList())
+
+    service.sendSetupCompletedNotifications(offender, contactDetails)
+
+    verify(domainEventService).publishDomainEvent(
+      eq(DomainEventType.V2_SETUP_COMPLETED),
+      eq(offender.uuid),
+      eq(offender.crn),
+      any(),
+      eq(null),
+      eq(null),
+    )
+  }
+
+  @Test
   fun `sendDeactivationCompletedNotifications - publishes setup removed domain event`() {
     val offender = createOffender()
     val contactDetails = createContactDetailsWithEvents()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorV2ServiceTest.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -15,6 +16,8 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.audit.EventAuditV2Service
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.CheckinInterval
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ContactPreference
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.OffenderStatus
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.events.AdditionalInformation
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.events.DomainEventType
 import java.net.URI
 import java.time.Clock
 import java.time.Duration
@@ -205,6 +208,66 @@ class NotificationOrchestratorV2ServiceTest {
     verify(domainEventService).publishDomainEvent(any(), eq(offender.uuid), eq(offender.crn), any(), eq(null), eq(null))
   }
 
+  @Test
+  fun `sendSetupCompletedNotifications - includes event number when contact details have events`() {
+    val offender = createOffender()
+    val contactDetails = createContactDetailsWithEvents()
+
+    whenever(notificationPersistence.buildOffenderNotifications(any(), any(), any())).thenReturn(emptyList())
+    whenever(notificationPersistence.saveNotifications(any())).thenReturn(emptyList())
+
+    service.sendSetupCompletedNotifications(offender, contactDetails)
+
+    verify(domainEventService).publishDomainEvent(
+      eq(DomainEventType.V2_SETUP_COMPLETED),
+      eq(offender.uuid),
+      eq(offender.crn),
+      any(),
+      eq(null),
+      eq(AdditionalInformation(eventNumber = 12345L)),
+    )
+  }
+
+  @Test
+  fun `sendDeactivationCompletedNotifications - publishes setup removed domain event`() {
+    val offender = createOffender()
+    val contactDetails = createContactDetailsWithEvents()
+
+    whenever(notificationPersistence.buildOffenderNotifications(any(), any(), any())).thenReturn(emptyList())
+    whenever(notificationPersistence.saveNotifications(any())).thenReturn(emptyList())
+
+    service.sendDeactivationCompletedNotifications(offender, contactDetails)
+
+    verify(domainEventService).publishDomainEvent(
+      eq(DomainEventType.V2_SETUP_REMOVED),
+      eq(offender.uuid),
+      eq(offender.crn),
+      any(),
+      eq(null),
+      eq(AdditionalInformation(eventNumber = 12345L)),
+    )
+  }
+
+  @Test
+  fun `sendDeactivationCompletedNotifications - publishes event without additionalInformation when no events`() {
+    val offender = createOffender()
+    val contactDetails = createContactDetails()
+
+    whenever(notificationPersistence.buildOffenderNotifications(any(), any(), any())).thenReturn(emptyList())
+    whenever(notificationPersistence.saveNotifications(any())).thenReturn(emptyList())
+
+    service.sendDeactivationCompletedNotifications(offender, contactDetails)
+
+    verify(domainEventService).publishDomainEvent(
+      eq(DomainEventType.V2_SETUP_REMOVED),
+      eq(offender.uuid),
+      eq(offender.crn),
+      any(),
+      eq(null),
+      eq(null),
+    )
+  }
+
   private fun createOffender(status: OffenderStatus = OffenderStatus.VERIFIED) = OffenderV2(
     uuid = UUID.randomUUID(),
     crn = "X123456",
@@ -228,6 +291,21 @@ class NotificationOrchestratorV2ServiceTest {
     dueDate = LocalDate.now(clock),
     createdAt = clock.instant(),
     createdBy = "SYSTEM",
+  )
+
+  private fun createContactDetailsWithEvents() = ContactDetails(
+    crn = "X123456",
+    name = Name("John", "Smith"),
+    mobile = "07700900123",
+    email = "test@test.com",
+    practitioner = PractitionerDetails(
+      name = Name("Jane", "Doe"),
+      email = "jane.doe@probation.gov.uk",
+      localAdminUnit = OrganizationalUnit("LAU01", "Test LAU"),
+      probationDeliveryUnit = OrganizationalUnit("PDU01", "Test PDU"),
+      provider = OrganizationalUnit("PRV01", "Test Provider"),
+    ),
+    events = listOf(Event(number = 12345L, mainOffence = CodedDescription("OFF01", "Test Offence"), sentence = null)),
   )
 
   private fun createContactDetails() = ContactDetails(


### PR DESCRIPTION
- Add new esupervision.setup.removed domain event, published when online check-ins are stopped for an offender
- Include eventNumber in additionalInformation for both setup.completed and setup.removed events
- Make detailUrl nullable on DomainEvent — setup events have no callback detail endpoint
- Remove the /v2/events/setup-completed/{uuid} endpoint and associated detail/formatting logic (no longer needed by consumers)