### PR TITLE
ESUP-1250 Use livenessEnabled rather than livenessResult

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/CheckinV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/CheckinV2Service.kt
@@ -211,7 +211,7 @@ class CheckinV2Service(
     }
 
     // Only verify video exists for non-liveness check-ins (liveness has no video)
-    if (checkin.livenessResult == null && !s3UploadService.isCheckinVideoUploaded(checkin)) {
+    if (!checkin.livenessEnabled && !s3UploadService.isCheckinVideoUploaded(checkin)) {
       throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Video not uploaded")
     }
 


### PR DESCRIPTION
Submission bug for checkins where the liveness check was skipped due to timeouts etc