### PR TITLE
ESUP-1262 Add and adjust sensitive flags

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/CheckinV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/CheckinV2Service.kt
@@ -336,6 +336,7 @@ class CheckinV2Service(
     offenderEventLogRepository.save(
       OffenderEventLogV2(
         comment = reviewInfo.comment,
+        sensitive = request.sensitive,
         createdAt = clock.instant(),
         logEntryType = reviewInfo.logEntryType,
         practitioner = request.reviewedBy,
@@ -392,10 +393,11 @@ class CheckinV2Service(
     val annotation = offenderEventLogRepository.save(
       OffenderEventLogV2(
         comment = request.notes,
+        sensitive = request.sensitive == true,
         createdAt = clock.instant(),
         logEntryType = LogEntryType.OFFENDER_CHECKIN_ANNOTATED,
         practitioner = request.updatedBy,
-        UUID.randomUUID(),
+        uuid = UUID.randomUUID(),
         offender = checkin.offender,
         checkin = checkin.id,
       ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/CheckinV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/CheckinV2Service.kt
@@ -393,7 +393,7 @@ class CheckinV2Service(
     val annotation = offenderEventLogRepository.save(
       OffenderEventLogV2(
         comment = request.notes,
-        sensitive = request.sensitive == true,
+        sensitive = request.sensitive,
         createdAt = clock.instant(),
         logEntryType = LogEntryType.OFFENDER_CHECKIN_ANNOTATED,
         practitioner = request.updatedBy,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
@@ -415,6 +415,7 @@ data class ReviewCheckinV2Request(
   @Schema(description = "Risk management feedback", required = false)
   val riskManagementFeedback: Boolean? = null,
   @Schema(description = "Whether the review contains sensitive information", required = false)
+  @JsonDeserialize(using = StrictBooleanDeserializer::class)
   val sensitive: Boolean = false,
 )
 
@@ -434,6 +435,7 @@ data class AnnotateCheckinV2Request(
   @field:NotBlank
   val notes: String,
   @Schema(description = "Whether the annotation contains sensitive information", required = false)
+  @JsonDeserialize(using = StrictBooleanDeserializer::class)
   val sensitive: Boolean = false,
 )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Entities.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Entities.kt
@@ -418,6 +418,9 @@ open class EventAuditV2(
 
   @Column(name = "notes", nullable = true, columnDefinition = "TEXT")
   open var notes: String? = null,
+
+  @Column(name = "sensitive", nullable = false)
+  open val sensitive: Boolean = false,
 ) : V2BaseEntity()
 
 /**
@@ -458,6 +461,9 @@ open class JobLogV2(
 open class OffenderEventLogV2(
   @Column(name = "comment", nullable = true)
   open var comment: String,
+
+  @Column(name = "sensitive", nullable = false)
+  open var sensitive: Boolean = false,
 
   @Column(name = "created_at", nullable = true)
   open var createdAt: Instant,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/audit/EventAuditV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/audit/EventAuditV2Service.kt
@@ -134,6 +134,7 @@ class EventAuditV2Service(
         reviewDurationHours = reviewDurationHours,
         manualIdCheckResult = checkin.manualIdCheck?.name,
         notes = notes,
+        sensitive = checkin.sensitive,
       )
 
       transactionTemplate.execute { auditRepository.save(audit) }
@@ -213,7 +214,7 @@ class EventAuditV2Service(
     }
   }
 
-  private fun recordOffenderStatusEvent(eventType: String, offender: OffenderV2, contactDetails: ContactDetails, notes: String) {
+  private fun recordOffenderStatusEvent(eventType: String, offender: OffenderV2, contactDetails: ContactDetails, notes: String, sensitive: Boolean = false) {
     assert(eventType in listOf("OFFENDER_VERIFIED", "OFFENDER_UNVERIFIED"))
     try {
       val audit = buildAudit(
@@ -221,6 +222,7 @@ class EventAuditV2Service(
         offender,
         contactDetails,
         notes = notes,
+        sensitive = sensitive,
       )
       transactionTemplate.execute { auditRepository.save(audit) }
     } catch (e: Exception) {
@@ -228,8 +230,8 @@ class EventAuditV2Service(
     }
   }
 
-  fun recordOffenderDeactivated(offender: OffenderV2, contactDetails: ContactDetails, notes: String) {
-    recordOffenderStatusEvent("OFFENDER_DEACTIVATED", offender, contactDetails, notes)
+  fun recordOffenderDeactivated(offender: OffenderV2, contactDetails: ContactDetails, notes: String, sensitive: Boolean = false) {
+    recordOffenderStatusEvent("OFFENDER_DEACTIVATED", offender, contactDetails, notes, sensitive)
   }
 
   fun recordOffenderReactivated(offender: OffenderV2, contactDetails: ContactDetails, notes: String) {
@@ -248,6 +250,7 @@ class EventAuditV2Service(
     livenessResult: String? = null,
     manualIdCheckResult: String? = null,
     notes: String? = null,
+    sensitive: Boolean = false,
   ): EventAuditV2 = EventAuditV2(
     eventType = eventType,
     occurredAt = clock.instant(),
@@ -269,6 +272,7 @@ class EventAuditV2Service(
     livenessResult = livenessResult,
     manualIdCheckResult = manualIdCheckResult,
     notes = notes,
+    sensitive = sensitive,
   )
 
   companion object {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/serialization/StrictBooleanDeserializer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/serialization/StrictBooleanDeserializer.kt
@@ -2,25 +2,16 @@ import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.core.JsonToken
 import com.fasterxml.jackson.databind.DeserializationContext
 import com.fasterxml.jackson.databind.JsonDeserializer
-import com.fasterxml.jackson.databind.exc.InvalidFormatException
 
 class StrictBooleanDeserializer : JsonDeserializer<Boolean>() {
+
   override fun deserialize(p: JsonParser, ctxt: DeserializationContext): Boolean {
     val token = p.currentToken
 
     if (token == JsonToken.VALUE_TRUE) return true
     if (token == JsonToken.VALUE_FALSE) return false
-    throw InvalidFormatException(
-      p,
-      "Strict boolean parsing failed. Expected literal true or false, but got: ${p.text}",
-      p.text,
-      Boolean::class.java,
-    )
+    throw RuntimeException("Expected strict boolean (true/false), but got invalid value")
   }
-  override fun getNullValue(ctxt: DeserializationContext): Boolean = throw InvalidFormatException(
-    ctxt.parser,
-    "The 'sensitive' field cannot be null. It must be strictly a boolean (true or false).",
-    null,
-    Boolean::class.java,
-  )
+
+  override fun getNullValue(ctxt: DeserializationContext): Boolean = throw RuntimeException("Expected strict boolean (true/false), but got null")
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/serialization/StrictBooleanDeserializer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/serialization/StrictBooleanDeserializer.kt
@@ -1,0 +1,26 @@
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.core.JsonToken
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.exc.InvalidFormatException
+
+class StrictBooleanDeserializer : JsonDeserializer<Boolean>() {
+  override fun deserialize(p: JsonParser, ctxt: DeserializationContext): Boolean {
+    val token = p.currentToken
+
+    if (token == JsonToken.VALUE_TRUE) return true
+    if (token == JsonToken.VALUE_FALSE) return false
+    throw InvalidFormatException(
+      p,
+      "Strict boolean parsing failed. Expected literal true or false, but got: ${p.text}",
+      p.text,
+      Boolean::class.java,
+    )
+  }
+  override fun getNullValue(ctxt: DeserializationContext): Boolean = throw InvalidFormatException(
+    ctxt.parser,
+    "The 'sensitive' field cannot be null. It must be strictly a boolean (true or false).",
+    null,
+    Boolean::class.java,
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderV2Resource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderV2Resource.kt
@@ -218,16 +218,17 @@ class OffenderV2Resource(
       LOGGER.info("Cancelled ${pendingCheckins.size} created/pending check ins for CRN ${saved.crn} due to offender deactivation")
     }
 
-    recordOffenderAuditEvent("OFFENDER_DEACTIVATED", offender, request.reason)
+    recordOffenderAuditEvent("OFFENDER_DEACTIVATED", offender, request.reason, request.sensitive)
 
     val photoUrl = getOffenderPhotoUrl(saved)
 
     LOGGER.info(
-      "Deactivated offender: uuid={}, crn={}, requestedBy={}, reason={}",
+      "Deactivated offender: uuid={}, crn={}, requestedBy={}, reason={}, sensitive={}",
       uuid,
       offender.crn,
       request.requestedBy,
       request.reason,
+      request.sensitive,
     )
 
     val setup = offenderSetupRepository.findByOffender(offender).orElse(null)
@@ -388,7 +389,7 @@ class OffenderV2Resource(
     }
   }
 
-  private fun recordOffenderAuditEvent(eventType: String, offender: OffenderV2, reason: String) {
+  private fun recordOffenderAuditEvent(eventType: String, offender: OffenderV2, reason: String, sensitive: Boolean = false) {
     assert(eventType in listOf("OFFENDER_DEACTIVATED", "OFFENDER_REACTIVATED"))
     var contactDetails: ContactDetails? = null
     try {
@@ -398,7 +399,7 @@ class OffenderV2Resource(
       LOGGER.info("Failed to get contact details for offender ${offender.crn} from NDelius. Using missing details instead.")
     }
     when (eventType) {
-      "OFFENDER_DEACTIVATED" -> eventAuditService.recordOffenderDeactivated(offender, contactDetails ?: missingDetails(offender.crn), reason)
+      "OFFENDER_DEACTIVATED" -> eventAuditService.recordOffenderDeactivated(offender, contactDetails ?: missingDetails(offender.crn), reason, sensitive)
       "OFFENDER_REACTIVATED" -> eventAuditService.recordOffenderReactivated(offender, contactDetails ?: missingDetails(offender.crn), reason)
     }
   }
@@ -455,6 +456,9 @@ data class DeactivateOffenderRequest(
   @Schema(description = "Reason for deactivation", required = true)
   @field:NotBlank
   val reason: String,
+
+  @Schema(description = "Whether the deactivation reason contains sensitive information", required = false)
+  val sensitive: Boolean = false,
 )
 
 /** Request to reactivate an offender */

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderV2Resource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderV2Resource.kt
@@ -457,6 +457,7 @@ data class DeactivateOffenderRequest(
   @field:NotBlank
   val reason: String,
 
+  @JsonDeserialize(using = StrictBooleanDeserializer::class)
   @Schema(description = "Whether the deactivation reason contains sensitive information", required = false)
   val sensitive: Boolean = false,
 )

--- a/src/main/resources/db/changelog/changesets/53_add_sensitive_flags.sql
+++ b/src/main/resources/db/changelog/changesets/53_add_sensitive_flags.sql
@@ -1,0 +1,11 @@
+--liquibase formatted sql
+
+--changeset Maddie-Williams:53_add_sensitive_flags
+ALTER TABLE event_audit_log_v2 
+    ADD COLUMN sensitive BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE offender_event_log_v2 
+    ADD COLUMN sensitive BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- rollback ALTER TABLE event_audit_log_v2 DROP COLUMN sensitive;
+-- rollback ALTER TABLE offender_event_log_v2 DROP COLUMN sensitive;

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -103,3 +103,5 @@ databaseChangeLog:
       file: db/changelog/changesets/51_question_add_uuid.sql
   - include:
       file: db/changelog/changesets/52_add_question_examples.sql
+  - include:
+      file: db/changelog/changesets/53_add_sensitive_flags.sql

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/CheckinV2ServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/CheckinV2ServiceIntegrationTest.kt
@@ -101,6 +101,7 @@ class CheckinV2ServiceIntegrationTest : IntegrationTestBase() {
     offenderEventLogV2Repository.save(
       OffenderEventLogV2(
         "he forgot",
+        sensitive = false,
         Instant.now(),
         logEntryType = LogEntryType.OFFENDER_CHECKIN_NOT_SUBMITTED,
         practitioner = offender.practitionerId,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/CheckinV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/CheckinV2ServiceTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNull
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -385,6 +386,11 @@ class CheckinV2ServiceTest {
     assertEquals(true, checkin.sensitive)
     assertEquals(true, result.sensitive)
     verify(checkinRepository).save(checkin)
+    verify(offenderEventLogRepository).save(
+      argThat {
+        sensitive == true && comment == "Contains private health info"
+      },
+    )
   }
 
   @Test
@@ -415,6 +421,11 @@ class CheckinV2ServiceTest {
     assertEquals(false, checkin.sensitive)
     assertEquals(false, result.sensitive)
     verify(checkinRepository).save(checkin)
+    verify(offenderEventLogRepository).save(
+      argThat {
+        sensitive == false && comment == "Test note"
+      },
+    )
   }
 
   @Test
@@ -446,6 +457,12 @@ class CheckinV2ServiceTest {
     assertEquals(true, checkin.sensitive)
     assertEquals(true, result.sensitive)
     verify(checkinRepository).save(checkin)
+
+    verify(offenderEventLogRepository).save(
+      argThat {
+        sensitive == true && comment == "Added sensitive medical evidence"
+      },
+    )
   }
 
   @Test
@@ -476,6 +493,12 @@ class CheckinV2ServiceTest {
     assertEquals(false, checkin.sensitive)
     assertEquals(false, result.sensitive)
     verify(checkinRepository, never()).save(checkin)
+
+    verify(offenderEventLogRepository).save(
+      argThat {
+        sensitive == false && comment == "Test notes"
+      },
+    )
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderV2ResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderV2ResourceTest.kt
@@ -227,6 +227,66 @@ class OffenderV2ResourceTest {
     verify(offenderRepository).save(offender)
   }
 
+  @Test
+  fun `deactivateOffender - happy path - passes sensitive flag as TRUE to audit service`() {
+    val uuid = UUID.randomUUID()
+    val offender = createOffender(uuid, OffenderStatus.VERIFIED)
+    val request = DeactivateOffenderRequest(
+      requestedBy = "PRACT001",
+      reason = "Safety concerns disclosed",
+      sensitive = true,
+    )
+    val contactDetails = uk.gov.justice.digital.hmpps.esupervisionapi.v2.ContactDetails(
+      crn = offender.crn,
+      mobile = "07700900123",
+      name = uk.gov.justice.digital.hmpps.esupervisionapi.v2.Name("John", "Doe"),
+    )
+
+    whenever(offenderRepository.findByUuid(uuid)).thenReturn(Optional.of(offender))
+    whenever(offenderRepository.save(any())).thenAnswer { it.getArgument(0) }
+    whenever(ndiliusApiClient.getContactDetails(offender.crn)).thenReturn(contactDetails)
+
+    val result = resource.deactivateOffender(uuid, request)
+
+    assertEquals(HttpStatus.OK, result.statusCode)
+
+    verify(eventAuditV2Service).recordOffenderDeactivated(
+      eq(offender),
+      eq(contactDetails),
+      eq("Safety concerns disclosed"),
+      eq(true),
+    )
+  }
+
+  @Test
+  fun `deactivateOffender - happy path - passes sensitive flag as FALSE to audit service`() {
+    val uuid = UUID.randomUUID()
+    val offender = createOffender(uuid, OffenderStatus.VERIFIED)
+    val request = DeactivateOffenderRequest(
+      requestedBy = "PRACT001",
+      reason = "Standard deactivation",
+      sensitive = false,
+    )
+    val contactDetails = uk.gov.justice.digital.hmpps.esupervisionapi.v2.ContactDetails(
+      crn = offender.crn,
+      mobile = "07700900123",
+      name = uk.gov.justice.digital.hmpps.esupervisionapi.v2.Name("John", "Doe"),
+    )
+
+    whenever(offenderRepository.findByUuid(uuid)).thenReturn(Optional.of(offender))
+    whenever(offenderRepository.save(any())).thenAnswer { it.getArgument(0) }
+    whenever(ndiliusApiClient.getContactDetails(offender.crn)).thenReturn(contactDetails)
+
+    resource.deactivateOffender(uuid, request)
+
+    verify(eventAuditV2Service).recordOffenderDeactivated(
+      eq(offender),
+      eq(contactDetails),
+      eq("Standard deactivation"),
+      eq(false),
+    )
+  }
+
   // ========================================
   // Reactivate Tests
   // ========================================


### PR DESCRIPTION
[ESUP-1262](https://dsdmoj.atlassian.net/browse/ESUP-1262)


This PR adds the sensitive flag property to the deactivate offender request, so that we can capture when the reason given for the deactivation is marked as sensitive where appropriate. This gets saved to the `event_audit_log_v2` table, where we have added a new boolean column `sensitive`.

Updated CheckinV2Service so that when a practitioner marks a note as sensitive during the review or annotate process, that flag is now saved directly to the specific entry  to `offender_event_log_v2` table (and not just the check in table as it was before). To do this I've also added a new boolean column `sensitive` to this table too. Additionally, as the review already gets saved to the `event_audit_log_v2`, we include the sensitive flag value in that new sensitive column mentioned above.

Based on QA feedback in the previous sensitive API ticket, it also addresses an issue for the sensitive property where the API was accepting and converting invalid data types (like 123, "true", or explicit nulls) into booleans. To make it stricter, this introduces a `StrictBooleanDeserializer` which intercepts incoming JSON and throws a exception if the value is not a literal boolean. This has been applied wherever the sensitive flag is expected in a  request.

[ESUP-1262]: https://dsdmoj.atlassian.net/browse/ESUP-1262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ