### PR TITLE
FIX: ensure we're not allowing empty strings

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/QuestionParamsValidator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/QuestionParamsValidator.kt
@@ -43,7 +43,7 @@ internal fun ConstraintValidatorContext.constraint(message: String) {
 fun validatePlaceholders(params: Map<String, Any>): Boolean {
   val placeholders = params["placeholders"] ?: return true
   if (placeholders is Map<*, *>) {
-    return placeholders.all { it.key is String && it.value is String }
+    return placeholders.all { it.key is String && it.value is String && (it.value as String).isNotBlank() }
   }
   return false
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/QuestionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/QuestionService.kt
@@ -162,7 +162,7 @@ fun QuestionListItemDto.evalTemplate(): OffenderQuestion {
   var hint = spec["hint"] as String
   val values = (this.params["placeholders"] ?: emptyMap<String, String>()) as Map<String, String>
   for (placeholder in this.template.placeholders()) {
-    val value = values[placeholder]
+    val value = values[placeholder]?.trim()
     templateString = templateString.replacePlaceholder(placeholder, value)
     hint = hint.replacePlaceholder(placeholder, value)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/ValidatorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/ValidatorTest.kt
@@ -37,6 +37,15 @@ class ValidatorTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `AssignCustomQuestionsRequest validator - fail, empty string placeholders`() {
+    val req = assignCustomQuestionsRequest.copy(
+      questions = listOf(CustomQuestionItem(1, mapOf("placeholders" to mapOf("key" to "")))),
+    )
+    val result = validator.validate(req)
+    assertTrue(result.isNotEmpty())
+  }
+
+  @Test
   fun `AssignCustomQuestionsRequest validator - fail, placeholders are not strings`() {
     val req = assignCustomQuestionsRequest.copy(
       questions = listOf(CustomQuestionItem(1, mapOf("placeholders" to listOf(1, 2, 3)))),


### PR DESCRIPTION
At the moment the /assignment endpoint allows empty strings to be submitted as template values. This change updates the validator to fail in such cases