### PR TITLE
ESUP-1625 Update wording. Remove video link

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/ProxyLinkCreator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/ProxyLinkCreator.kt
@@ -13,7 +13,5 @@ class ProxyLinkCreator(
 
   fun checkinSnapshot(checkin: OffenderCheckinV2, index: Int = 0): URI = URI.create("${appConfig.mediaProxyUrl()}/checkin/${checkin.uuid}/snapshot?index=$index")
 
-  fun checkinVideo(checkin: OffenderCheckinV2): URI = URI.create("${appConfig.mediaProxyUrl()}/checkin/${checkin.uuid}/video")
-
   fun offenderReferencePhoto(offender: OffenderV2): URI = URI.create("${appConfig.mediaProxyUrl()}/offender/${offender.uuid}/photo")
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/EventDetailV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/EventDetailV2Service.kt
@@ -121,12 +121,12 @@ class EventDetailV2Service(
         sb.appendLine("Check in status: Submitted")
         sb.appendLine()
         checkin.autoIdCheck?.let {
-          sb.appendLine("System ID check result: ${formatAutoIdCheckResult(it.name)}")
+          val label = if (checkin.livenessEnabled) "System ID and liveness check result" else "System ID check result"
+          sb.appendLine("$label: ${formatAutoIdCheckResult(it.name)}")
         }
         if (appConfig.enabledFeatures.contains(Feature.ESUP_1239)) {
           sb.appendLine("Reference photo: ${proxyLinkCreator.offenderReferencePhoto(checkin.offender)}")
           sb.appendLine("Checkin snapshot: ${proxyLinkCreator.checkinSnapshot(checkin, 0)}")
-          sb.appendLine("Checkin video: ${proxyLinkCreator.checkinVideo(checkin)}")
         }
         checkin.surveyResponse?.let { survey ->
           sb.appendLine()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/EventDetailV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/EventDetailV2ServiceTest.kt
@@ -123,6 +123,25 @@ class EventDetailV2ServiceTest {
     }
 
     @Test
+    fun `labels automated ID check as System ID and liveness check result when liveness enabled`() {
+      val uuid = UUID.randomUUID()
+      val offender = createOffender(UUID.randomUUID())
+      val checkin = createCheckin(
+        uuid,
+        offender,
+        autoIdCheck = AutomatedIdVerificationResult.MATCH,
+        livenessEnabled = true,
+      )
+      whenever(checkinRepository.findByUuid(uuid)).thenReturn(Optional.of(checkin))
+
+      val result = service.getEventDetail("/v2/events/checkin-submitted/$uuid")
+
+      assertThat(result).isNotNull
+      assertThat(result!!.notes).contains("System ID and liveness check result: Pass")
+      assertThat(result.notes).doesNotContain("System ID check result:")
+    }
+
+    @Test
     fun `formats automated ID check NO_FACE_DETECTED`() {
       val uuid = UUID.randomUUID()
       val offender = createOffender(UUID.randomUUID())
@@ -414,6 +433,7 @@ class EventDetailV2ServiceTest {
     manualIdCheck: ManualIdVerificationResult? = null,
     surveyResponse: Map<String, Any>? = null,
     sensitive: Boolean = false,
+    livenessEnabled: Boolean = false,
   ) = OffenderCheckinV2(
     uuid = uuid,
     offender = offender,
@@ -427,5 +447,6 @@ class EventDetailV2ServiceTest {
     manualIdCheck = manualIdCheck,
     surveyResponse = surveyResponse,
     sensitive = sensitive,
+    livenessEnabled = livenessEnabled,
   )
 }


### PR DESCRIPTION
Use 'System ID and liveness check' when liveness is enabled
Remove video links as we will no longer store video regardless of liveness or not