### PR TITLE
Remove question assignment on offender deactivation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderV2Resource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderV2Resource.kt
@@ -39,6 +39,7 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.OffenderStatus
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.dto.LocationInfo
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.dto.UploadLocationResponse
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.storage.S3UploadService
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.question.QuestionService
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.setup.OffenderSetupV2Service
 import java.time.Clock
 import java.time.Duration
@@ -59,6 +60,7 @@ class OffenderV2Resource(
   private val checkinRepository: OffenderCheckinV2Repository,
   private val offenderSetupRepository: OffenderSetupV2Repository,
   private val offenderSetupV2Service: OffenderSetupV2Service,
+  private val questionService: QuestionService,
 ) {
 
   @PreAuthorize("hasRole('ROLE_ESUPERVISION__ESUPERVISION_UI')")
@@ -203,6 +205,8 @@ class OffenderV2Resource(
     offender.status = OffenderStatus.INACTIVE
     offender.updatedAt = clock.instant()
     val saved = offenderRepository.save(offender)
+
+    questionService.deleteUpcomingAssignment(offender.crn)
 
     // set any pending check ins to cancelled
     val pendingCheckins = checkinRepository.findAllByOffenderAndStatus(saved, CheckinV2Status.CREATED)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderV2ResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderV2ResourceTest.kt
@@ -31,6 +31,7 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.CheckinInterval
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ContactPreference
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.OffenderStatus
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.storage.S3UploadService
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.question.QuestionService
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.setup.OffenderSetupV2Service
 import java.net.URI
 import java.time.Clock
@@ -53,6 +54,7 @@ class OffenderV2ResourceTest {
   private val checkinRepository: OffenderCheckinV2Repository = mock()
   private val offenderSetupRepository: OffenderSetupV2Repository = mock()
   private val offenderSetupV2Service: OffenderSetupV2Service = mock()
+  private val questionService: QuestionService = mock()
 
   private lateinit var resource: OffenderV2Resource
 
@@ -69,6 +71,7 @@ class OffenderV2ResourceTest {
       checkinRepository,
       offenderSetupRepository,
       offenderSetupV2Service,
+      questionService,
     )
   }
 
@@ -97,6 +100,7 @@ class OffenderV2ResourceTest {
     assertEquals(HttpStatus.OK, result.statusCode)
     assertEquals(OffenderStatus.INACTIVE, result.body?.status)
     assertEquals(uuid, result.body?.uuid)
+    verify(questionService).deleteUpcomingAssignment(eq(offender.crn))
     verify(offenderRepository).save(any())
     verify(notificationV2Service).sendDeactivationCompletedNotifications(eq(offender), eq(contactDetails), isNull())
   }


### PR DESCRIPTION
Any assigned questions will most likely be out of date if the offender is reactivated.

Note: Most of the body of that resource should be pulled into the service, but that's a separate ticket.