### PR TITLE
Custom Questions: change when assignment and a check in get linked

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Repositories.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Repositories.kt
@@ -678,7 +678,6 @@ interface QuestionListAssignmentRepository : JpaRepository<QuestionListAssignmen
     """
     insert into question_list_assignment (question_list_id, offender_id, checkin_id, updated_at)
     select :listId, :offenderId, :checkinId, now()
-    where not exists (select 1 from offender_checkin_v2 where offender_id = :offenderId and status = 'CREATED'::offender_checkin_status_v2)
     on conflict (offender_id) where checkin_id is null 
     do update set
         question_list_id = :listId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/QuestionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/QuestionService.kt
@@ -9,7 +9,6 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.utils.today
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.AssignCustomQuestionsRequest
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.AssignCustomQuestionsResponse
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinV2Service
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinV2Status
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.Language
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderQuestion
@@ -84,8 +83,12 @@ class QuestionService(
 
     val listId = questionListAssignmentRepository.upcomingAssignment(offender.id)
     val today = clock.today()
+    val checkinDay = isCheckinDay(offender, today)
+    val checkinForTodayExists = if (checkinDay) checkinRepository.existsByOffenderAndDueDate(offender, today) else null
+    val nextCheckinDay = if (checkinForTodayExists == false) today else nextCheckinDay(offender, today)
+
     return UpcomingQuestionAssignmentInfo(
-      if (isCheckinDay(offender, today)) today else nextCheckinDay(offender, today),
+      nextCheckinDay,
       listId,
     )
   }
@@ -110,12 +113,6 @@ class QuestionService(
     val maybeCheckin = checkinRepository.findByOffenderAndDueDate(offender, clock.today())
     if (maybeCheckin.isEmpty && isCheckinDay(offender, clock.today())) {
       throw BadArgumentException("Offender is due for a checkin. Too late to assign questions.")
-    } else {
-      maybeCheckin.ifPresent {
-        if (it.status == CheckinV2Status.CREATED) {
-          throw BadArgumentException("Checkin already due and CREATED. Too late to assign questions.")
-        }
-      }
     }
 
     val listId = questionsRepository.upsertQuestionList(

--- a/src/main/resources/db/changelog/changesets/49_move_qs_assignment_trigger_to_insert.sql
+++ b/src/main/resources/db/changelog/changesets/49_move_qs_assignment_trigger_to_insert.sql
@@ -4,7 +4,9 @@
 
 DROP TRIGGER IF EXISTS trg_checkin_status_change ON offender_checkin_v2;
 
-CREATE OR REPLACE FUNCTION fn_update_question_assignment()
+ALTER FUNCTION fn_update_question_assignment() RENAME TO fn_update_question_assignment_on_update;
+
+CREATE OR REPLACE FUNCTION fn_update_question_assignment_on_insert()
     RETURNS TRIGGER AS $$
 BEGIN
     UPDATE question_list_assignment
@@ -20,4 +22,14 @@ CREATE TRIGGER trg_checkin_status_change
     AFTER INSERT ON offender_checkin_v2
     FOR EACH ROW
     WHEN (NEW.status = 'CREATED'::offender_checkin_status_v2)
-EXECUTE FUNCTION fn_update_question_assignment();
+EXECUTE FUNCTION fn_update_question_assignment_on_insert();
+
+--rollback:
+--rollback drop trigger if exists trg_checkin_status_change ON offender_checkin_v2;
+--rollback drop function fn_update_question_assignment_on_insert;
+--rollback ALTER FUNCTION fn_update_question_assignment_on_update() RENAME TO fn_update_question_assignment;
+--rollback CREATE TRIGGER trg_checkin_status_change
+--rollback     AFTER UPDATE ON offender_checkin_v2
+--rollback     FOR EACH ROW
+--rollback     WHEN (OLD.status = 'CREATED'::offender_checkin_status_v2 and OLD.STATUS IS DISTINCT FROM NEW.status)
+--rollback  EXECUTE FUNCTION fn_update_question_assignment();

--- a/src/main/resources/db/changelog/changesets/49_move_qs_assignment_trigger_to_insert.sql
+++ b/src/main/resources/db/changelog/changesets/49_move_qs_assignment_trigger_to_insert.sql
@@ -1,0 +1,23 @@
+--liquibase formatted sql
+
+--changeset roland.sadowski:49_move_qs_assignment_trigger_to_insert splitStatements:false
+
+DROP TRIGGER IF EXISTS trg_checkin_status_change ON offender_checkin_v2;
+
+CREATE OR REPLACE FUNCTION fn_update_question_assignment()
+    RETURNS TRIGGER AS $$
+BEGIN
+    UPDATE question_list_assignment
+    SET checkin_id = NEW.id,
+        updated_at = now()
+    WHERE offender_id = NEW.offender_id and checkin_id IS NULL;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_checkin_status_change
+    AFTER INSERT ON offender_checkin_v2
+    FOR EACH ROW
+    WHEN (NEW.status = 'CREATED'::offender_checkin_status_v2)
+EXECUTE FUNCTION fn_update_question_assignment();

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -95,3 +95,5 @@ databaseChangeLog:
       file: db/changelog/changesets/47_fix_default_question_list_order.sql
   - include:
       file: db/changelog/changesets/48_update_hint_for_customisable_questions.sql
+  - include:
+      file: db/changelog/changesets/49_move_qs_assignment_trigger_to_insert.sql

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/QuestionsIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/QuestionsIT.kt
@@ -41,6 +41,7 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.placeholders
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -158,7 +159,7 @@ class QuestionsIT : IntegrationTestBase() {
 
     val checkin = offenderCheckinService.createCheckinByCrn(CreateCheckinByCrnV2Request("BARRY.WHITE", offender.crn, clock.today()))
     val assignment = questionService.upcomingAssignment(offender.crn)
-    assertNotNull(assignment.questionList)
+    assertNull(assignment.questionList)
 
     clock.advanceBy(Duration.ofHours(4))
     offenderCheckinService.submitCheckin(checkin.uuid, SubmitCheckinV2Request(mapOf("version" to "whatever")))
@@ -223,15 +224,22 @@ class QuestionsIT : IntegrationTestBase() {
         clock.today(),
       ),
     )
-    // there's a checkin with STATUS=CREATED already
-    assertThrows(BadArgumentException::class.java) {
-      questionService.assignCustomQuestions(offender.crn, addQuestionsRequest)
-    }
+    // the assignment should have the checkin set
+    val upcoming2 = questionListAssignmentRepository.upcomingAssignment(offender.id)
+    assertNull(upcoming2, "No assignment should be present after checkin2 was submitted: $upcoming2")
+
+    // We can assign questions to the _next_ checkin now
+    val assignment3 = questionService.assignCustomQuestions(offender.crn, addQuestionsRequest)
+
+    val upcoming3 = questionService.upcomingAssignment(offender.crn)
+    assertEquals(assignment3.listId, upcoming3.questionList)
+    assertEquals(offender.firstCheckin.plus(offender.checkinInterval.toDays(), ChronoUnit.DAYS), assignment3.expectedCheckinDate)
+
     val submission2 = offenderCheckinService.submitCheckin(checkin2.uuid, SubmitCheckinV2Request(mapOf("version" to "whatever")))
 
     // the assignment should have the checkin set
     val assignment = questionListAssignmentRepository.upcomingAssignment(offender.id)
-    assertNull(assignment, "No assignment should be present after checkin1 was submitted: $assignment")
+    assertNotNull(assignment, "New assignment should be there after a submission of checkin2: $assignment")
   }
 
   @Test


### PR DESCRIPTION
The trigger creating the link now runs on INSERT not on check in status UPDATE. This means we can now create question assignments for next check in as soon as the "current" check in gets created (and not wait until it gets SUBMITTED/EXPIRED).

The `expectedCheckinDate` returned by `QuestionService.upcomingAssignment()` method, on the day a check in is due, depends on whether the check is already in the DB or not (if not, returns "today", else the next check in date according to schedule).