### PR TITLE
Esup 1820/reinstate face match rekognition bean

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/rekognition/RekognitionV2Config.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/rekognition/RekognitionV2Config.kt
@@ -24,7 +24,7 @@ import java.time.Duration
 @Profile("!test & !stubrekog")
 @Configuration
 class RekognitionV2Config(
-  @Value("\${rekognition.region}") private val region: String,
+  @Value("\${rekognition.region}") private val facematchRegion: String,
   @Value("\${rekognition.liveness.region}") private val livenessRegion: String,
   @Value("\${rekognition.role_arn}") private val roleArn: String,
   @Value("\${rekognition.role_session_name}") private val roleSessionName: String,
@@ -34,7 +34,7 @@ class RekognitionV2Config(
 
   @Bean
   fun rekognitionCredentialsProvider(): AwsCredentialsProvider {
-    val stsClient = StsClient.builder().region(Region.of(region))
+    val stsClient = StsClient.builder().region(Region.of(facematchRegion))
       .credentialsProvider(DefaultCredentialsProvider.builder().build())
       .build()
 
@@ -54,11 +54,11 @@ class RekognitionV2Config(
    * in its own region, so `rekognition.region` MUST match the image bucket's region.
    * Kept distinct from the liveness client below, which runs in its own region.
    */
-  @Bean(name = ["rekognitionAsyncClient"])
-  fun rekognitionAsyncClient(rekognitionCredentialsProvider: AwsCredentialsProvider): RekognitionAsyncClient {
-    LOGGER.info("Creating Rekognition async client for face matching in region {}", region)
+  @Bean(name = ["facematchRekognitionAsyncClient"])
+  fun facematchRekognitionAsyncClient(rekognitionCredentialsProvider: AwsCredentialsProvider): RekognitionAsyncClient {
+    LOGGER.info("Creating Rekognition async client for face matching in region {}", facematchRegion)
     return RekognitionAsyncClient.builder()
-      .region(Region.of(region))
+      .region(Region.of(facematchRegion))
       .credentialsProvider(rekognitionCredentialsProvider)
       .httpClientBuilder {
         NettyNioAsyncHttpClient.builder()
@@ -71,10 +71,10 @@ class RekognitionV2Config(
 
   @Bean
   fun offenderIdVerifierV2(
-    @Qualifier("rekognitionAsyncClient") rekognitionAsyncClient: RekognitionAsyncClient,
+    @Qualifier("facematchRekognitionAsyncClient") facematchRekognitionAsyncClient: RekognitionAsyncClient,
   ): OffenderIdVerifier {
     LOGGER.info("Creating V2 RekognitionCompareFacesService with real AWS Rekognition (async)")
-    return RekognitionCompareFacesService(rekognitionAsyncClient)
+    return RekognitionCompareFacesService(facematchRekognitionAsyncClient)
   }
 
   /** Separate Rekognition client for Face Liveness in eu-west-1 */

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/rekognition/RekognitionV2Config.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/rekognition/RekognitionV2Config.kt
@@ -49,10 +49,10 @@ class RekognitionV2Config(
   }
 
   /**
-   * Rekognition client for face matching (CompareFaces), in eu-west-2.
+   * Rekognition client for face matching (CompareFaces).
    * CompareFaces reads its images from S3, and Rekognition can only read a bucket
-   * in its own region, so this MUST be the same region as the image bucket (eu-west-2).
-   * Kept distinct from the eu-west-1 liveness client below.
+   * in its own region, so `rekognition.region` MUST match the image bucket's region.
+   * Kept distinct from the liveness client below, which runs in its own region.
    */
   @Bean(name = ["rekognitionAsyncClient"])
   fun rekognitionAsyncClient(rekognitionCredentialsProvider: AwsCredentialsProvider): RekognitionAsyncClient {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/rekognition/RekognitionV2Config.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/rekognition/RekognitionV2Config.kt
@@ -48,8 +48,31 @@ class RekognitionV2Config(
       }.build()
   }
 
+  /**
+   * Rekognition client for face matching (CompareFaces), in eu-west-2.
+   * CompareFaces reads its images from S3, and Rekognition can only read a bucket
+   * in its own region, so this MUST be the same region as the image bucket (eu-west-2).
+   * Kept distinct from the eu-west-1 liveness client below.
+   */
+  @Bean(name = ["rekognitionAsyncClient"])
+  fun rekognitionAsyncClient(rekognitionCredentialsProvider: AwsCredentialsProvider): RekognitionAsyncClient {
+    LOGGER.info("Creating Rekognition async client for face matching in region {}", region)
+    return RekognitionAsyncClient.builder()
+      .region(Region.of(region))
+      .credentialsProvider(rekognitionCredentialsProvider)
+      .httpClientBuilder {
+        NettyNioAsyncHttpClient.builder()
+          .maxConcurrency(maxConcurrency)
+          .readTimeout(Duration.ofSeconds(readTimeoutSeconds))
+          .build()
+      }
+      .build()
+  }
+
   @Bean
-  fun offenderIdVerifierV2(rekognitionAsyncClient: RekognitionAsyncClient): OffenderIdVerifier {
+  fun offenderIdVerifierV2(
+    @Qualifier("rekognitionAsyncClient") rekognitionAsyncClient: RekognitionAsyncClient,
+  ): OffenderIdVerifier {
     LOGGER.info("Creating V2 RekognitionCompareFacesService with real AWS Rekognition (async)")
     return RekognitionCompareFacesService(rekognitionAsyncClient)
   }


### PR DESCRIPTION
Reintroduce a separate rekognition client running in the specified face match aws region