### PR TITLE
update "next check-in" logic

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Repositories.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Repositories.kt
@@ -710,6 +710,11 @@ class QuestionRepository(
 @Repository
 interface QuestionListAssignmentRepository : JpaRepository<QuestionListAssignment, Long> {
 
+  interface AssignmentInfo {
+    val questionListId: Long
+    val dueDate: LocalDate?
+  }
+
   @Query(
     """
     insert into question_list_assignment (question_list_id, offender_id, checkin_id, updated_at)
@@ -724,14 +729,21 @@ interface QuestionListAssignmentRepository : JpaRepository<QuestionListAssignmen
   @Modifying
   fun createAssignment(offenderId: Long, listId: Long, checkinId: Long? = null): Int
 
+  /**
+   * Returns list id if any, and a due date of already awaiting check-in, if any.
+   */
   @Query(
     """
-    select qla.question_list_id from question_list_assignment qla
-    where qla.offender_id = :offenderId and qla.checkin_id is null
+      select qla.question_list_id, c.due_date
+      from question_list_assignment qla
+      left join offender_checkin_v2 c on qla.checkin_id = c.id
+      where qla.offender_id = :offenderId 
+      and (qla.checkin_id is null or c.status = 'CREATED')
+      limit 1
   """,
     nativeQuery = true,
   )
-  fun upcomingAssignment(offenderId: Long): Long?
+  fun upcomingAssignmentAndDueDate(offenderId: Long): Optional<AssignmentInfo>
 
   /**
    * Returns the question list id for the checkin, if any.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/QuestionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/QuestionService.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.esupervisionapi.v2.question
 
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.validation.annotation.Validated
@@ -14,6 +15,7 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.Language
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderQuestion
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderQuestionList
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.QuestionListAssignmentRepository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.QuestionListItemDto
@@ -29,8 +31,11 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.OffenderStatus
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.exceptions.BadArgumentException
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.placeholders
 import java.time.Clock
+import java.time.Duration
 import java.util.UUID
 import kotlin.collections.emptyMap
+import kotlin.jvm.optionals.getOrDefault
+import kotlin.jvm.optionals.getOrNull
 
 @Service
 @Validated
@@ -41,6 +46,7 @@ class QuestionService(
   private val checkinService: CheckinV2Service,
   private val checkinRepository: OffenderCheckinV2Repository,
   private val clock: Clock,
+  @param:Value("\${app.scheduling.checkin-notification.window:72h}") private val checkinWindow: Duration,
 ) {
 
   private val crnRegex = Regex("[A-Z]\\d{6}")
@@ -52,7 +58,7 @@ class QuestionService(
   fun offenderQuestionList(listId: Long, language: Language): OffenderQuestionList {
     require(listId > 0)
 
-    val questions = questionsRepository.getListItems(listId).map { it.evalTemplate() }
+    val questions = questionsRepository.getListItems(listId, language).map { it.evalTemplate() }
     return OffenderQuestionList(listId, questions)
   }
 
@@ -67,7 +73,7 @@ class QuestionService(
       throw BadArgumentException("Offender status is ${offender.status}")
     }
 
-    val upcoming = upcomingAssignment(crn)
+    val upcoming = upcomingAssignment(offender)
     val items = if (upcoming.questionList != null) questionsRepository.getListItems(upcoming.questionList, language) else questionsRepository.defaultListItems(language)
     return UpcomingQuestionListItems(upcoming.expectedCheckinDate, items)
   }
@@ -76,22 +82,12 @@ class QuestionService(
    * Returns a minimal set of information about the upcoming question list assignment.
    */
   @Transactional(readOnly = true)
-  fun upcomingAssignment(crn: CRN): UpcomingQuestionAssignmentInfo {
-    require(crn.matches(crnRegex))
-    val offender = offenderRepository.findByCrn(crn).orElseThrow { BadArgumentException("Offender not found for CRN=$crn") }
-    if (offender.status != OffenderStatus.VERIFIED) {
-      throw BadArgumentException("Offender status is ${offender.status}")
-    }
-
-    val listId = questionListAssignmentRepository.upcomingAssignment(offender.id)
-    val today = clock.today()
-    val checkinDay = isCheckinDay(offender, today)
-    val checkinForTodayExists = if (checkinDay) checkinRepository.existsByOffenderAndDueDate(offender, today) else null
-    val nextCheckinDay = if (checkinForTodayExists == false) today else nextCheckinDay(offender, today)
-
+  fun upcomingAssignment(offender: OffenderV2): UpcomingQuestionAssignmentInfo {
+    require(offender.status == OffenderStatus.VERIFIED) { "Offender status is ${offender.status}" }
+    val info = questionListAssignmentRepository.upcomingAssignmentAndDueDate(offender.id).getOrNull()
     return UpcomingQuestionAssignmentInfo(
-      nextCheckinDay,
-      listId,
+      info?.dueDate ?: nextCheckinDay(offender, clock.today()),
+      info?.questionListId,
     )
   }
 
@@ -112,8 +108,9 @@ class QuestionService(
     if (offender.status != OffenderStatus.VERIFIED) {
       throw BadArgumentException("Can't add question to offender with status ${offender.status}")
     }
-    val maybeCheckin = checkinRepository.findByOffenderAndDueDate(offender, clock.today())
-    if (maybeCheckin.isEmpty && isCheckinDay(offender, clock.today())) {
+    val today = clock.today()
+    val checkin = checkinRepository.findByOffenderAndDueDate(offender, today).getOrNull()
+    if ((checkin == null && isCheckinDay(offender, today)) || (checkin != null && checkin.status == CheckinV2Status.CREATED)) {
       throw BadArgumentException("Offender is due for a checkin. Too late to assign questions.")
     }
 
@@ -136,7 +133,7 @@ class QuestionService(
       throw BadArgumentException("Too late to assign questions. Checkin possibly CREATED for offender=$crn: firstCheckin=${offender.firstCheckin}, interval=${offender.checkinInterval}")
     }
 
-    return AssignCustomQuestionsResponse(nextCheckinDay(offender, clock.today()), listId)
+    return AssignCustomQuestionsResponse(nextCheckinDay(offender, today), listId)
   }
 
   @Transactional

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/QuestionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/QuestionService.kt
@@ -34,7 +34,6 @@ import java.time.Clock
 import java.time.Duration
 import java.util.UUID
 import kotlin.collections.emptyMap
-import kotlin.jvm.optionals.getOrDefault
 import kotlin.jvm.optionals.getOrNull
 
 @Service

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/QuestionsIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/QuestionsIT.kt
@@ -252,9 +252,9 @@ class QuestionsIT : IntegrationTestBase() {
     assertNull(upcoming4)
 
     val assignment2 = questionService.assignCustomQuestions(offender.crn, addQuestionsRequest)
-    val upcoming5 = questionListAssignmentRepository.upcomingAssignmentAndDueDate(offender.id)
+    val upcoming5 = questionListAssignmentRepository.upcomingAssignmentAndDueDate(offender.id).getOrNull()
     assertNotNull(assignment2.listId)
-    assertEquals(assignment2.listId, upcoming5.getOrNull()?.questionListId)
+    assertEquals(assignment2.listId, upcoming5?.questionListId)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/QuestionsIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/QuestionsIT.kt
@@ -41,8 +41,8 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.placeholders
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
-import java.time.temporal.ChronoUnit
 import java.util.UUID
+import kotlin.jvm.optionals.getOrNull
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Import(TestClockConfiguration::class)
@@ -159,8 +159,8 @@ class QuestionsIT : IntegrationTestBase() {
     assertTrue(qlitems.size > 1)
 
     val checkin = offenderCheckinService.createCheckinByCrn(CreateCheckinByCrnV2Request("BARRY.WHITE", offender.crn, clock.today()))
-    val assignment = questionService.upcomingAssignment(offender.crn)
-    assertNull(assignment.questionList, "*Upcoming* assignment should flip to null after a checkin is created")
+    val assignment = questionService.upcomingAssignment(offender)
+    assertNotNull(assignment.questionList, "*Upcoming* assignment should not flip to null after a checkin is created")
 
     val checkinEntity = offenderCheckinV2Repository.findByUuid(checkin.uuid)
     val checkinQuestions = questionListAssignmentRepository.checkinAssignment(checkinEntity.get().id)
@@ -172,8 +172,8 @@ class QuestionsIT : IntegrationTestBase() {
     clock.advanceBy(Duration.ofHours(4))
     offenderCheckinService.submitCheckin(checkin.uuid, SubmitCheckinV2Request(mapOf("version" to "whatever")))
 
-    val assignmentAfterSubmission = questionService.upcomingAssignment(offender.crn)
-    assertNull(assignmentAfterSubmission.questionList)
+    val assignmentAfterSubmission = questionService.upcomingAssignment(offender)
+    assertNull(assignmentAfterSubmission.questionList, "Upcoming assignment should flip to null after a checkin is submitted")
   }
 
   @Test
@@ -220,8 +220,10 @@ class QuestionsIT : IntegrationTestBase() {
     clock.advanceBy(Duration.ofHours(1))
     val submission1 = offenderCheckinService.submitCheckin(checkin1.uuid, SubmitCheckinV2Request(mapOf("version" to "whatever")))
 
-    questionService.assignCustomQuestions(offender.crn, addQuestionsRequest)
-    assertNotNull(questionListAssignmentRepository.upcomingAssignment(offender.id))
+    val assignment1 = questionService.assignCustomQuestions(offender.crn, addQuestionsRequest)
+    val upcoming1 = questionListAssignmentRepository.upcomingAssignmentAndDueDate(offender.id).getOrNull()
+    assertNotNull(upcoming1)
+    assertEquals(assignment1.listId, upcoming1.questionListId)
 
     // ----- DAY 2
     clock.advanceBy(Duration.ofDays(1))
@@ -233,21 +235,26 @@ class QuestionsIT : IntegrationTestBase() {
       ),
     )
     // the assignment should have the checkin set
-    val upcoming2 = questionListAssignmentRepository.upcomingAssignment(offender.id)
-    assertNull(upcoming2, "No assignment should be present after checkin2 was submitted: $upcoming2")
+    val upcoming2 = questionListAssignmentRepository.upcomingAssignmentAndDueDate(offender.id).getOrNull()
+    assertNotNull(upcoming2, "Assignment should be present until checkin2 is submitted: $upcoming2")
+    assertEquals(assignment1.listId, upcoming2.questionListId)
 
-    // We can assign questions to the _next_ checkin now
-    val assignment3 = questionService.assignCustomQuestions(offender.crn, addQuestionsRequest)
+    assertThrows(BadArgumentException::class.java, {
+      questionService.assignCustomQuestions(offender.crn, addQuestionsRequest)
+    }, "We can't assign questions until check-in is submitted/expired")
 
-    val upcoming3 = questionService.upcomingAssignment(offender.crn)
-    assertEquals(assignment3.listId, upcoming3.questionList)
-    assertEquals(offender.firstCheckin.plus(offender.checkinInterval.toDays(), ChronoUnit.DAYS), assignment3.expectedCheckinDate)
+    // Verify out assignment hasn't changed
+    val upcoming3 = questionService.upcomingAssignment(offender)
+    assertEquals(upcoming2.questionListId, upcoming3.questionList)
 
     val submission2 = offenderCheckinService.submitCheckin(checkin2.uuid, SubmitCheckinV2Request(mapOf("version" to "whatever")))
+    val upcoming4 = questionListAssignmentRepository.upcomingAssignmentAndDueDate(offender.id).getOrNull()
+    assertNull(upcoming4)
 
-    // the assignment should have the checkin set
-    val assignment = questionListAssignmentRepository.upcomingAssignment(offender.id)
-    assertNotNull(assignment, "New assignment should be there after a submission of checkin2: $assignment")
+    val assignment2 = questionService.assignCustomQuestions(offender.crn, addQuestionsRequest)
+    val upcoming5 = questionListAssignmentRepository.upcomingAssignmentAndDueDate(offender.id)
+    assertNotNull(assignment2.listId)
+    assertEquals(assignment2.listId, upcoming5.getOrNull()?.questionListId)
   }
 
   @Test


### PR DESCRIPTION
For purposes of MPOP UI, we consider the next check-in as either:
- check in that hasn't been created yet
- a check-in of status CREATED

This PR modifies relevant methods to update the logic accordingly.