### PR TITLE
ESUP-1635, ESUP-1660: question examples

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
@@ -662,7 +662,7 @@ data class QuestionTemplateDto(
   @field:Schema(description = "Placeholder examples to be presented in a table", required = false)
   val example: String?,
 
-  @field:Schema(description = "Fully question examples", required = false)
+  @field:Schema(description = "Question examples", required = false)
   val questionExamples: List<String>?,
 )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
@@ -659,17 +659,25 @@ data class QuestionTemplateDto(
   @field:Schema(description = "Response spec", required = true)
   val responseSpec: Map<String, Any>,
 
-  @field:Schema(description = "Example", required = false)
+  @field:Schema(description = "Placeholder examples to be presented in a table", required = false)
   val example: String?,
+
+  @field:Schema(description = "Fully question examples", required = false)
+  val questionExamples: List<String>?,
 )
 
-fun QuestionTemplateDto.placeholders(): List<String> {
-  val placeholders = this.responseSpec["placeholders"]
+/**
+ * Safely extract placeholder names (not including the "{{" or "}}" delimiters) from the response spec.
+ */
+fun questionTemplatePlaceholders(responseSpec: Map<String, Any>): List<String> {
+  val placeholders = responseSpec["placeholders"]
   if (placeholders is List<*>) {
     return placeholders.map { it.toString() }
   }
   return emptyList()
 }
+
+fun QuestionTemplateDto.placeholders(): List<String> = questionTemplatePlaceholders(responseSpec)
 
 /**
  * Specifies parameters for a choice item of a custom question item

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Repositories.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Repositories.kt
@@ -684,10 +684,17 @@ class QuestionRepository(
       try {
         var q = template
         if (replacement is Map<*, *>) {
-          val m = replacement as Map<String, String>
-          m.entries.forEach {
-            q = q.replacePlaceholder(it.key, it.value)
+          replacement.entries.forEach {
+            val key = it.key
+            val value = it.value
+            if (key is String && value is String) {
+              q = q.replacePlaceholder(key, value)
+            } else {
+              LOGGER.warn("evalExamples: Invalid replacement for questionId={}, key={}, value={}", questionId, key, value)
+            }
           }
+        } else {
+          LOGGER.warn("evalExamples: Invalid replacement for questionId={}, replacement={}", questionId, replacement)
         }
         return q
       } catch (e: Exception) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Repositories.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Repositories.kt
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Component
 import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.esupervisionapi.utils.logger
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ExternalUserId
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.OffenderStatus
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.question.replacePlaceholder
@@ -645,19 +646,20 @@ class QuestionRepository(
   private fun toQuestionTemplate(rs: ResultSet, idx: Int): QuestionTemplateDto {
     val template = rs.getString("question_template")
     val responseSpec = asMap(rs, "response_spec")
+    val questionId = rs.getLong("question_id")
 
     // We're going to safely create question examples from the template,
     // We don't want to fail here because:
     // 1. Missing/invalid example should not stop us from returning data
     // 2. We have integration tests for the SYSTEM customisable questions that verify the examples get created
     val questionExamples = responseSpec["placeholders_examples"]?.let {
-      if (it is List<*>) it as List<Any> else null
+      if (it is List<*>) it else null
     }
-      ?.map { evalExamples(template, it) }
+      ?.map { evalExample(questionId, template, it) }
       ?.filter { !it.contains("{{") }
 
     return QuestionTemplateDto(
-      id = rs.getLong("question_id"),
+      id = questionId,
       policy = QuestionPolicy.fromString(rs.getString("policy")),
       template = template,
       responseFormat = QuestionResponseFormat.fromString(rs.getString("response_format")),
@@ -667,29 +669,34 @@ class QuestionRepository(
     )
   }
 
-  private fun evalExamples(template: String, replacement: Any): String {
-    try {
-      var q = template
-      if (replacement is Map<*, *>) {
-        val m = replacement as Map<String, String>
-        m.entries.forEach {
-          q = q.replacePlaceholder(it.key, it.value)
-        }
-      }
-      return q
-    } catch (e: Exception) {
-      // This will be filtered out, we don't want to log as this may be a lot of results.
-      // We also don't want to throw here, it's not a critical failure if an example string is missing
-      return template
-    }
-  }
-
   private fun asMap(rs: ResultSet, columnName: String): Map<String, Any> {
     val content = rs.getString(columnName) ?: return emptyMap()
     return objectMapper.readValue(
       content,
       object : TypeReference<Map<String, Any>>() {},
     )
+  }
+
+  companion object {
+    val LOGGER = logger<QuestionRepository>()
+
+    private fun evalExample(questionId: Long, template: String, replacement: Any?): String {
+      try {
+        var q = template
+        if (replacement is Map<*, *>) {
+          val m = replacement as Map<String, String>
+          m.entries.forEach {
+            q = q.replacePlaceholder(it.key, it.value)
+          }
+        }
+        return q
+      } catch (e: Exception) {
+        // This will be filtered out
+        // We also don't want to throw here, it's not a critical failure if an example string is missing
+        LOGGER.warn("evalExamples: Failed to eval example for questionId={}, replacement={}: {}", questionId, replacement, e.message)
+        return template
+      }
+    }
   }
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Repositories.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Repositories.kt
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Component
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ExternalUserId
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.OffenderStatus
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.question.replacePlaceholder
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.stats.StatsProviderDto
 import java.lang.reflect.ParameterizedType
 import java.math.BigDecimal
@@ -634,31 +635,53 @@ class QuestionRepository(
     objectMapper.writeValueAsString(questions),
   )
 
-  private fun questionTemplateRowMapper(rs: ResultSet, idx: Int): QuestionTemplateDto {
-    val spec: Map<String, Any> = asMap(rs, "response_spec")
+  private fun questionTemplateRowMapper(rs: ResultSet, idx: Int): QuestionTemplateDto = toQuestionTemplate(rs, idx)
+
+  private fun listItemRowMapper(rs: ResultSet, idx: Int): QuestionListItemDto = QuestionListItemDto(
+    template = toQuestionTemplate(rs, idx),
+    params = asMap(rs, "params"),
+  )
+
+  private fun toQuestionTemplate(rs: ResultSet, idx: Int): QuestionTemplateDto {
+    val template = rs.getString("question_template")
+    val responseSpec = asMap(rs, "response_spec")
+
+    // We're going to safely create question examples from the template,
+    // We don't want to fail here because:
+    // 1. Missing/invalid example should not stop us from returning data
+    // 2. We have integration tests for the SYSTEM customisable questions that verify the examples get created
+    val questionExamples = responseSpec["placeholders_examples"]?.let {
+      if (it is List<*>) it as List<Any> else null
+    }
+      ?.map { evalExamples(template, it) }
+      ?.filter { !it.contains("{{") }
+
     return QuestionTemplateDto(
       id = rs.getLong("question_id"),
       policy = QuestionPolicy.fromString(rs.getString("policy")),
-      template = rs.getString("question_template"),
+      template = template,
       responseFormat = QuestionResponseFormat.fromString(rs.getString("response_format")),
-      responseSpec = spec,
+      responseSpec = responseSpec,
       example = rs.getString("example"),
+      questionExamples = questionExamples,
     )
   }
 
-  private fun listItemRowMapper(rs: ResultSet, idx: Int): QuestionListItemDto {
-    val template = QuestionTemplateDto(
-      id = rs.getLong("question_id"),
-      policy = QuestionPolicy.fromString(rs.getString("policy")),
-      template = rs.getString("question_template"),
-      responseFormat = QuestionResponseFormat.fromString(rs.getString("response_format")),
-      responseSpec = asMap(rs, "response_spec"),
-      example = rs.getString("example"),
-    )
-    return QuestionListItemDto(
-      template = template,
-      params = asMap(rs, "params"),
-    )
+  private fun evalExamples(template: String, replacement: Any): String {
+    try {
+      var q = template
+      if (replacement is Map<*, *>) {
+        val m = replacement as Map<String, String>
+        m.entries.forEach {
+          q = q.replacePlaceholder(it.key, it.value)
+        }
+      }
+      return q
+    } catch (e: Exception) {
+      // This will be filtered out in, we don't want to log as this may be a lot of results.
+      // We also don't want to throw here, it's not a critical failure if an example string is missing
+      return template
+    }
   }
 
   private fun asMap(rs: ResultSet, columnName: String): Map<String, Any> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Repositories.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Repositories.kt
@@ -678,7 +678,7 @@ class QuestionRepository(
       }
       return q
     } catch (e: Exception) {
-      // This will be filtered out in, we don't want to log as this may be a lot of results.
+      // This will be filtered out, we don't want to log as this may be a lot of results.
       // We also don't want to throw here, it's not a critical failure if an example string is missing
       return template
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/QuestionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/QuestionService.kt
@@ -186,4 +186,4 @@ fun QuestionListItemDto.evalTemplate(): OffenderQuestion {
   return OffenderQuestion(templateString, this.template.responseFormat, processedSpec)
 }
 
-private fun String.replacePlaceholder(placeholder: String, value: String?): String = this.replace("{{$placeholder}}", value ?: "{{$placeholder}}")
+fun String.replacePlaceholder(placeholder: String, value: String?): String = this.replace("{{$placeholder}}", value ?: "{{$placeholder}}")

--- a/src/main/resources/db/changelog/changesets/52_add_question_examples.sql
+++ b/src/main/resources/db/changelog/changesets/52_add_question_examples.sql
@@ -1,0 +1,252 @@
+--liquibase formatted sql
+
+--changeset roland.sadowski:52_add_question_examples-1 splitStatements:false
+
+CREATE OR REPLACE FUNCTION fn_update_question_spec_with_example(
+    p_question_uuid uuid,
+    p_examples jsonb
+)
+    RETURNS INT AS $$
+DECLARE
+    affected_rows INT;
+BEGIN
+    -- note: we're updating both language versions - atm we both we don't have
+    -- translations so both variants hold en-GB text
+    UPDATE question_info qi
+    SET
+        --example_placeholder = p_examples,
+        response_spec = jsonb_set(qi.response_spec, '{placeholders_examples}', p_examples->'replacements'),
+        updated_at = now()
+    FROM (SELECT id FROM question WHERE uuid = p_question_uuid) AS q
+    WHERE qi.question_id = q.id;
+
+    -- Capture the number of rows updated
+    GET DIAGNOSTICS affected_rows = ROW_COUNT;
+
+    RETURN affected_rows;
+END;
+$$ LANGUAGE plpgsql;
+
+--rollback drop function fn_update_question_spec_with_example;
+
+--changeset roland.sadowski:52_add_question_examples-2 splitStatements:false
+
+select fn_update_question_spec_with_example(
+       '35d40bed-875b-5b2e-a30c-2aa9a088e161'::uuid,
+           $${
+               "replacements": [
+                  {"thing": "your unpaid work"},
+                  {"thing": "your home life"}
+               ]
+           }$$::jsonb
+);
+
+select fn_update_question_spec_with_example(
+       '8f110f57-e18c-5576-b949-d9f60d814fad'::uuid,
+       $${
+         "replacements": [
+           {"thing": "in your relationship with your parent"},
+           {"thing": "with your health"}
+         ]
+       }$$::jsonb
+);
+
+select fn_update_question_spec_with_example(
+       'c1433bb0-a661-58f2-a01f-f459f0d835ca'::uuid,
+       $${
+         "replacements": [
+           {"thing": "your university course going"},
+           {"thing": "your application for housing going"}
+         ]
+       }$$::jsonb
+);
+
+select fn_update_question_spec_with_example(
+       '74d33d12-925b-5ce2-96ac-5ae844dd4ad4'::uuid,
+       $${
+         "replacements": [
+           {"thing": "your visit to see your family"},
+           {"thing": "your job interview"}
+         ]
+       }$$::jsonb
+);
+
+select fn_update_question_spec_with_example(
+   '24e3a3b3-80b3-5e55-b027-e53ce426a9b4'::uuid,
+   $${
+     "replacements": [
+       {"thing": "your housing situation"},
+       {"thing": "finding a new job"}
+     ]
+   }$$::jsonb
+);
+
+select fn_update_question_spec_with_example(
+       '2b042554-cb44-5da4-9bca-5090227b73ea'::uuid,
+       $${
+         "replacements": [
+           {"thing": "get an appointment with the service we referred you to since we last spoke"},
+           {"thing": "sort out a new flat"}
+         ]
+       }$$::jsonb
+);
+
+select fn_update_question_spec_with_example(
+       '9fae71ca-a03d-54e7-bf88-5e63668f70bf'::uuid,
+       $${
+         "replacements": [
+           {"thing": "your home address"},
+           {"thing": "the vehicle you drive"}
+         ]
+       }$$::jsonb
+);
+
+select fn_update_question_spec_with_example(
+       '6c69ef33-a2ec-5f27-b5ff-b66428bbca3d'::uuid,
+       $${
+         "replacements": [
+           {"thing": "homelessness prevention about your housing application"},
+           {"thing": "the doctors about your recent appointment"}
+         ]
+       }$$::jsonb
+);
+
+select fn_update_question_spec_with_example(
+       '61c5c0a7-4511-5493-82f4-8ddbb9d3a287'::uuid,
+       $${
+         "replacements": [
+           {"thing": "see your family"},
+           {"thing": "your support group"}
+         ]
+       }$$::jsonb
+);
+
+select fn_update_question_spec_with_example(
+       'ba6078cc-e540-5216-be29-511cff0c2fc8'::uuid,
+       $${
+         "replacements": [
+           {"thing": "your GP about your health issue"},
+           {"thing": "the council about your housing application"}
+         ]
+       }$$::jsonb
+);
+
+select fn_update_question_spec_with_example(
+       'efd535ba-8fad-5381-bf10-5de19ec10210'::uuid,
+       $${
+         "replacements": [
+           {"thing": "your home life"},
+           {"thing": "your health"}
+         ]
+       }$$::jsonb
+);
+
+select fn_update_question_spec_with_example(
+       '04a65bc8-4969-544f-b912-5459fdb59d3e'::uuid,
+       $${
+         "replacements": [
+           {"thing": "taking the medication you were given by your doctor"},
+           {"thing": "in a relationship with someone"}
+         ]
+       }$$::jsonb
+);
+
+select fn_update_question_spec_with_example(
+       'ad1b2ba1-fb73-5383-a0eb-e1a5d26dc3b6'::uuid,
+       $${
+         "replacements": [
+           {"thing": "your family and and home life"},
+           {"thing": "your work"}
+         ]
+       }$$::jsonb
+);
+
+select fn_update_question_spec_with_example(
+       '67785061-43bc-5a7a-a436-1914bcfb42db'::uuid,
+       $${
+         "replacements": [
+           {"thing": "you to find a new job"},
+           {"thing": "you to change your current situation at home"}
+         ]
+       }$$::jsonb
+);
+
+select fn_update_question_spec_with_example(
+       '2dd89a71-8649-58bd-bbe8-bb4d42f71393'::uuid,
+       $${
+         "replacements": [
+           {"thing": "need us to contact you about your recent appointment"},
+           {"thing": "want any support with you benefits application"}
+         ]
+       }$$::jsonb
+);
+
+select fn_update_question_spec_with_example(
+       '13f6daee-15ee-5746-afc2-65e3f147905a'::uuid,
+       $${
+         "replacements": [
+           {"thing": "your job application"},
+           {"thing": "applying for a new house"}
+         ]
+       }$$::jsonb
+);
+
+select fn_update_question_spec_with_example(
+       '8f66a1f4-9466-502a-904c-c8c881c6a10b'::uuid,
+       $${
+         "replacements": [
+           {"thing": "if we referred you to a therapy service"},
+           {"thing": "to speak to someone about your financial situation"}
+         ]
+       }$$::jsonb
+);
+
+select fn_update_question_spec_with_example(
+       'fcb3d562-f173-5b0c-9b1f-e7a5ed1960ee'::uuid,
+       $${
+         "replacements": [
+           {"thing": "get a doctor's appointment"},
+           {"thing": "fill in your housing application form"}
+         ]
+       }$$::jsonb
+);
+
+select fn_update_question_spec_with_example(
+       '7586d463-931e-58f0-9b5e-e434796ef330'::uuid,
+       $${
+         "replacements": [
+           {"thing": "college"},
+           {"thing": "at home"}
+         ]
+       }$$::jsonb
+);
+
+select fn_update_question_spec_with_example(
+       '0c2611c8-bfce-57fe-b263-6d5a5751b08a'::uuid,
+       $${
+         "replacements": [
+           {"thing": "your home life"},
+           {"thing": "your financial situation"}
+         ]
+       }$$::jsonb
+);
+
+--rollback update question_info set example_full = NULL;
+
+--changeset roland.sadowski:52_add_question_examples-3 splitStatements:false
+
+UPDATE question_info qi
+SET
+    response_spec = jsonb_set(qi.response_spec, '{alternative, label}', '"No, I do not need any support"'::jsonb),
+    updated_at = now()
+FROM (SELECT id FROM question WHERE uuid = '49639e7b-4c9d-54d4-8cdc-aa641d6d5c25'::uuid) AS q
+WHERE qi.question_id = q.id;
+
+UPDATE question_info qi
+SET
+    response_spec = jsonb_set(qi.response_spec, '{alternative, id}', '"NO_HELP"'::jsonb),
+    updated_at = now()
+FROM (SELECT id FROM question WHERE uuid = '49639e7b-4c9d-54d4-8cdc-aa641d6d5c25'::uuid) AS q
+WHERE qi.question_id = q.id;
+
+-- no rollback

--- a/src/main/resources/db/changelog/changesets/52_add_question_examples.sql
+++ b/src/main/resources/db/changelog/changesets/52_add_question_examples.sql
@@ -231,7 +231,7 @@ select fn_update_question_spec_with_example(
        }$$::jsonb
 );
 
---rollback update question_info set example_full = NULL;
+--rollback update question_info set response_spec = response_spec - 'placeholders_examples';
 
 --changeset roland.sadowski:52_add_question_examples-3 splitStatements:false
 

--- a/src/main/resources/db/changelog/changesets/52_add_question_examples.sql
+++ b/src/main/resources/db/changelog/changesets/52_add_question_examples.sql
@@ -155,7 +155,7 @@ select fn_update_question_spec_with_example(
        'ad1b2ba1-fb73-5383-a0eb-e1a5d26dc3b6'::uuid,
        $${
          "replacements": [
-           {"thing": "your family and and home life"},
+           {"thing": "your family and home life"},
            {"thing": "your work"}
          ]
        }$$::jsonb
@@ -176,7 +176,7 @@ select fn_update_question_spec_with_example(
        $${
          "replacements": [
            {"thing": "need us to contact you about your recent appointment"},
-           {"thing": "want any support with you benefits application"}
+           {"thing": "want any support with your benefits application"}
          ]
        }$$::jsonb
 );

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -101,3 +101,5 @@ databaseChangeLog:
       file: db/changelog/changesets/50_add_question_list_assignment_index.sql
   - include:
       file: db/changelog/changesets/51_question_add_uuid.sql
+  - include:
+      file: db/changelog/changesets/52_add_question_examples.sql

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/QuestionTemplateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/QuestionTemplateTest.kt
@@ -37,6 +37,7 @@ private val example = QuestionListItemDto(
     responseFormat = QuestionResponseFormat.TEXT,
     responseSpec = mapOf("placeholders" to listOf("this", "that"), "hint" to "Hint about {{this}}"),
     example = "Example of this or that",
+    questionExamples = null,
   ),
   params = mapOf("placeholders" to mapOf("this" to "this", "that" to "that")) as Map<String, Any>,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/QuestionsIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/QuestionsIT.kt
@@ -82,7 +82,8 @@ class QuestionsIT : IntegrationTestBase() {
         {
           "placeholders": ["thing"],
           "hint": "Hint for the {{thing}} question",
-          "domain_msg_head": "What did they say about the {{thing}}?"
+          "domain_msg_head": "What did they say about the {{thing}}?",
+          "placeholders_examples": [ {"thing": "School"}, {"thing": "Work"} ] 
         }
       """.trimIndent(),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/ValidatorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/ValidatorTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.esupervisionapi.v2.question
 
 import jakarta.validation.Validator
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -114,6 +115,11 @@ class ValidatorTest : IntegrationTestBase() {
       assertTrue(
         result.isValid,
         "Question id=${templates[i].id} failed validation: ${result.message}",
+      )
+      assertEquals(
+        2,
+        templates[i].questionExamples?.size,
+        "Each SYSTEM custom question should have 2 examples, but found: ${templates[i].questionExamples}",
       )
     }
   }


### PR DESCRIPTION
Adds question examples to returned question templates.

We don't store the examples in full - only the placeholders and do the substitution in the row mapper. The example template values are stored in the `responseSpec` JSONB blob.

Also, small content update for the fixed question (ESUP-1660).