### PR TITLE
ESUP-1689: simplify survey details formatting

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/App.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/App.kt
@@ -1,10 +1,12 @@
 package uk.gov.justice.digital.hmpps.esupervisionapi
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.runApplication
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
 import org.springframework.scheduling.annotation.EnableScheduling
+import uk.gov.justice.digital.hmpps.esupervisionapi.config.SurveyValueExpansionsConfig
 import java.time.Clock
 import java.time.ZoneId
 
@@ -13,6 +15,7 @@ private val defaultTimeZone = ZoneId.of(System.getenv("TZ") ?: "Europe/London")
 @EnableCaching
 @SpringBootApplication
 @EnableScheduling
+@EnableConfigurationProperties(SurveyValueExpansionsConfig::class)
 class EsupervisionApp {
   @Bean fun clock(): Clock = Clock.system(defaultTimeZone)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/SurveyValueExpansionsConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/SurveyValueExpansionsConfig.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * Configuration options influencing how the offender survey values are displayed.
+ */
+@ConfigurationProperties(prefix = "app.offender-survey")
+class SurveyValueExpansionsConfig(
+  /**
+   * Maps values coming from a web form into a human-friendly string, which
+   * will be used in an NDelius note.
+   *
+   * Example: SUPPORT_SYSTEM -> Relationships (family, friends, partner)
+   */
+  val expansions: Map<String, String> = mapOf(),
+
+  /**
+   * Maps values coming from a web form into a human-friendly string, which
+   * will be used as a label in an NDelius note.
+   *
+   * Example: mentalHealthSupport -> "What they want us to know about mental health"
+   */
+  val customLabels: Map<String, String> = mapOf(),
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/EventDetailV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/EventDetailV2Service.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.esupervisionapi.v2
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.esupervisionapi.config.AppConfig
 import uk.gov.justice.digital.hmpps.esupervisionapi.config.Feature
+import uk.gov.justice.digital.hmpps.esupervisionapi.config.SurveyValueExpansionsConfig
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.ProxyLinkCreator
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.logger
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.checkin.appendQuestionsAndAnswers
@@ -22,6 +23,7 @@ class EventDetailV2Service(
   private val eventLogRepository: OffenderEventLogV2Repository,
   private val proxyLinkCreator: ProxyLinkCreator,
   private val appConfig: AppConfig,
+  val expansionsConfig: SurveyValueExpansionsConfig,
 ) {
 
   fun getEventDetail(detailUrl: String): EventDetailResponse? {
@@ -137,7 +139,7 @@ class EventDetailV2Service(
         }
         checkin.surveyResponse?.let { survey ->
           sb.appendLine()
-          sb.appendQuestionsAndAnswers(survey)
+          sb.appendQuestionsAndAnswers(survey, expansionsConfig)
         }
       }
       DomainEventType.V2_CHECKIN_REVIEWED -> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/SurveyDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/SurveyDetails.kt
@@ -50,7 +50,7 @@ private fun formatSurveyResponseHumanReadable(survey: Map<String, Any>, surveyCo
     val formattedValueNew: List<String> = when (surveyValue) {
       is String -> listOf(surveyValue)
       is Boolean -> listOf(if (surveyValue) "YES" else "NO")
-      is Number -> listOf(value)
+      is Number -> listOf(surveyValue.toString())
       is List<*> -> surveyValue.filter { it is String && it.isNotBlank() }.map { it as String }
       else -> listOf(surveyValue.toString())
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/SurveyDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/SurveyDetails.kt
@@ -1,19 +1,20 @@
 package uk.gov.justice.digital.hmpps.esupervisionapi.v2.checkin
 
+import uk.gov.justice.digital.hmpps.esupervisionapi.config.SurveyValueExpansionsConfig
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.SurveyVersion
 
 /**
  * See [formatSurvey]
  */
-fun StringBuilder.appendQuestionsAndAnswers(survey: Map<String, Any>): StringBuilder = formatSurvey(survey, this)
+fun StringBuilder.appendQuestionsAndAnswers(survey: Map<String, Any>, surveyConfig: SurveyValueExpansionsConfig?): StringBuilder = formatSurvey(survey, this, surveyConfig)
 
 /**
  * Formats the offender's response to a survey into a human-readable string
  * that will be displayed as a note in NDelius.
  */
-fun formatSurvey(survey: Map<String, Any>, sb: StringBuilder): StringBuilder {
+fun formatSurvey(survey: Map<String, Any>, sb: StringBuilder, surveyConfig: SurveyValueExpansionsConfig?): StringBuilder {
   sb.appendLine("Check in answers:")
-  formatSurveyResponseHumanReadable(survey).forEach {
+  formatSurveyResponseHumanReadable(survey, surveyConfig).forEach {
     sb.appendLine(it)
     sb.appendLine()
   }
@@ -36,139 +37,35 @@ fun formatSurvey(survey: Map<String, Any>, sb: StringBuilder): StringBuilder {
   return sb
 }
 
-private fun formatSurveyResponseHumanReadable(survey: Map<String, Any>): List<String> {
+private fun formatSurveyResponseHumanReadable(survey: Map<String, Any>, surveyConfig: SurveyValueExpansionsConfig?): List<String> {
   val lines = mutableListOf<String>()
-
-  // Custom labels for known fields
-  val customLabels = mapOf(
-    "mentalHealth" to "How they have been feeling",
-    "mentalHealthComment" to "What they want us to know about how they have been feeling",
-    "assistance" to "Anything they need support with or to let us know",
-    "mentalHealthSupport" to "What they want us to know about mental health",
-    "alcoholSupport" to "What they want us to know about alcohol",
-    "drugsSupport" to "What they want us to know about drugs",
-    "moneySupport" to "What they want us to know about money",
-    "housingSupport" to "What they want us to know about housing",
-    "employmentEduSupport" to "What they want us to know about employment and education",
-    "supportSystemSupport" to "What they want us to know about their relationships",
-    "otherSupport" to "What they want us to know about (something else)",
-    "callback" to "If they need us to contact them before their next appointment",
-    "callbackDetails" to "What they want to talk about",
-  )
-
+  val formValuesExpansions = surveyConfig?.expansions ?: emptyMap()
+  val customLabels = surveyConfig?.customLabels ?: emptyMap()
   for ((key, value) in customLabels) {
-    val surveyValue = survey[key]
+    val surveyValue = survey[key] ?: continue
 
-    // Skip null or empty values
-    if (surveyValue == null) continue
     if (surveyValue is String && surveyValue.isBlank()) continue
     if (surveyValue is List<*> && surveyValue.isEmpty()) continue
-    if (surveyValue is Map<*, *> && surveyValue.isEmpty()) continue
 
-    // Format the value based on its type
-    val formattedValue = formatValue(surveyValue)
+    val formattedValueNew: List<String> = when (surveyValue) {
+      is String -> listOf(surveyValue)
+      is Boolean -> listOf(if (surveyValue) "YES" else "NO")
+      is Number -> listOf(value)
+      is List<*> -> surveyValue.filter { it is String && it.isNotBlank() }.map { it as String }
+      else -> listOf(surveyValue.toString())
+    }
+    if (formattedValueNew.isEmpty()) continue
+    val formatted = formattedValueNew.map { formValuesExpansions.getOrElse(it) { maybePrettifySnakeCase(it) } }
 
-    // Skip if formatted value is empty
-    if (formattedValue.isBlank()) continue
-
-    lines.add("$value: $formattedValue")
+    lines.add("$value: ${formatted.joinToString(", ")}")
   }
 
   return lines
 }
 
-@Suppress("UNCHECKED_CAST")
-private fun formatValue(value: Any?, indent: Int = 0): String {
-  if (value == null) return ""
+private fun maybePrettifySnakeCase(value: String): String = if (value == value.uppercase()) prettifySnakeCase(value) else value
 
-  return when (value) {
-    is String -> formatStringValue(value)
-    is Boolean -> if (value) "Yes" else "No"
-    is Number -> value.toString()
-    is List<*> -> formatListValue(value, indent)
-    is Map<*, *> -> formatMapValue(value as Map<String, Any>, indent)
-    else -> value.toString()
-  }
-}
-
-/**
- * Format string values - convert enums and special values to readable text
- */
-private fun formatStringValue(value: String): String {
-  if (value.isBlank()) return ""
-
-  // Common enum patterns to human-readable
-  return when {
-    // Yes/No values
-    value.equals("YES", ignoreCase = true) -> "Yes"
-    value.equals("NO", ignoreCase = true) -> "No"
-    // NO_HELP special case
-    value == "NO_HELP" -> "No, I don't need any support"
-    // SCREAMING_SNAKE_CASE to Title Case
-    value == value.uppercase() -> {
-      value.lowercase().split("_").joinToString(" ") { word ->
-        word.replaceFirstChar { it.uppercase() }
-      }
-    }
-    // Already readable
-    else -> value
-  }
-}
-
-/**
- * Format list values
- */
-private fun formatListValue(list: List<*>, indent: Int): String {
-  val filteredList = list.filterNotNull()
-    .map { formatValue(it, indent) }
-    .filter { it.isNotBlank() && it != "No help" }
-
-  if (filteredList.isEmpty()) return ""
-  if (filteredList.size == 1) return filteredList.first()
-
-  return filteredList.joinToString(", ")
-}
-
-/**
- * Format map/object values as key: value pairs
- */
-private fun formatMapValue(map: Map<String, Any>, indent: Int): String {
-  if (map.isEmpty()) return ""
-
-  val indentStr = "  ".repeat(indent + 1)
-  val entries = map.entries
-    .filter { (_, v) -> v != null }
-    .mapNotNull { (k, v) ->
-      val formattedValue = formatValue(v, indent + 1)
-      if (formattedValue.isBlank()) {
-        null
-      } else {
-        "$indentStr${camelCaseToHumanReadable(k)}: $formattedValue"
-      }
-    }
-
-  if (entries.isEmpty()) return ""
-
-  return "\n" + entries.joinToString("\n")
-}
-
-/**
- * Convert camelCase to Human Readable
- * e.g., "mentalHealthSupport" -> "Mental health support"
- */
-private fun camelCaseToHumanReadable(camelCase: String): String {
-  if (camelCase.isBlank()) return ""
-
-  val result = StringBuilder()
-  for ((index, char) in camelCase.withIndex()) {
-    if (char.isUpperCase() && index > 0) {
-      result.append(' ')
-      result.append(char.lowercase())
-    } else if (index == 0) {
-      result.append(char.uppercase())
-    } else {
-      result.append(char)
-    }
-  }
-  return result.toString()
-}
+private fun prettifySnakeCase(value: String): String = value
+  .lowercase()
+  .split("_")
+  .joinToString(" ") { word -> word.replaceFirstChar { it.uppercase() } }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,6 +53,28 @@ app:
     esup-1239: true
     # ensure a POP is still on probation before sending them a check in link
     esup-1183: true
+  offender-survey:
+    # expand form values into human-readable strings in NDelius notes
+    expansions:
+      YES: "Yes"
+      NO: "No"
+      EMPLOYMENT_EDU: "Employment and education"
+      SUPPORT_SYSTEM: "Relationships (family, friends, partner)"
+      NO_HELP: "No, I don't need any support"
+    custom-labels:
+      mentalHealth: "How they have been feeling"
+      mentalHealthComment: "What they want us to know about how they have been feeling"
+      assistance: "Anything they need support with or to let us know"
+      mentalHealthSupport: "What they want us to know about mental health"
+      alcoholSupport: "What they want us to know about alcohol"
+      drugsSupport: "What they want us to know about drugs"
+      moneySupport: "What they want us to know about money"
+      housingSupport: "What they want us to know about housing"
+      employmentEduSupport: "What they want us to know about employment and education"
+      supportSystemSupport: "What they want us to know about their relationships"
+      otherSupport: "What they want us to know about (something else)"
+      callback: "If they need us to contact them before their next appointment"
+      callbackDetails: "What they want to talk about"
 
 spring:
   application:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -60,7 +60,7 @@ app:
       NO: "No"
       EMPLOYMENT_EDU: "Employment and education"
       SUPPORT_SYSTEM: "Relationships (family, friends, partner)"
-      NO_HELP: "No, I don't need any support"
+      NO_HELP: "No, I do not need any support"
     custom-labels:
       mentalHealth: "How they have been feeling"
       mentalHealthComment: "What they want us to know about how they have been feeling"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/EventDetailV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/EventDetailV2ServiceTest.kt
@@ -26,7 +26,15 @@ class EventDetailV2ServiceTest {
   private val eventLogRepository: OffenderEventLogV2Repository = mock()
   private val proxyLinkCreator: ProxyLinkCreator = mock()
   private val appConfig: AppConfig = mock()
-  private val surveyExpansionsConfig: SurveyValueExpansionsConfig = mock()
+  private val surveyExpansionsConfig: SurveyValueExpansionsConfig = SurveyValueExpansionsConfig(
+    mapOf(),
+    mapOf(
+      "mentalHealth" to "How they have been feeling",
+      "callback" to "If they need us to contact them before their next appointment",
+      "callbackDetails" to "What they want to talk about",
+      "assistance" to "Anything they need support with or to let us know",
+    ),
+  )
 
   private lateinit var service: EventDetailV2Service
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/EventDetailV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/EventDetailV2ServiceTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.esupervisionapi.config.AppConfig
+import uk.gov.justice.digital.hmpps.esupervisionapi.config.SurveyValueExpansionsConfig
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.ProxyLinkCreator
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.AutomatedIdVerificationResult
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.CheckinInterval
@@ -25,12 +26,13 @@ class EventDetailV2ServiceTest {
   private val eventLogRepository: OffenderEventLogV2Repository = mock()
   private val proxyLinkCreator: ProxyLinkCreator = mock()
   private val appConfig: AppConfig = mock()
+  private val surveyExpansionsConfig: SurveyValueExpansionsConfig = mock()
 
   private lateinit var service: EventDetailV2Service
 
   @BeforeEach
   fun setUp() {
-    service = EventDetailV2Service(checkinRepository, eventLogRepository, proxyLinkCreator, appConfig)
+    service = EventDetailV2Service(checkinRepository, eventLogRepository, proxyLinkCreator, appConfig, surveyExpansionsConfig)
   }
 
   @Nested

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/SurveyDetailsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/SurveyDetailsTest.kt
@@ -3,9 +3,24 @@ package uk.gov.justice.digital.hmpps.esupervisionapi.v2.checkin
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.esupervisionapi.config.SurveyValueExpansionsConfig
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.SurveyVersion
 
 class SurveyDetailsTest {
+
+  val surveyConfig = SurveyValueExpansionsConfig(
+    mapOf(
+      "WELL" to "Very well",
+      "NOT_WELL" to "Not well",
+      "NO_HELP" to "No help",
+      "HELP" to "Help",
+      "NOT_SURE" to "Not sure",
+    ),
+    mapOf(
+      "mentalHealth" to "What they want us to know about mental health",
+      "housingSupport" to "What they want us to know about housing",
+    ),
+  )
 
   @Test
   fun `render survey with custom questions`() {
@@ -19,14 +34,16 @@ class SurveyDetailsTest {
       ),
     )
 
-    val result = formatSurvey(survey, StringBuilder()).toString()
+    val result = formatSurvey(survey, StringBuilder(), surveyConfig).toString()
+    assertTrue(result.contains("What they want us to know about mental health: Very well"))
+    assertTrue(result.contains("What they want us to know about housing: No help"))
     assertTrue(result.contains("What is your favourite colour?: Blue"))
     assertTrue(result.contains("What is your favourite animal?: Dog"))
   }
 
   @Test
   fun `render survey with no custom questions`() {
-    val result = formatSurvey(exampleSurvey, StringBuilder()).toString()
+    val result = formatSurvey(exampleSurvey, StringBuilder(), surveyConfig).toString()
     assertFalse(result.contains("Custom questions"))
   }
 
@@ -37,7 +54,7 @@ class SurveyDetailsTest {
     survey["customQuestions"] = listOf(
       mapOf("question" to "What is your favourite colour?", "response" to "Blue"),
     )
-    val result = formatSurvey(survey, StringBuilder()).toString()
+    val result = formatSurvey(survey, StringBuilder(), surveyConfig).toString()
     assertFalse(result.contains("Blue"))
   }
 }


### PR DESCRIPTION
Removes most of the convoluted formatting code (e.g. formatting arbitrarily nested maps, which we don't actually have a use case for...) and moves the custom labels to a configuration file.