### PR TITLE
ESUP-1802: fetch the latest offender setup record for offender

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Repositories.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Repositories.kt
@@ -122,6 +122,15 @@ interface OffenderV2Repository : JpaRepository<OffenderV2, Long> {
 @Repository
 interface OffenderSetupV2Repository : JpaRepository<OffenderSetupV2, Long> {
   fun findByUuid(uuid: UUID): Optional<OffenderSetupV2>
+
+  @Query(
+    """
+    SELECT s FROM OffenderSetupV2 s
+    WHERE s.offender = :offender
+    ORDER BY s.createdAt DESC
+    LIMIT 1
+  """,
+  )
   fun findByOffender(offender: OffenderV2): Optional<OffenderSetupV2>
   fun findAllByPractitionerId(practitionerId: ExternalUserId): List<OffenderSetupV2>
 


### PR DESCRIPTION
We now allow more than one offender setup record per offender ID (this can happen when someone initiates a setup, but doesn't finish it then initiates another one).