### PR TITLE
refactor annotateCheckin() to use events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/CheckinPersistenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/CheckinPersistenceService.kt
@@ -53,4 +53,23 @@ class CheckinPersistenceService(
 
     appEventPublisher.publishEvent(event)
   }
+
+  @Transactional
+  fun checkinAnnotation(checkin: OffenderCheckinV2, event: PartialCheckinAnnotatedEvent, request: AnnotateCheckinV2Request) {
+    checkinRepository.save(checkin)
+    val logEntry = offenderEventLogRepository.save(
+      OffenderEventLogV2(
+        comment = request.notes,
+        sensitive = checkin.sensitive,
+        createdAt = clock.instant(),
+        logEntryType = LogEntryType.OFFENDER_CHECKIN_ANNOTATED,
+        practitioner = request.updatedBy,
+        uuid = UUID.randomUUID(),
+        offender = checkin.offender,
+        checkin = checkin.id,
+      ),
+    )
+
+    appEventPublisher.publishEvent(event.finalise(logEntry))
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/CheckinV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/CheckinV2Service.kt
@@ -379,7 +379,6 @@ class CheckinV2Service(
   }
 
   /** Annotate a checkin */
-  @Transactional
   fun annotateCheckin(uuid: UUID, request: AnnotateCheckinV2Request): CheckinV2Dto {
     val checkin =
       checkinRepository.findByUuid(uuid).orElseThrow {
@@ -392,31 +391,20 @@ class CheckinV2Service(
         "Checkin must be reviewed before being annotated",
       )
     }
-    // if check in was already marked as sensitive, it cannot be then marked as not sensitive
-    val effectiveSensitive = checkin.sensitive || request.sensitive
-    if (checkin.sensitive != effectiveSensitive) {
-      checkin.sensitive = effectiveSensitive
-      checkinRepository.save(checkin)
-    }
-    val annotation = offenderEventLogRepository.save(
-      OffenderEventLogV2(
-        comment = request.notes,
-        sensitive = effectiveSensitive,
-        createdAt = clock.instant(),
-        logEntryType = LogEntryType.OFFENDER_CHECKIN_ANNOTATED,
-        practitioner = request.updatedBy,
-        uuid = UUID.randomUUID(),
-        offender = checkin.offender,
-        checkin = checkin.id,
-      ),
-    )
 
+    checkin.sensitive = checkin.sensitive || request.sensitive
+    val personalDetails = ndiliusApiClient.getContactDetails(checkin.offender.crn)
+    val event = PartialCheckinAnnotatedEvent(
+      checkinId = checkin.id,
+      offenderId = checkin.offender.id,
+      checkin = checkin.dto(personalDetails, clock = clock, checkinWindow = checkinWindowPeriod),
+      practitionerId = request.updatedBy,
+      offenderContactPreference = checkin.offender.contactPreference,
+    )
+    checkinPersistenceService.checkinAnnotation(checkin, event, request)
     LOGGER.info("Checkin annotated: {} by {}", uuid, request.updatedBy)
 
-    notificationService.sendCheckinUpdatedNotifications(checkin, annotation)
-
-    val personalDetails = ndiliusApiClient.getContactDetails(checkin.offender.crn)
-    return checkin.dto(personalDetails, clock = clock, checkinWindow = checkinWindowPeriod)
+    return event.checkin
   }
 
   /** Get proxy URL for checkin video */

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/EventDtos.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/EventDtos.kt
@@ -2,13 +2,25 @@ package uk.gov.justice.digital.hmpps.esupervisionapi.v2
 
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ContactPreference
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ExternalUserId
+import java.util.UUID
 
-sealed interface ICheckinEvent {
+/**
+ * Marker interface; use it to tag classes that are not ready to be processed (e.g., they're missing some values)
+ */
+interface IPartialEvent
+
+interface IEventBase {
   val checkinId: Long
   val offenderId: Long
   val practitionerId: ExternalUserId
   val checkin: CheckinV2Dto
   val offenderContactPreference: ContactPreference
+}
+
+/**
+ * Our listeners should be able to process any subclass of this.
+ */
+sealed interface ICheckinEvent : IEventBase {
   val outboxItemCoords: Pair<OutboxItemType, Long>? get() = null
 }
 
@@ -30,4 +42,36 @@ data class CheckinReviewedEvent(
   override val offenderContactPreference: ContactPreference,
 ) : ICheckinEvent {
   override val outboxItemCoords = OutboxItemType.CHECKIN_REVIEWED to checkinId
+}
+
+data class CheckinAnnotatedEvent(
+  override val checkinId: Long,
+  override val offenderId: Long,
+  override val practitionerId: ExternalUserId,
+  override val checkin: CheckinV2Dto,
+  override val offenderContactPreference: ContactPreference,
+  val annotation: Pair<Long, UUID>,
+) : ICheckinEvent {
+  override val outboxItemCoords = OutboxItemType.CHECKIN_ANNOTATED to annotation.first
+}
+
+/**
+ * Fully finalised event requires the `outboxItemCoords` to be set.
+ */
+data class PartialCheckinAnnotatedEvent(
+  override val checkinId: Long,
+  override val offenderId: Long,
+  override val practitionerId: ExternalUserId,
+  override val checkin: CheckinV2Dto,
+  override val offenderContactPreference: ContactPreference,
+) : IEventBase,
+  IPartialEvent {
+  fun finalise(logEntry: OffenderEventLogV2): CheckinAnnotatedEvent = CheckinAnnotatedEvent(
+    checkinId = checkinId,
+    offenderId = offenderId,
+    checkin = checkin,
+    practitionerId = practitionerId,
+    offenderContactPreference = offenderContactPreference,
+    annotation = Pair(logEntry.id, logEntry.uuid),
+  )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorV2Service.kt
@@ -423,12 +423,12 @@ class NotificationOrchestratorV2Service(
   )
 
   /** Send notifications for checkin updated event */
-  fun sendCheckinUpdatedNotifications(checkin: OffenderCheckinV2, annotation: OffenderEventLogV2) {
+  fun sendCheckinUpdatedNotifications(event: CheckinAnnotatedEvent) {
     domainEventService.publishDomainEvent(
       eventType = DomainEventType.V2_CHECKIN_ANNOTATED,
-      uuid = annotation.uuid,
-      crn = checkin.offender.crn,
-      description = "Check-in updated for ${checkin.offender.crn}",
+      uuid = event.annotation.second,
+      crn = event.checkin.crn,
+      description = "Check-in updated for ${event.checkin.crn}",
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationV2Service.kt
@@ -80,8 +80,8 @@ class NotificationV2Service(
   /**
    * Send notifications for checkin updated event
    */
-  fun sendCheckinUpdatedNotifications(checkin: OffenderCheckinV2, annotation: OffenderEventLogV2) {
-    orchestrator.sendCheckinUpdatedNotifications(checkin, annotation)
+  fun sendCheckinUpdatedNotifications(event: CheckinAnnotatedEvent) {
+    orchestrator.sendCheckinUpdatedNotifications(event)
   }
 
   /**

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Entities.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Entities.kt
@@ -742,6 +742,7 @@ enum class OutboxItemType {
   CHECKIN_SUBMITTED,
   CHECKIN_REVIEWED,
   CHECKIN_EXPIRED,
+  CHECKIN_ANNOTATED,
 }
 
 enum class OutboxItemStatus {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Repositories.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Repositories.kt
@@ -144,6 +144,7 @@ interface OffenderSetupV2Repository : JpaRepository<OffenderSetupV2, Long> {
  */
 @Repository
 interface OffenderCheckinV2Repository : JpaRepository<OffenderCheckinV2, Long> {
+  @Transactional(readOnly = true)
   @EntityGraph(attributePaths = ["offender"])
   fun findByUuid(uuid: UUID): Optional<OffenderCheckinV2>
   fun findAllByOffenderAndStatus(offender: OffenderV2, status: CheckinV2Status): List<OffenderCheckinV2>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Repositories.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Repositories.kt
@@ -144,7 +144,6 @@ interface OffenderSetupV2Repository : JpaRepository<OffenderSetupV2, Long> {
  */
 @Repository
 interface OffenderCheckinV2Repository : JpaRepository<OffenderCheckinV2, Long> {
-  @Transactional(readOnly = true)
   @EntityGraph(attributePaths = ["offender"])
   fun findByUuid(uuid: UUID): Optional<OffenderCheckinV2>
   fun findAllByOffenderAndStatus(offender: OffenderV2, status: CheckinV2Status): List<OffenderCheckinV2>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/events/CheckinEventsListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/events/CheckinEventsListener.kt
@@ -14,6 +14,10 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.NotificationV2Service
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OutboxItemRepository
 import java.util.concurrent.CompletableFuture
 
+/**
+ * We rely on outbox items being inserted before processing the event.
+ * We typically insert them via triggers.
+ */
 @Service
 class CheckinEventsListener(
   private val notificationService: NotificationV2Service,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/events/CheckinEventsListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/events/CheckinEventsListener.kt
@@ -6,6 +6,7 @@ import org.springframework.transaction.event.TransactionPhase
 import org.springframework.transaction.event.TransactionalEventListener
 import org.springframework.transaction.support.TransactionTemplate
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.logger
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinAnnotatedEvent
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinReviewedEvent
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinSubmittedEvent
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.ICheckinEvent
@@ -27,6 +28,7 @@ class CheckinEventsListener(
     when (event) {
       is CheckinSubmittedEvent -> notificationService.sendCheckinSubmittedNotifications(event)
       is CheckinReviewedEvent -> notificationService.sendCheckinReviewedNotifications(event)
+      is CheckinAnnotatedEvent -> notificationService.sendCheckinUpdatedNotifications(event)
     }
     event.outboxItemCoords?.let { (type, id) ->
       val result = outboxItemRepository.markAsSent(type.name, id)

--- a/src/main/resources/db/changelog/changesets/65_add_checkin_event_enum_value.sql
+++ b/src/main/resources/db/changelog/changesets/65_add_checkin_event_enum_value.sql
@@ -1,7 +1,31 @@
 --liquibase formatted sql
 
---changeset roland.sadowski:65_add_checkin_event_enum_value splitStatements:false
+--changeset roland.sadowski:65_add_checkin_event_enum_value-1 splitStatements:false
 
 alter type OutboxItemType add value 'CHECKIN_ANNOTATED';
 
 --rollback alter type OutboxItemType drop value 'CHECKIN_ANNOTATED';
+
+--changeset roland.sadowski:65_add_checkin_event_enum_value-2 splitStatements:false
+
+CREATE OR REPLACE FUNCTION fn_add_outbox_record_on_offender_event_log_insert()
+    RETURNS TRIGGER AS $$
+BEGIN
+    INSERT INTO outbox_items(type, entity_id)
+    VALUES (
+            'CHECKIN_ANNOTATED'::OutboxItemType,
+            NEW.id
+           );
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_checkin_status_change__outbox
+    AFTER INSERT on offender_event_log_v2
+    FOR EACH ROW
+    WHEN (NEW.log_entry_type in ('OFFENDER_CHECKIN_ANNOTATED'::log_entry_type_v2))
+EXECUTE FUNCTION fn_add_outbox_record_on_offender_event_log_insert();
+
+--rollback:
+--rollback drop trigger trg_checkin_status_change__outbox on offender_event_log_v2;
+--rollback drop function fn_add_outbox_record_on_offender_event_log_insert();

--- a/src/main/resources/db/changelog/changesets/65_add_checkin_event_enum_value.sql
+++ b/src/main/resources/db/changelog/changesets/65_add_checkin_event_enum_value.sql
@@ -20,7 +20,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE TRIGGER trg_checkin_status_change__outbox
+CREATE TRIGGER trg_offender_event_log_event__outbox
     AFTER INSERT on offender_event_log_v2
     FOR EACH ROW
     WHEN (NEW.log_entry_type in ('OFFENDER_CHECKIN_ANNOTATED'::log_entry_type_v2))

--- a/src/main/resources/db/changelog/changesets/65_add_checkin_event_enum_value.sql
+++ b/src/main/resources/db/changelog/changesets/65_add_checkin_event_enum_value.sql
@@ -1,0 +1,7 @@
+--liquibase formatted sql
+
+--changeset roland.sadowski:65_add_checkin_event_enum_value splitStatements:false
+
+alter type OutboxItemType add value 'CHECKIN_ANNOTATED';
+
+--rollback alter type OutboxItemType drop value 'CHECKIN_ANNOTATED';

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -127,3 +127,5 @@ databaseChangeLog:
       file: db/changelog/changesets/63_update_provider_month_mv.sql
   - include:
       file: db/changelog/changesets/64_update_monthly_feedback_mv.sql
+  - include:
+      file: db/changelog/changesets/65_add_checkin_event_enum_value.sql

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/CheckinV2ServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/CheckinV2ServiceIntegrationTest.kt
@@ -1,10 +1,10 @@
 package uk.gov.justice.digital.hmpps.esupervisionapi.v2.checkin
 
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
@@ -72,8 +72,8 @@ class CheckinV2ServiceIntegrationTest : IntegrationTestBase() {
   @MockitoBean
   private lateinit var checkinCreationService: CheckinCreationService
 
-  @BeforeEach
-  fun setUp() {
+  @AfterEach
+  fun tearDown() {
     offenderEventLogV2Repository.deleteAll()
     checkinV2Repository.deleteAll()
     offenderV2Repository.deleteAll()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/CheckinV2ServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/CheckinV2ServiceIntegrationTest.kt
@@ -8,10 +8,14 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.reset
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.bean.override.mockito.MockitoBean
+import uk.gov.justice.digital.hmpps.esupervisionapi.datagen.offenderTemplate
+import uk.gov.justice.digital.hmpps.esupervisionapi.datagen.toEntity
 import uk.gov.justice.digital.hmpps.esupervisionapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.AnnotateCheckinV2Request
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinV2Service
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinV2Status
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.ContactDetails
@@ -22,13 +26,16 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderEventLogV2
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderEventLogV2Repository
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2Repository
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ContactPreference
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OutboxItemRepository
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OutboxItemType
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.ReviewCheckinV2Request
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.SubmitCheckinV2Request
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.SurveyVersion
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ManualIdVerificationResult
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.rekognition.OffenderIdVerifier
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.storage.S3UploadService
 import java.net.URI
-import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
@@ -46,6 +53,9 @@ class CheckinV2ServiceIntegrationTest : IntegrationTestBase() {
 
   @Autowired
   private lateinit var offenderEventLogV2Repository: OffenderEventLogV2Repository
+
+  @Autowired
+  private lateinit var outboxItemRepository: OutboxItemRepository
 
   @MockitoBean
   private lateinit var ndiliusApiClient: INdiliusApiClient
@@ -67,23 +77,14 @@ class CheckinV2ServiceIntegrationTest : IntegrationTestBase() {
     offenderEventLogV2Repository.deleteAll()
     checkinV2Repository.deleteAll()
     offenderV2Repository.deleteAll()
+    outboxItemRepository.deleteAll()
+    reset(s3UploadService)
   }
 
   @Test
   fun `getCheckin - happy path - returns checkin details`() {
-    val offender = offenderV2Repository.save(
-      OffenderV2(
-        uuid = UUID.randomUUID(),
-        crn = "X123456",
-        practitionerId = "PRACT001",
-        firstCheckin = LocalDate.now(),
-        checkinInterval = Duration.ofDays(7),
-        createdAt = Instant.now(),
-        createdBy = "SYSTEM",
-        updatedAt = Instant.now(),
-        contactPreference = ContactPreference.PHONE,
-      ),
-    )
+    val offender = offenderTemplate.copy().toEntity()
+    offenderV2Repository.save(offender)
 
     // we want some content in the checkin logs, so we add a CHECKIN_NOT_SUBMITTED event and
     // set the checkin status to match
@@ -94,7 +95,7 @@ class CheckinV2ServiceIntegrationTest : IntegrationTestBase() {
         status = CheckinV2Status.EXPIRED,
         dueDate = LocalDate.now(),
         createdAt = Instant.now(),
-        createdBy = "PRACT001",
+        createdBy = offender.practitionerId,
       ),
     )
 
@@ -128,17 +129,7 @@ class CheckinV2ServiceIntegrationTest : IntegrationTestBase() {
   @Test
   fun `getCheckin - with personal details - returns checkin with personal details`() {
     val offender = offenderV2Repository.save(
-      OffenderV2(
-        uuid = UUID.randomUUID(),
-        crn = "X987654",
-        practitionerId = "PRACT002",
-        firstCheckin = LocalDate.now(),
-        checkinInterval = Duration.ofDays(7),
-        createdAt = Instant.now(),
-        createdBy = "SYSTEM",
-        updatedAt = Instant.now(),
-        contactPreference = ContactPreference.PHONE,
-      ),
+      offenderTemplate.copy(crn = "X987654", practitionerId = "PRACT002").toEntity(),
     )
 
     val checkinUuid = UUID.randomUUID()
@@ -146,12 +137,14 @@ class CheckinV2ServiceIntegrationTest : IntegrationTestBase() {
       OffenderCheckinV2(
         uuid = checkinUuid,
         offender = offender,
-        status = CheckinV2Status.SUBMITTED,
+        status = CheckinV2Status.CREATED,
         dueDate = LocalDate.now(),
         createdAt = Instant.now(),
-        createdBy = "PRACT002",
+        createdBy = offender.practitionerId,
       ),
     )
+    whenever(s3UploadService.isCheckinVideoUploaded(any())).thenReturn(true)
+    checkinV2Service.submitCheckin(checkinUuid, SubmitCheckinV2Request(survey = mapOf("version" to SurveyVersion.V20260416Questions.version)))
 
     val contactDetails = ContactDetails(
       crn = offender.crn,
@@ -172,29 +165,26 @@ class CheckinV2ServiceIntegrationTest : IntegrationTestBase() {
   @Test
   fun `getCheckin - with flagged survey answers - calculates flags correctly`() {
     val offender = offenderV2Repository.save(
-      OffenderV2(
-        uuid = UUID.randomUUID(),
-        crn = "X234567",
-        practitionerId = "PRACT001",
-        firstCheckin = LocalDate.now(),
-        checkinInterval = Duration.ofDays(7),
-        createdAt = Instant.now(),
-        createdBy = "SYSTEM",
-        updatedAt = Instant.now(),
-        contactPreference = ContactPreference.PHONE,
-      ),
+      offenderTemplate.copy(crn = "X234567", practitionerId = "PRACT001").toEntity(),
     )
 
     val checkin = checkinV2Repository.save(
       OffenderCheckinV2(
         uuid = UUID.randomUUID(),
         offender = offender,
-        status = CheckinV2Status.SUBMITTED,
+        status = CheckinV2Status.CREATED,
         dueDate = LocalDate.now(),
         createdAt = Instant.now(),
-        createdBy = "PRACT001",
-        surveyResponse = mapOf(
-          "version" to "2025-07-10@pilot",
+        createdBy = offender.practitionerId,
+      ),
+    )
+
+    whenever(s3UploadService.isCheckinVideoUploaded(any())).thenReturn(true)
+    val submissionResult = checkinV2Service.submitCheckin(
+      checkin.uuid,
+      SubmitCheckinV2Request(
+        survey = mapOf(
+          "version" to SurveyVersion.V20250710pilot.version,
           "mentalHealth" to "STRUGGLING",
           "callback" to "YES",
           "assistance" to listOf("HELP"),
@@ -212,30 +202,24 @@ class CheckinV2ServiceIntegrationTest : IntegrationTestBase() {
 
   @Test
   fun `getCheckin - with non-flagged survey answers - returns empty flaggedResponses`() {
-    val offender = offenderV2Repository.save(
-      OffenderV2(
-        uuid = UUID.randomUUID(),
-        crn = "X345678",
-        practitionerId = "PRACT001",
-        firstCheckin = LocalDate.now(),
-        checkinInterval = Duration.ofDays(7),
-        createdAt = Instant.now(),
-        createdBy = "SYSTEM",
-        updatedAt = Instant.now(),
-        contactPreference = ContactPreference.PHONE,
-      ),
-    )
-
+    val offender = offenderV2Repository.save(offenderTemplate.copy(crn = "X345678").toEntity())
     val checkin = checkinV2Repository.save(
       OffenderCheckinV2(
         uuid = UUID.randomUUID(),
         offender = offender,
-        status = CheckinV2Status.SUBMITTED,
+        status = CheckinV2Status.CREATED,
         dueDate = LocalDate.now(),
         createdAt = Instant.now(),
-        createdBy = "PRACT001",
-        surveyResponse = mapOf(
-          "version" to "2025-07-10@pilot",
+        createdBy = offender.practitionerId,
+      ),
+    )
+
+    whenever(s3UploadService.isCheckinVideoUploaded(any())).thenReturn(true)
+    checkinV2Service.submitCheckin(
+      checkin.uuid,
+      SubmitCheckinV2Request(
+        survey = mapOf(
+          "version" to SurveyVersion.V20250710pilot.version,
           "mentalHealth" to "GREAT",
           "callback" to "NO",
           "assistance" to listOf("NO_HELP"),
@@ -247,5 +231,53 @@ class CheckinV2ServiceIntegrationTest : IntegrationTestBase() {
 
     assertNotNull(result.flaggedResponses)
     assertTrue(result.flaggedResponses.isEmpty(), "Expected flaggedResponses to be empty, but found: ${result.flaggedResponses}")
+  }
+
+  @Test
+  fun `annotateCheckin - happy path`() {
+    val offender = offenderV2Repository.save(offenderTemplate.copy(crn = "X345678").toEntity())
+    val checkin = checkinV2Repository.save(
+      OffenderCheckinV2(
+        uuid = UUID.randomUUID(),
+        offender = offender,
+        status = CheckinV2Status.CREATED,
+        dueDate = LocalDate.now(),
+        createdAt = Instant.now(),
+        createdBy = offender.practitionerId,
+      ),
+    )
+
+    whenever(s3UploadService.isCheckinVideoUploaded(any())).thenReturn(true)
+    checkinV2Service.submitCheckin(checkin.uuid, SubmitCheckinV2Request(survey = mapOf("version" to SurveyVersion.V20250710pilot.version)))
+
+    val reviewResult = checkinV2Service.reviewCheckin(
+      checkin.uuid,
+      ReviewCheckinV2Request(
+        reviewedBy = offender.practitionerId,
+        manualIdCheck = ManualIdVerificationResult.MATCH,
+        notes = "Test note",
+      ),
+    )
+    assertEquals(CheckinV2Status.REVIEWED, reviewResult.status)
+
+    val annotationResult = checkinV2Service.annotateCheckin(
+      checkin.uuid,
+      AnnotateCheckinV2Request(
+        updatedBy = offender.practitionerId,
+        notes = "Looking good",
+        sensitive = false,
+      ),
+    )
+    assertEquals(CheckinV2Status.REVIEWED, annotationResult.status)
+
+    val result = checkinV2Service.getCheckin(checkin.uuid, includePersonalDetails = false)
+    result.checkinLogs.logs.first().let {
+      assertEquals(LogEntryType.OFFENDER_CHECKIN_ANNOTATED, it.logEntryType)
+      assertEquals("Looking good", it.notes)
+    }
+
+    val annotationEvent = offenderEventLogV2Repository.findAll().first { it.logEntryType == LogEntryType.OFFENDER_CHECKIN_ANNOTATED && it.checkin == checkin.id }
+    // note: we don't care about the status of the outbox item, just that it's there
+    outboxItemRepository.findByTypeAndEntityId(OutboxItemType.CHECKIN_ANNOTATED, annotationEvent.id).orElseThrow()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/CheckinV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/CheckinV2ServiceTest.kt
@@ -512,13 +512,7 @@ class CheckinV2ServiceTest {
 
     assertEquals(true, checkin.sensitive)
     assertEquals(true, result.sensitive)
-    verify(checkinRepository).save(checkin)
-
-    verify(offenderEventLogRepository).save(
-      argThat {
-        sensitive == true && comment == "Added sensitive medical evidence"
-      },
-    )
+    verify(checkinPersistenceService).checkinAnnotation(argThat { sensitive }, any(), any())
   }
 
   @Test
@@ -550,10 +544,12 @@ class CheckinV2ServiceTest {
     assertEquals(false, result.sensitive)
     verify(checkinRepository, never()).save(checkin)
 
-    verify(offenderEventLogRepository).save(
+    verify(checkinPersistenceService).checkinAnnotation(
       argThat {
-        sensitive == false && comment == "Test notes"
+        sensitive == false
       },
+      any(),
+      any(),
     )
   }
 
@@ -621,12 +617,7 @@ class CheckinV2ServiceTest {
     service.annotateCheckin(uuid, AnnotateCheckinV2Request("P1", "Note", sensitive = false))
 
     assertEquals(true, checkin.sensitive)
-    verify(checkinRepository, never()).save(checkin)
-    verify(offenderEventLogRepository).save(
-      argThat {
-        sensitive == true && comment == "Note"
-      },
-    )
+    verify(checkinPersistenceService).checkinAnnotation(argThat { sensitive }, any(), any())
   }
 
   @Test


### PR DESCRIPTION
Refactors `CheckinV2Service.annotateCheckin()` method to use events and removes `@Transactional` annotation from it