### PR TITLE
ESUP-1250 Add liveness enabled flag to distinguish check in match res…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/CheckinV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/CheckinV2Service.kt
@@ -449,6 +449,9 @@ class CheckinV2Service(
       )
     }
 
+    checkin.livenessEnabled = true
+    checkinRepository.save(checkin)
+
     val sessionId = awaitRekognition(
       future = livenessSessionService.createSession(),
       action = "create liveness session",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
@@ -299,6 +299,8 @@ data class CheckinV2Dto(
   val livenessResult: LivenessResult? = null,
   @field:Schema(description = "Liveness confidence score 0-100 (null for video-based check-ins)", required = false)
   val livenessConfidence: Float? = null,
+  @field:Schema(description = "Whether liveness verification was enabled for this check-in", required = false)
+  val livenessEnabled: Boolean = false,
   @field:Schema(description = "Manual ID check result", required = false)
   val manualIdCheck: ManualIdVerificationResult? = null,
   @field:Schema(description = "Survey responses (JSONB)", required = false)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Entities.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Entities.kt
@@ -219,6 +219,9 @@ open class OffenderCheckinV2(
   @Column(name = "liveness_confidence", nullable = true)
   open var livenessConfidence: Float? = null,
 
+  @Column(name = "liveness_enabled", nullable = false)
+  open var livenessEnabled: Boolean = false,
+
   @Column(name = "manual_id_check", nullable = true, length = 50)
   @Enumerated(EnumType.STRING)
   open var manualIdCheck: ManualIdVerificationResult? = null,
@@ -257,6 +260,7 @@ open class OffenderCheckinV2(
       autoIdCheck = autoIdCheck,
       livenessResult = livenessResult,
       livenessConfidence = livenessConfidence,
+      livenessEnabled = livenessEnabled,
       manualIdCheck = manualIdCheck,
       riskFeedback = riskFeedback,
       sensitive = sensitive,

--- a/src/main/resources/db/changelog/changesets/46_add_liveness_enabled_to_offender_checkin_v2.sql
+++ b/src/main/resources/db/changelog/changesets/46_add_liveness_enabled_to_offender_checkin_v2.sql
@@ -1,0 +1,8 @@
+--liquibase formatted sql
+
+--changeset richard-birch:46_add_liveness_enabled_to_offender_checkin_v2
+
+ALTER TABLE offender_checkin_v2
+    ADD COLUMN liveness_enabled BOOLEAN NOT NULL DEFAULT FALSE;
+
+--rollback ALTER TABLE offender_checkin_v2 DROP COLUMN liveness_enabled;

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -89,3 +89,5 @@ databaseChangeLog:
       file: db/changelog/changesets/44_custom_questions_definitions.sql
   - include:
       file: db/changelog/changesets/45_add_liveness_columns_to_offender_checkin_v2.sql
+  - include:
+      file: db/changelog/changesets/46_add_liveness_enabled_to_offender_checkin_v2.sql

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/CheckinV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/CheckinV2ServiceTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.esupervisionapi.v2.checkin
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -46,6 +47,7 @@ import java.time.LocalDate
 import java.time.ZoneId
 import java.util.Optional
 import java.util.UUID
+import java.util.concurrent.CompletableFuture
 
 class CheckinV2ServiceTest {
 
@@ -539,6 +541,69 @@ class CheckinV2ServiceTest {
 
     assertEquals(true, checkin.sensitive)
     verify(checkinRepository, never()).save(checkin)
+  }
+
+  @Test
+  fun `createLivenessSession - happy path - sets livenessEnabled to true`() {
+    val uuid = UUID.randomUUID()
+    val offender = createOffender()
+    val checkin = OffenderCheckinV2(
+      uuid = uuid,
+      offender = offender,
+      status = CheckinV2Status.CREATED,
+      dueDate = LocalDate.now(clock),
+      createdAt = clock.instant(),
+      createdBy = "SYSTEM",
+    )
+
+    assertFalse(checkin.livenessEnabled)
+
+    whenever(checkinRepository.findByUuid(uuid)).thenReturn(Optional.of(checkin))
+    whenever(checkinRepository.save(any())).thenAnswer { it.getArgument(0) }
+    whenever(livenessSessionService.createSession()).thenReturn(CompletableFuture.completedFuture("session-123"))
+
+    val result = service.createLivenessSession(uuid)
+
+    assertEquals("session-123", result.sessionId)
+    assertTrue(checkin.livenessEnabled)
+    verify(checkinRepository).save(checkin)
+  }
+
+  @Test
+  fun `createLivenessSession - unhappy path - checkin not found throws exception`() {
+    val uuid = UUID.randomUUID()
+
+    whenever(checkinRepository.findByUuid(uuid)).thenReturn(Optional.empty())
+
+    val exception = assertThrows(ResponseStatusException::class.java) {
+      service.createLivenessSession(uuid)
+    }
+
+    assertEquals(HttpStatus.NOT_FOUND, exception.statusCode)
+  }
+
+  @Test
+  fun `createLivenessSession - unhappy path - non-CREATED checkin throws exception`() {
+    val uuid = UUID.randomUUID()
+    val offender = createOffender()
+    val checkin = OffenderCheckinV2(
+      uuid = uuid,
+      offender = offender,
+      status = CheckinV2Status.SUBMITTED,
+      dueDate = LocalDate.now(clock),
+      createdAt = clock.instant(),
+      createdBy = "SYSTEM",
+      submittedAt = clock.instant(),
+    )
+
+    whenever(checkinRepository.findByUuid(uuid)).thenReturn(Optional.of(checkin))
+
+    val exception = assertThrows(ResponseStatusException::class.java) {
+      service.createLivenessSession(uuid)
+    }
+
+    assertEquals(HttpStatus.BAD_REQUEST, exception.statusCode)
+    assertFalse(checkin.livenessEnabled)
   }
 
   private fun createOffender() = OffenderV2(


### PR DESCRIPTION
For the practitioner reviewing a check in, the system ID check status needs to be aware of whether liveness was enabled or not. If enabled, only check ins where both the liveness check and the face match check are considered a pass.

- Add `liveness_enabled` flag
- Set flag true on liveness session request
- Expose flag in check in details endpoint
- Add tests for correctly setting flag