### PR TITLE
Fix sensitive flag mismatch between checkin and event log on annotate…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/CheckinV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/CheckinV2Service.kt
@@ -333,10 +333,11 @@ class CheckinV2Service(
       }
 
     val reviewInfo = request.appliedTo(checkin)
+    val effectiveSensitive = checkin.sensitive || request.sensitive
     offenderEventLogRepository.save(
       OffenderEventLogV2(
         comment = reviewInfo.comment,
-        sensitive = request.sensitive,
+        sensitive = effectiveSensitive,
         createdAt = clock.instant(),
         logEntryType = reviewInfo.logEntryType,
         practitioner = request.reviewedBy,
@@ -352,9 +353,7 @@ class CheckinV2Service(
     checkin.reviewedBy = request.reviewedBy
     checkin.manualIdCheck = request.manualIdCheck
     checkin.riskFeedback = request.riskManagementFeedback
-    if (!checkin.sensitive && request.sensitive) {
-      checkin.sensitive = true
-    }
+    checkin.sensitive = effectiveSensitive
     checkinRepository.save(checkin)
 
     LOGGER.info("Checkin reviewed: {} by {}", uuid, request.reviewedBy)
@@ -386,14 +385,15 @@ class CheckinV2Service(
       )
     }
     // if check in was already marked as sensitive, it cannot be then marked as not sensitive
-    if (checkin.sensitive != true && request.sensitive == true) {
-      checkin.sensitive = true
+    val effectiveSensitive = checkin.sensitive || request.sensitive
+    if (checkin.sensitive != effectiveSensitive) {
+      checkin.sensitive = effectiveSensitive
       checkinRepository.save(checkin)
     }
     val annotation = offenderEventLogRepository.save(
       OffenderEventLogV2(
         comment = request.notes,
-        sensitive = request.sensitive,
+        sensitive = effectiveSensitive,
         createdAt = clock.instant(),
         logEntryType = LogEntryType.OFFENDER_CHECKIN_ANNOTATED,
         practitioner = request.updatedBy,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/CheckinV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/CheckinV2ServiceTest.kt
@@ -566,6 +566,49 @@ class CheckinV2ServiceTest {
 
     assertEquals(true, checkin.sensitive)
     verify(checkinRepository, never()).save(checkin)
+    verify(offenderEventLogRepository).save(
+      argThat {
+        sensitive == true && comment == "Note"
+      },
+    )
+  }
+
+  @Test
+  fun `reviewCheckin - sensitive log entry stays true when check in was already marked as true`() {
+    val uuid = UUID.randomUUID()
+    val offender = createOffender()
+    val checkin = OffenderCheckinV2(
+      uuid = uuid,
+      offender = offender,
+      status = CheckinV2Status.SUBMITTED,
+      dueDate = LocalDate.now(clock),
+      createdAt = clock.instant(),
+      createdBy = "SYSTEM",
+      submittedAt = clock.instant(),
+      sensitive = true,
+    )
+
+    whenever(checkinRepository.findByUuid(uuid)).thenReturn(Optional.of(checkin))
+    whenever(checkinRepository.save(any())).thenAnswer { it.getArgument(0) }
+    whenever(offenderEventLogRepository.save(any())).thenAnswer { it.getArgument(0) }
+
+    val result = service.reviewCheckin(
+      uuid,
+      ReviewCheckinV2Request(
+        reviewedBy = "PRACT001",
+        manualIdCheck = ManualIdVerificationResult.MATCH,
+        notes = "Some note",
+        sensitive = false,
+      ),
+    )
+
+    assertEquals(true, checkin.sensitive)
+    assertEquals(true, result.sensitive)
+    verify(offenderEventLogRepository).save(
+      argThat {
+        sensitive == true
+      },
+    )
   }
 
   @Test


### PR DESCRIPTION
…/review

When a checkin is already marked as `sensitive=true`, the parent `offender_checkin_v2.sensitive` is correctly saved, but the offender_event_log row created during annotate/review was saved with the `request.sensitive` value. This left the checkin row marked `sensitive=true` while the log entry was `sensitive=false`.

Both annotateCheckin and reviewCheckin now use `effectiveSensitive = checkin.sensitive || request.sensitive` and use it for both the log entry and the checkin update, so the two rows stay the same.
