### PR TITLE
ESUP-1651: add check in questions endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/StubDataProvider.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/StubDataProvider.kt
@@ -1,9 +1,13 @@
 package uk.gov.justice.digital.hmpps.esupervisionapi.utils
 
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CodedDescription
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.ContactDetails
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.Event
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.Name
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OrganizationalUnit
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.PractitionerDetails
+import java.time.LocalDate
+import java.time.ZoneId
 
 typealias CRN = String
 
@@ -76,6 +80,16 @@ class GeneratingStubDataProvider : StubDataProvider {
         provider = OrganizationalUnit(
           code = "PRV${parsed.unit.padStart(3, '0')}",
           description = "Provider ${parsed.unit}",
+        ),
+      ),
+      events = listOf(
+        Event(
+          1,
+          CodedDescription("0001", "stealing candy"),
+          Event.Sentence(
+            LocalDate.now(ZoneId.of("Europe/London")).minusWeeks(90),
+            "Sentence description here",
+          ),
         ),
       ),
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
@@ -765,3 +765,10 @@ data class UpcomingOffenderQuestions(
   val expectedCheckinDate: LocalDate,
   val questions: List<OffenderQuestion>,
 )
+
+/**
+ * Questions for a checkin. If no custom questions were assigned, returns the default list.
+ */
+data class OffenderCheckinQuestionsResponse(
+  val questions: List<OffenderQuestion>,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Repositories.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Repositories.kt
@@ -9,7 +9,6 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Component
 import org.springframework.stereotype.Repository
-import uk.gov.justice.digital.hmpps.esupervisionapi.utils.CRN
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ExternalUserId
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.OffenderStatus
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.stats.StatsProviderDto
@@ -698,17 +697,16 @@ interface QuestionListAssignmentRepository : JpaRepository<QuestionListAssignmen
   fun upcomingAssignment(offenderId: Long): Long?
 
   /**
-   * Returns question list ID of upcoming question list assignment, if any.
+   * Returns the question list id for the checkin, if any.
    */
   @Query(
     """
     select qla.question_list_id from question_list_assignment qla
-    join offender_v2 o on o.id = qla.offender_id
-    where o.crn = :crn and qla.offender_id = :offenderId and qla.checkin_id is null
+    where qla.checkin_id = :checkinId
   """,
     nativeQuery = true,
   )
-  fun upcomingAssignment(crn: CRN): Long?
+  fun checkinAssignment(checkinId: Long): Long?
 
   @Query(
     """

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/QuestionResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/QuestionResource.kt
@@ -23,9 +23,11 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.AssignCustomQuestionsRequ
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.AssignCustomQuestionsResponse
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.Language
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.ListQuestionTemplatesResponse
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinQuestionsResponse
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderQuestionList
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.UpcomingOffenderQuestions
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.UpcomingQuestionItemsResponse
+import java.util.UUID
 
 @Validated
 @RestController
@@ -94,6 +96,25 @@ class QuestionResource(
     val upcoming = questionService.upcomingQuestionListItems(crn, language)
     val upcomingQuestions = upcoming.items.map { it.evalTemplate() }
     return ResponseEntity.ok(UpcomingOffenderQuestions(upcoming.expectedCheckinDate, upcomingQuestions))
+  }
+
+  @PreAuthorize("hasRole('ROLE_ESUPERVISION__ESUPERVISION_UI')")
+  @GetMapping("/checkin/{uuid}/offender-questions")
+  @Tag(name = "offender")
+  @Operation(
+    summary = "Get checkin questions for the offender",
+    description = """
+      Assuming the checkin has not been submitted, expired or cancelled, this endpoint will always return valid questions for an offender (including the fixed questions). 
+      These are meant be used in the offender context.
+    """,
+  )
+  fun checkinQuestions(
+    @PathVariable(name = "uuid") checkinUuid: UUID,
+    @RequestParam(required = true) @Valid language: Language,
+  ): ResponseEntity<OffenderCheckinQuestionsResponse> {
+    val items = questionService.checkinQuestions(checkinUuid, language)
+    val questions = items.map { it.evalTemplate() }
+    return ResponseEntity.ok(OffenderCheckinQuestionsResponse(questions))
   }
 
   @PreAuthorize("hasRole('ROLE_ESUPERVISION__ESUPERVISION_UI')")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/QuestionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/QuestionService.kt
@@ -28,6 +28,7 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.OffenderStatus
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.exceptions.BadArgumentException
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.placeholders
 import java.time.Clock
+import java.util.UUID
 import kotlin.collections.emptyMap
 
 @Service
@@ -145,6 +146,15 @@ class QuestionService(
     val result = questionListAssignmentRepository.deleteUpcomingAssignment(offender.id)
     LOG.info("Removed upcoming question list assignment for CRN={}, result={}", crn, result)
     return result == 1
+  }
+
+  @Transactional
+  fun checkinQuestions(checkinUuid: UUID, language: Language): List<QuestionListItemDto> {
+    val checkin = checkinRepository.findByUuid(checkinUuid).orElseThrow { BadArgumentException("Checkin not found for UUID=$checkinUuid") }
+    val listId = questionListAssignmentRepository.checkinAssignment(checkin.id)
+    val items = if (listId != null) questionsRepository.getListItems(listId, language) else questionsRepository.defaultListItems(language)
+    LOG.info("checkinQuestions: returning {} items for checkin UUID={}, listId={}", items.size, checkinUuid, listId)
+    return items
   }
 
   companion object {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/QuestionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/QuestionService.kt
@@ -148,7 +148,7 @@ class QuestionService(
     return result == 1
   }
 
-  @Transactional
+  @Transactional(readOnly = true)
   fun checkinQuestions(checkinUuid: UUID, language: Language): List<QuestionListItemDto> {
     val checkin = checkinRepository.findByUuid(checkinUuid).orElseThrow { BadArgumentException("Checkin not found for UUID=$checkinUuid") }
     val listId = questionListAssignmentRepository.checkinAssignment(checkin.id)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/QuestionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/QuestionService.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.utils.today
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.AssignCustomQuestionsRequest
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.AssignCustomQuestionsResponse
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinV2Service
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinV2Status
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.Language
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderQuestion
@@ -151,6 +152,9 @@ class QuestionService(
   @Transactional(readOnly = true)
   fun checkinQuestions(checkinUuid: UUID, language: Language): List<QuestionListItemDto> {
     val checkin = checkinRepository.findByUuid(checkinUuid).orElseThrow { BadArgumentException("Checkin not found for UUID=$checkinUuid") }
+    if (checkin.status != CheckinV2Status.CREATED) {
+      throw BadArgumentException("Can't checkin questions for checkin with status ${checkin.status}")
+    }
     val listId = questionListAssignmentRepository.checkinAssignment(checkin.id)
     val items = if (listId != null) questionsRepository.getListItems(listId, language) else questionsRepository.defaultListItems(language)
     LOG.info("checkinQuestions: returning {} items for checkin UUID={}, listId={}", items.size, checkinUuid, listId)

--- a/src/main/resources/db/changelog/changesets/50_add_question_list_assignment_index.sql
+++ b/src/main/resources/db/changelog/changesets/50_add_question_list_assignment_index.sql
@@ -1,0 +1,7 @@
+--liquibase formatted sql
+
+--changeset roland.sadowski:50_add_question_list_assignment_index splitStatements:false
+
+create index "idx_assignment_checkin_id" on question_list_assignment (checkin_id);
+
+--rollback drop index if exists "idx_assignment_checkin_id";

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/QuestionsIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/QuestionsIT.kt
@@ -152,14 +152,21 @@ class QuestionsIT : IntegrationTestBase() {
     assertEquals(1, templates.size)
 
     val addQuestionsRequest = makeAssignCustomQuestionsRequest(Language.ENGLISH, templates)
-    val resp = questionService.assignCustomQuestions(offender.crn, addQuestionsRequest)
+    questionService.assignCustomQuestions(offender.crn, addQuestionsRequest)
 
     val qlitems = questionListItemRepository.findAllItems()
-    assertEquals(2 + 1, qlitems.size)
+    assertTrue(qlitems.size > 1)
 
     val checkin = offenderCheckinService.createCheckinByCrn(CreateCheckinByCrnV2Request("BARRY.WHITE", offender.crn, clock.today()))
     val assignment = questionService.upcomingAssignment(offender.crn)
-    assertNull(assignment.questionList)
+    assertNull(assignment.questionList, "*Upcoming* assignment should flip to null after a checkin is created")
+
+    val checkinEntity = offenderCheckinV2Repository.findByUuid(checkin.uuid)
+    val checkinQuestions = questionListAssignmentRepository.checkinAssignment(checkinEntity.get().id)
+    assertNotNull(checkinQuestions, "The assignment should still be visible for the checkin UI")
+
+    val checkinQuestionResponse = questionService.checkinQuestions(checkin.uuid, Language.ENGLISH)
+    assertEquals(questionRepository.defaultListItems(Language.ENGLISH).size + 1, checkinQuestionResponse.size)
 
     clock.advanceBy(Duration.ofHours(4))
     offenderCheckinService.submitCheckin(checkin.uuid, SubmitCheckinV2Request(mapOf("version" to "whatever")))


### PR DESCRIPTION
When we changed when the link between questions assignment and a check in is established from CREATED->* to check in creation, the endpoint returning upcoming offender questions could no longer be used by both MPOP and Probation Check In UI. Those two clients require that those questions are visible at slightly different times (e.g. the offender needs to see the questions until they submit a check in, while practitioners shouldn't really see/change the questions once the check in is created).

This commit adds an resource to get offender questions for a check in (note this was not possible when the link between an assignment and a check in was created on transition to SUBMITTED/EXPIRED/CANCELLED).