### PR TITLE
Add eligibility choice value to offender setup record/dto.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
@@ -231,8 +231,8 @@ data class OffenderInfoV2(
   val contactPreference: ContactPreference,
   @get:Schema(description = "Setup start timestamp (optional)", required = false)
   val startedAt: Instant? = null,
-  @get:Schema(description = "Eligibility choice", required = true)
-  val eligibilityChoice: EligibilityChoice,
+  @get:Schema(description = "Eligibility choice", required = false)
+  val eligibilityChoice: EligibilityChoice?,
 )
 
 /**

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
@@ -192,22 +192,6 @@ data class OffenderV2Dto(
   val personalDetails: ContactDetails? = null,
 )
 
-/** V2 Offender creation request */
-data class CreateOffenderV2Request(
-  @Schema(description = "Case Reference Number", required = true, example = "X123456")
-  @field:NotBlank
-  @field:Pattern(regexp = "^[A-Z]\\d{6}$", message = "CRN must be in format X123456")
-  val crn: String,
-  @Schema(description = "Practitioner ID", required = true)
-  @field:NotBlank
-  val practitionerId: ExternalUserId,
-  @Schema(description = "Date of first checkin", required = true)
-  @JsonDeserialize(using = LocalDateDeserializer::class)
-  val firstCheckin: LocalDate,
-  @Schema(description = "Interval between checkins", required = true)
-  val checkinInterval: CheckinInterval,
-)
-
 // ========================================
 // V2 Offender Setup DTOs
 // ========================================

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
@@ -214,23 +214,25 @@ data class CreateOffenderV2Request(
 
 /** V2 Offender information for starting setup V2 does not store PII - only CRN */
 data class OffenderInfoV2(
-  @Schema(description = "Setup UUID", required = true) val setupUuid: UUID,
-  @Schema(description = "Practitioner ID", required = true)
+  @get:Schema(description = "Setup UUID", required = true) val setupUuid: UUID,
+  @get:Schema(description = "Practitioner ID", required = true)
   @field:NotBlank
   val practitionerId: ExternalUserId,
-  @Schema(description = "Case Reference Number", required = true, example = "X123456")
-  @field:NotBlank
-  @field:Pattern(regexp = "^[A-Z]\\d{6}$", message = "CRN must be in format X123456")
+  @get:Schema(description = "Case Reference Number", required = true, example = "X123456")
+  @get:NotBlank
+  @get:Pattern(regexp = "^[A-Z]\\d{6}$", message = "CRN must be in format X123456")
   val crn: String,
-  @Schema(description = "Date of first checkin", required = true)
-  @JsonDeserialize(using = LocalDateDeserializer::class)
+  @get:Schema(description = "Date of first checkin", required = true)
+  @get:JsonDeserialize(using = LocalDateDeserializer::class)
   val firstCheckin: LocalDate,
-  @Schema(description = "Interval between checkins", required = true)
+  @get:Schema(description = "Interval between checkins", required = true)
   val checkinInterval: CheckinInterval,
-  @Schema(description = "POP contact preference", required = true)
+  @get:Schema(description = "POP contact preference", required = true)
   val contactPreference: ContactPreference,
-  @Schema(description = "Setup start timestamp (optional)", required = false)
+  @get:Schema(description = "Setup start timestamp (optional)", required = false)
   val startedAt: Instant? = null,
+  @get:Schema(description = "Eligibility choice", required = true)
+  val eligibilityChoice: EligibilityChoice,
 )
 
 /**
@@ -257,13 +259,15 @@ data class OffenderInfoInitial(
 
 /** V2 Offender setup DTO (response) */
 data class OffenderSetupV2Dto(
-  @Schema(description = "Setup unique identifier", required = true) val uuid: UUID,
-  @Schema(description = "Practitioner's unique ID", required = true)
+  @get:Schema(description = "Setup unique identifier", required = true) val uuid: UUID,
+  @get:Schema(description = "Practitioner's unique ID", required = true)
   val practitionerId: ExternalUserId,
-  @Schema(description = "Offender's unique ID", required = true) val offenderUuid: UUID,
-  @Schema(description = "Created timestamp", required = true) val createdAt: Instant,
-  @Schema(description = "Setup started timestamp (optional)", required = false)
+  @get:Schema(description = "Offender's unique ID", required = true) val offenderUuid: UUID,
+  @get:Schema(description = "Created timestamp", required = true) val createdAt: Instant,
+  @get:Schema(description = "Setup started timestamp (optional)", required = false)
   val startedAt: Instant? = null,
+  @get:Schema(description = "Eligibility choice", required = false)
+  val eligibilityChoice: EligibilityChoice? = null,
 )
 
 // ========================================

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
@@ -219,28 +219,6 @@ data class OffenderInfoV2(
   val eligibilityChoice: EligibilityChoice?,
 )
 
-/**
- * Offender information required to start/resume the offender setup process.
- */
-data class OffenderInfoInitial(
-  @field:Schema(description = "Practitioner ID", required = true)
-  @field:NotBlank
-  val practitionerId: ExternalUserId,
-  @field:Schema(description = "Case Reference Number", required = true, example = "X123456")
-  @field:NotBlank
-  @field:Pattern(regexp = "^[A-Z]\\d{6}$", message = "CRN must be in format X123456")
-  val crn: String,
-  @field:Schema(description = "Date of first checkin", required = true)
-  @field:JsonDeserialize(using = LocalDateDeserializer::class)
-  val firstCheckin: LocalDate,
-  @field:Schema(description = "Interval between checkins", required = true)
-  val checkinInterval: CheckinInterval,
-  @field:Schema(description = "POP contact preference", required = true)
-  val contactPreference: ContactPreference,
-  @field:Schema(description = "Setup start timestamp (optional)", required = false)
-  val startedAt: Instant? = null,
-)
-
 /** V2 Offender setup DTO (response) */
 data class OffenderSetupV2Dto(
   @get:Schema(description = "Setup unique identifier", required = true) val uuid: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Entities.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Entities.kt
@@ -103,6 +103,11 @@ open class OffenderV2(
   )
 }
 
+enum class EligibilityChoice {
+  REPLACE_F2F,
+  SUPPLEMENT_F2F,
+}
+
 /**
  * V2 Offender Setup Entity
  */
@@ -133,6 +138,9 @@ open class OffenderSetupV2(
 
   @Column(name = "setup_counter", nullable = false)
   open var setupCounter: Int = 1,
+
+  @Column(name = "eligibility_choice", nullable = true)
+  open var eligibilityChoice: EligibilityChoice? = null,
 ) : V2BaseEntity() {
   fun setupId(): UUID = UUID.nameUUIDFromBytes("$id:$setupCounter".toByteArray())
 
@@ -146,6 +154,7 @@ open class OffenderSetupV2(
     offenderUuid = offender.uuid,
     createdAt = createdAt,
     startedAt = startedAt,
+    eligibilityChoice = eligibilityChoice,
   )
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Entities.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Entities.kt
@@ -140,6 +140,7 @@ open class OffenderSetupV2(
   open var setupCounter: Int = 1,
 
   @Column(name = "eligibility_choice", nullable = true)
+  @Enumerated(EnumType.STRING)
   open var eligibilityChoice: EligibilityChoice? = null,
 ) : V2BaseEntity() {
   fun setupId(): UUID = UUID.nameUUIDFromBytes("$id:$setupCounter".toByteArray())

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupV2Service.kt
@@ -12,7 +12,6 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.NotificationFailureExcept
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.NotificationV2Service
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2Repository
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderInfoInitial
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderInfoV2
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderSetupV2
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderSetupV2Dto
@@ -119,46 +118,6 @@ class OffenderSetupV2Service(
       createdAt = saved.createdAt,
       startedAt = saved.startedAt,
     )
-  }
-
-  /**
-   * Initiates or re-starts the setup process for an offender based on the provided offender information.
-   * Checks if an offender setup already exists for the given CRN. If no setup exists, a new setup is initiated.
-   * If a setup exists but the offender's status is not "INITIAL", an exception is thrown.
-   * Otherwise, the existing offender information is updated with the provided details.
-   *
-   * @param offenderInfo the initial information about the offender
-   * @return the updated offender setup
-   * @throws BadArgumentException if the offender exists but has a status other than "INITIAL"
-   */
-  @Transactional
-  fun startOffenderSetup(offenderInfo: OffenderInfoInitial): OffenderSetupV2Dto {
-    LOGGER.info("Initiating offender setup for CRN={}", offenderInfo.crn)
-    val setup = offenderSetupRepository.findByCrn(offenderInfo.crn).orElse(null)
-    if (setup == null) {
-      return startOffenderSetup(offenderInfo.toOffenderInfoV2())
-    } else if (setup.offender.status != OffenderStatus.INITIAL) {
-      throw BadArgumentException("Offender already exists.")
-    }
-
-    val now = clock.instant()
-    val offender = setup.offender
-    offender.practitionerId = offenderInfo.practitionerId
-    offender.firstCheckin = offenderInfo.firstCheckin
-    offender.checkinInterval = offenderInfo.checkinInterval.duration
-    offender.contactPreference = offenderInfo.contactPreference
-    offender.updatedAt = now
-
-    offenderRepository.save(offender)
-
-    LOGGER.info(
-      "Re-started V2 offender setup: offender={}, crn={}, setup={}",
-      offender.uuid,
-      offender.crn,
-      setup.uuid,
-    )
-
-    return setup.dto()
   }
 
   /**
@@ -319,14 +278,3 @@ fun <T> raiseOnConstraintViolation(
     throw e
   }
 }
-
-private fun OffenderInfoInitial.toOffenderInfoV2(): OffenderInfoV2 = OffenderInfoV2(
-  setupUuid = UUID.randomUUID(),
-  practitionerId = practitionerId,
-  crn = crn,
-  firstCheckin = firstCheckin,
-  checkinInterval = checkinInterval,
-  contactPreference = contactPreference,
-  startedAt = startedAt,
-  eligibilityChoice = eligibilityChoice
-)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupV2Service.kt
@@ -111,13 +111,7 @@ class OffenderSetupV2Service(
       saved.uuid,
     )
 
-    return OffenderSetupV2Dto(
-      uuid = saved.uuid,
-      practitionerId = saved.practitionerId,
-      offenderUuid = saved.offender.uuid,
-      createdAt = saved.createdAt,
-      startedAt = saved.startedAt,
-    )
+    return saved.dto()
   }
 
   /**

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupV2Service.kt
@@ -328,4 +328,5 @@ private fun OffenderInfoInitial.toOffenderInfoV2(): OffenderInfoV2 = OffenderInf
   checkinInterval = checkinInterval,
   contactPreference = contactPreference,
   startedAt = startedAt,
+  eligibilityChoice = eligibilityChoice
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupV2Service.kt
@@ -97,6 +97,7 @@ class OffenderSetupV2Service(
       practitionerId = offenderInfo.practitionerId,
       createdAt = now,
       startedAt = offenderInfo.startedAt,
+      eligibilityChoice = offenderInfo.eligibilityChoice,
     )
 
     val saved =

--- a/src/main/resources/db/changelog/changesets/55_add_eligibility_column.sql
+++ b/src/main/resources/db/changelog/changesets/55_add_eligibility_column.sql
@@ -1,0 +1,10 @@
+--liquibase formatted sql
+
+--changeset roland.sadowski:55_add_eligibility_column.sql splitStatements:false
+
+create type eligibility_choice as enum ('REPLACE_F2F', 'SUPPLEMENT_F2F');
+
+alter table offender_setup_v2 add eligibility_choice eligibility_choice;
+
+--rollback alter table offender_setup_v2 drop column eligibility_choice;
+--rollback drop type eligibility_choice;

--- a/src/main/resources/db/changelog/changesets/57_add_eligibility_column.sql
+++ b/src/main/resources/db/changelog/changesets/57_add_eligibility_column.sql
@@ -1,6 +1,6 @@
 --liquibase formatted sql
 
---changeset roland.sadowski:55_add_eligibility_column.sql splitStatements:false
+--changeset roland.sadowski:57_add_eligibility_column.sql splitStatements:false
 
 create type eligibility_choice as enum ('REPLACE_F2F', 'SUPPLEMENT_F2F');
 

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -111,3 +111,6 @@ databaseChangeLog:
       file: db/changelog/changesets/55_add_face_match_score_to_checkin_v2.sql
   - include:
       file: db/changelog/changesets/56_add_rekognition_log_entry_types.sql
+  - include:
+      file: db/changelog/changesets/57_add_eligibility_column.sql
+

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupV2ServiceTest.kt
@@ -14,10 +14,11 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.transaction.support.TransactionTemplate
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.EligibilityChoice
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.INdiliusApiClient
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.NotificationV2Service
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2Repository
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderInfoInitial
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderInfoV2
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderSetupV2
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderSetupV2Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2
@@ -75,12 +76,14 @@ class OffenderSetupV2ServiceTest {
     val practitionerId = "PRACT001"
     val firstCheckin = LocalDate.now(clock).plusDays(7)
 
-    val offenderInfo = OffenderInfoInitial(
+    val offenderInfo = OffenderInfoV2(
+      setupUuid = UUID.randomUUID(),
       practitionerId = practitionerId,
       crn = crn,
       firstCheckin = firstCheckin,
       checkinInterval = CheckinInterval.WEEKLY,
       contactPreference = ContactPreference.EMAIL,
+      eligibilityChoice = EligibilityChoice.SUPPLEMENT_F2F,
     )
 
     val savedOffender = OffenderV2(
@@ -96,23 +99,24 @@ class OffenderSetupV2ServiceTest {
       contactPreference = ContactPreference.EMAIL,
     )
 
-    val savedSetup = OffenderSetupV2(
-      uuid = UUID.randomUUID(),
+    val expectedSetup = OffenderSetupV2(
+      uuid = offenderInfo.setupUuid,
       offender = savedOffender,
       practitionerId = practitionerId,
       createdAt = clock.instant(),
-      startedAt = null,
+      startedAt = offenderInfo.startedAt,
+      eligibilityChoice = offenderInfo.eligibilityChoice,
     )
 
     whenever(offenderRepository.save(any())).thenReturn(savedOffender)
-    whenever(offenderSetupRepository.save(any())).thenReturn(savedSetup)
+    whenever(offenderSetupRepository.save(any())).thenReturn(expectedSetup)
 
     // When
     val result = service.startOffenderSetup(offenderInfo)
 
     // Then
     assertNotNull(result)
-    assertEquals(savedSetup.uuid, result.uuid)
+    assertEquals(offenderInfo.setupUuid, result.uuid)
     assertEquals(practitionerId, result.practitionerId)
     assertEquals(savedOffender.uuid, result.offenderUuid)
 
@@ -277,24 +281,29 @@ class OffenderSetupV2ServiceTest {
     )
 
     whenever(offenderSetupRepository.findByCrn(offender.crn)).thenReturn(Optional.of(setup))
+    whenever(offenderSetupRepository.save(any())).thenReturn(setup)
 
     val first = service.startOffenderSetup(
-      OffenderInfoInitial(
+      OffenderInfoV2(
+        setupUuid = UUID.randomUUID(),
         crn = offender.crn,
         practitionerId = "PRACT001",
         firstCheckin = offender.firstCheckin,
         checkinInterval = CheckinInterval.WEEKLY,
         contactPreference = offender.contactPreference,
+        eligibilityChoice = EligibilityChoice.SUPPLEMENT_F2F,
       ),
     )
 
     val second = service.startOffenderSetup(
-      OffenderInfoInitial(
+      OffenderInfoV2(
+        setupUuid = UUID.randomUUID(),
         crn = offender.crn,
         practitionerId = "PRACT001",
         firstCheckin = offender.firstCheckin,
         checkinInterval = CheckinInterval.WEEKLY,
         contactPreference = offender.contactPreference,
+        eligibilityChoice = EligibilityChoice.SUPPLEMENT_F2F,
       ),
     )
 


### PR DESCRIPTION
The offender setup request now accepts an optional eligibility value.

Also, removed some code around offender setup - it was only called from tests. This was an alternative setup path that didn't require the setup UUID in the payload. Somehow this ended up unused.
