### PR TITLE
FIX: Reverse order of questions in the Default list

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/SurveyDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/SurveyDetails.kt
@@ -7,9 +7,6 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.SurveyVersion
  */
 fun StringBuilder.appendQuestionsAndAnswers(survey: Map<String, Any>): StringBuilder = formatSurvey(survey, this)
 
-// as of now, we don't allow more than three questions, so we shouldn't need all of the below
-val customQuestionsMarkers = listOf("1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣", "7️⃣", "8️⃣", "9️⃣", "🔟")
-
 /**
  * Formats the offender's response to a survey into a human-readable string
  * that will be displayed as a note in NDelius.
@@ -25,17 +22,12 @@ fun formatSurvey(survey: Map<String, Any>, sb: StringBuilder): StringBuilder {
   if (version == SurveyVersion.V20260416Questions.version) {
     // customQuestions: Array<{ question: string; response: string; details?: string }>)
     val customQuestions = (survey["customQuestions"] as? List<Map<String, Any>>) ?: emptyList()
-    if (customQuestions.isNotEmpty()) {
-      sb.appendLine("Custom questions")
-    }
-    customQuestions.forEachIndexed { index, customQuestion ->
+    customQuestions.forEach { customQuestion ->
       val question = customQuestion["question"]
-      val marker = if (index < customQuestionsMarkers.size) customQuestionsMarkers[index] else "⏺️"
-      sb.appendLine("$marker $question")
-      val response = customQuestion["response"] ?: ""
-      sb.appendLine("Answer: ${response.trim()}")
-      val details = customQuestion["details"]
-      if (details != null) {
+      val response = (customQuestion["response"] ?: "") as String
+      sb.appendLine("$question: ${response.trim()}")
+      val details = (customQuestion["details"] ?: "") as String
+      if (details.isNotBlank()) {
         sb.appendLine("Details: ${details.trim()}")
       }
       sb.appendLine()

--- a/src/main/resources/db/changelog/changesets/47_fix_default_question_list_order.sql
+++ b/src/main/resources/db/changelog/changesets/47_fix_default_question_list_order.sql
@@ -1,0 +1,16 @@
+--liquibase formatted sql
+
+--changeset roland.sadowski:47_fix_default_question_list_order
+
+-- reverse the order of the Default question list
+UPDATE question_list_item
+SET position = updated_values.reversed_pos
+FROM (SELECT
+          question_list_id as list_id,
+          question_id as question_id,
+          ROW_NUMBER() OVER (ORDER BY position DESC) as reversed_pos
+      FROM question_list_item
+      WHERE question_list_id = (select id from question_list where name = 'Default')
+     ) as updated_values(list_id, question_id, reversed_pos)
+WHERE question_list_item.question_list_id = updated_values.list_id
+  and question_list_item.question_id = updated_values.question_id;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/SurveyDetailsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/SurveyDetailsTest.kt
@@ -20,9 +20,8 @@ class SurveyDetailsTest {
     )
 
     val result = formatSurvey(survey, StringBuilder()).toString()
-    assertTrue(result.contains("Custom questions\n"))
-    assertTrue(result.contains("1️⃣ What is your favourite colour?\nAnswer: Blue"))
-    assertTrue(result.contains("2️⃣ What is your favourite animal?\nAnswer: Dog"))
+    assertTrue(result.contains("What is your favourite colour?: Blue"))
+    assertTrue(result.contains("What is your favourite animal?: Dog"))
   }
 
   @Test
@@ -35,12 +34,15 @@ class SurveyDetailsTest {
   fun `render survey for pre-questions version`() {
     val survey = exampleSurvey.toMutableMap()
     survey["version"] = SurveyVersion.V20250710pilot.version
+    survey["customQuestions"] = listOf(
+      mapOf("question" to "What is your favourite colour?", "response" to "Blue"),
+    )
     val result = formatSurvey(survey, StringBuilder()).toString()
-    assertFalse(result.contains("Custom questions"))
+    assertFalse(result.contains("Blue"))
   }
 }
 
-private val exampleSurvey = mapOf(
+private val exampleSurvey: Map<String, Any> = mapOf(
   "version" to SurveyVersion.V20260416Questions.version,
   "mentalHealth" to "WELL",
   "housingSupport" to "NO_HELP",


### PR DESCRIPTION
The "fixed" questions are supposed to be in different order.

Also, updates the survey details content formatting.