### PR TITLE
Move the pipeline's concurrency rules to the job level

### DIFF
--- a/.github/workflows/build_and_deploy_to_env.yml
+++ b/.github/workflows/build_and_deploy_to_env.yml
@@ -9,8 +9,7 @@ on:
         required: true
         options:
           - dev
-          - test
-        default: 'test'
+        default: 'dev'
 
 permissions:
   contents: read

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -21,12 +21,6 @@ permissions:
   contents: read
   packages: write
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-# This will cancel all running build/test/release pipelines that are not on the main branch
-# If this pipeline is on the main branch, it will wait until existing runs complete
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
-
 jobs:
   helm_lint:
     strategy:
@@ -75,6 +69,11 @@ jobs:
     with:
       environment: 'preprod'
       app_version: '${{ needs.build.outputs.app_version }}'
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      # This will cancel all running build/test/release pipelines that are not on the main branch
+      # If this pipeline is on the main branch, it will wait until existing runs complete
+      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
   deploy_prod:
     name: Deploy to production environment
     if: github.ref == 'refs/heads/main'
@@ -86,3 +85,8 @@ jobs:
     with:
       environment: 'prod'
       app_version: '${{ needs.build.outputs.app_version }}'
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      # This will cancel all running build/test/release pipelines that are not on the main branch
+      # If this pipeline is on the main branch, it will wait until existing runs complete
+      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}


### PR DESCRIPTION
### Move the pipeline's concurrency rules to the job level

- The aim is that the latest merged changes can be deployed to DEV without being blocked by changes awaiting PROD release
- Keeping the concurrecy rules for the PREPROD & PROD jobs should mean that there still can only be a single run active in those environments
- Remove the TEST option from the build & deploy workflow as the TEST environment is no longer used