### PR TITLE
Remove checkin snapshot & video if manual id confirms match

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/CheckinV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/CheckinV2Service.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.esupervisionapi.v2
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.data.domain.PageRequest
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -10,12 +11,12 @@ import org.springframework.web.server.ResponseStatusException
 import software.amazon.awssdk.services.rekognition.model.GetFaceLivenessSessionResultsResponse
 import software.amazon.awssdk.services.rekognition.model.RekognitionException
 import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.NotificationType
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.GenericNotificationV2Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.audit.EventAuditV2Service
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.checkin.CheckinCreationService
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.AutomatedIdVerificationResult
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ExternalUserId
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.LivenessResult
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ManualIdVerificationResult
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.OffenderStatus
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.rekognition.CheckinVerificationImages
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.rekognition.FacialRecognitionOutcome
@@ -382,8 +383,15 @@ class CheckinV2Service(
 
     eventAuditService.recordCheckinReviewed(checkin, contactDetails)
 
-    val videoUrl = s3UploadService.getCheckinVideo(checkin)
+    LOGGER.info("Manual ID check : {} by {}", uuid, request.reviewedBy)
+    if (checkin.manualIdCheck == ManualIdVerificationResult.MATCH) {
+      s3UploadService.deleteCheckinSnapshot(uuid, 0)
+      s3UploadService.deleteCheckinVideo(uuid)
+      return checkin.dto(contactDetails, null, null, clock = clock, checkinWindow = checkinWindowPeriod)
+    }
+
     val snapshotUrl = s3UploadService.getCheckinSnapshot(checkin, 0)
+    val videoUrl = s3UploadService.getCheckinVideo(checkin)
     return checkin.dto(contactDetails, videoUrl, snapshotUrl, clock = clock, checkinWindow = checkinWindowPeriod)
   }
 
@@ -1054,7 +1062,7 @@ class CheckinV2Service(
     practitionerId: ExternalUserId,
     offenderUuid: UUID?,
     useCase: CheckinListUseCaseV2?,
-    pageRequest: org.springframework.data.domain.PageRequest,
+    pageRequest: PageRequest,
   ): CheckinCollectionV2Response {
     val page =
       when (useCase) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/domain/ManualIdVerificationResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/domain/ManualIdVerificationResult.kt
@@ -3,4 +3,5 @@ package uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain
 enum class ManualIdVerificationResult {
   MATCH,
   NO_MATCH,
+  MATCH_WITH_CONCERN,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/storage/S3UploadService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/storage/S3UploadService.kt
@@ -349,6 +349,8 @@ class S3UploadService(
   /**
    * V2 Checkin - deletes S3 object for checkin snapshot
    */
+  @CircuitBreaker(name = "awsS3")
+  @Retry(name = "awsS3")
   fun deleteCheckinSnapshot(uuid: UUID, index: Int): DeleteObjectResponse? {
     val key = CheckinPhotoKey(uuid, index)
     val delReq = deleteObjectRequest(bucketFor(key), key.toKey())
@@ -358,6 +360,8 @@ class S3UploadService(
   /**
    * V2 Checkin - deletes S3 object for checkin video
    */
+  @CircuitBreaker(name = "awsS3")
+  @Retry(name = "awsS3")
   fun deleteCheckinVideo(uuid: UUID): DeleteObjectResponse? {
     val key = CheckinVideoKey(uuid)
     val delReq = deleteObjectRequest(bucketFor(key), key.toKey())

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/storage/S3UploadService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/storage/S3UploadService.kt
@@ -7,6 +7,8 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest
+import software.amazon.awssdk.services.s3.model.DeleteObjectResponse
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException
@@ -187,6 +189,14 @@ class S3UploadService(
     return s3Presigner.presignPutObject(presignRequest).url()
   }
 
+  private fun deleteObjectRequest(bucket: String, key: String): DeleteObjectRequest {
+    val request = DeleteObjectRequest.builder()
+      .bucket(bucket)
+      .key(key)
+      .build()
+    return request
+  }
+
   // ============================================================
   // V2 Public API - Setup Photo Operations
   // ============================================================
@@ -334,6 +344,24 @@ class S3UploadService(
       bucket = videoUploadBucket,
       key = key.toKey(),
     )
+  }
+
+  /**
+   * V2 Checkin - deletes S3 object for checkin snapshot
+   */
+  fun deleteCheckinSnapshot(uuid: UUID, index: Int): DeleteObjectResponse? {
+    val key = CheckinPhotoKey(uuid, index)
+    val delReq = deleteObjectRequest(bucketFor(key), key.toKey())
+    return s3uploadClient.deleteObject(delReq)
+  }
+
+  /**
+   * V2 Checkin - deletes S3 object for checkin video
+   */
+  fun deleteCheckinVideo(uuid: UUID): DeleteObjectResponse? {
+    val key = CheckinVideoKey(uuid)
+    val delReq = deleteObjectRequest(bucketFor(key), key.toKey())
+    return s3uploadClient.deleteObject(delReq)
   }
 
   companion object {

--- a/src/main/resources/db/changelog/changesets/60_alter_verify_id_manual_result_v2.sql
+++ b/src/main/resources/db/changelog/changesets/60_alter_verify_id_manual_result_v2.sql
@@ -1,0 +1,9 @@
+-- liquibase formatted sql
+
+-- changeset dave.iles:60_alter_verify_id_manual_result_v2.sql-1 splitStatements:false
+ALTER TYPE public.verify_id_manual_result_v2
+    ADD VALUE 'MATCH_WITH_CONCERN' AFTER 'NO_MATCH';
+
+--rollback:
+-- No easy way to remove enum value in Postgres without dropping and recreating the type,
+-- which is dangerous. Leaving it as is.

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -117,3 +117,5 @@ databaseChangeLog:
       file: db/changelog/changesets/58_add_checkin_legacy_cleanup_job_enum.sql
   - include:
       file: db/changelog/changesets/59_setup_event_backfill_v2.sql
+  - include:
+      file: db/changelog/changesets/60_alter_verify_id_manual_result_v2.sql

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/CheckinV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/CheckinV2ServiceTest.kt
@@ -335,10 +335,46 @@ class CheckinV2ServiceTest {
 
     assertEquals(CheckinV2Status.REVIEWED, result.status)
     assertNotNull(result.reviewedAt)
+    assertNull(result.videoUrl)
+    assertNull(result.snapshotUrl)
+    assertEquals("PRACT001", result.reviewedBy)
+    assertEquals(ManualIdVerificationResult.MATCH, result.manualIdCheck)
+    verify(checkinRepository).save(any())
+  }
+
+  @Test
+  fun `reviewCheckin - happy path - completes review, manual id check MATCH_WITH_CONCERN`() {
+    val uuid = UUID.randomUUID()
+    val offender = createOffender()
+    val checkin = OffenderCheckinV2(
+      uuid = uuid,
+      offender = offender,
+      status = CheckinV2Status.SUBMITTED,
+      dueDate = LocalDate.now(clock),
+      createdAt = clock.instant(),
+      createdBy = "SYSTEM",
+      submittedAt = clock.instant(),
+      reviewStartedAt = clock.instant(),
+      reviewStartedBy = "PRACT001",
+    )
+
+    val request = ReviewCheckinV2Request(
+      reviewedBy = "PRACT001",
+      manualIdCheck = ManualIdVerificationResult.MATCH_WITH_CONCERN,
+      notes = "Approved",
+    )
+
+    whenever(checkinRepository.findByUuid(uuid)).thenReturn(Optional.of(checkin))
+    whenever(checkinRepository.save(any())).thenAnswer { it.getArgument(0) }
+
+    val result = service.reviewCheckin(uuid, request)
+
+    assertEquals(CheckinV2Status.REVIEWED, result.status)
+    assertNotNull(result.reviewedAt)
     assertNotNull(result.videoUrl)
     assertNotNull(result.snapshotUrl)
     assertEquals("PRACT001", result.reviewedBy)
-    assertEquals(ManualIdVerificationResult.MATCH, result.manualIdCheck)
+    assertEquals(ManualIdVerificationResult.MATCH_WITH_CONCERN, result.manualIdCheck)
     verify(checkinRepository).save(any())
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/CheckinV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/CheckinV2ServiceTest.kt
@@ -340,6 +340,8 @@ class CheckinV2ServiceTest {
     assertEquals("PRACT001", result.reviewedBy)
     assertEquals(ManualIdVerificationResult.MATCH, result.manualIdCheck)
     verify(checkinRepository).save(any())
+    verify(s3UploadService).deleteCheckinSnapshot(uuid, 0)
+    verify(s3UploadService).deleteCheckinVideo(uuid)
   }
 
   @Test
@@ -376,6 +378,8 @@ class CheckinV2ServiceTest {
     assertEquals("PRACT001", result.reviewedBy)
     assertEquals(ManualIdVerificationResult.MATCH_WITH_CONCERN, result.manualIdCheck)
     verify(checkinRepository).save(any())
+    verify(s3UploadService, never()).deleteCheckinVideo(any())
+    verify(s3UploadService, never()).deleteCheckinSnapshot(any(), any())
   }
 
   @Test


### PR DESCRIPTION
[ESUP-1763 - Dev: Implement API logic to remove image after successful practitioner review](https://dsdmoj.atlassian.net/browse/ESUP-1763)

ESUP should remove checkin snapshots & videos once they have been reviewed by a practitioner and marked as a MATCH without any concerns.

There will be a MPOP PR raised to add and return the new MATCH_WITH_CONCERN option to the manual id check 