### PR TITLE
ESUP-1713 Implement stops for in-reset & no events

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -31,7 +31,6 @@ generic-service:
     CHECKIN_LEGACY_CLEANUP_ENABLED: "true"
     CHECKIN_LEGACY_CLEANUP_DRY_RUN: "false"
     APP_FEATURES_ESUP_1239: "true"
-    APP_FEATURES_ESUP_1183: "true"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -31,7 +31,6 @@ generic-service:
     CHECKIN_LEGACY_CLEANUP_ENABLED: "true"
     CHECKIN_LEGACY_CLEANUP_DRY_RUN: "false"
     APP_FEATURES_ESUP_1239: "true"
-    APP_FEATURES_ESUP_1183: "true"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -27,7 +27,6 @@ generic-service:
     CHECKIN_LEGACY_CLEANUP_ENABLED: "true"
     CHECKIN_LEGACY_CLEANUP_DRY_RUN: "false"
     APP_FEATURES_ESUP_1239: "true"
-    APP_FEATURES_ESUP_1183: "true"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -22,7 +22,6 @@ generic-service:
     APP_ENV: "TEST"
     APP_SCHEDULING_MIGRATION_EVENT_REPLAY_CRON: "-"
     APP_FEATURES_ESUP_1239: "true"
-    APP_FEATURES_ESUP_1183: "true"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/AppConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/AppConfig.kt
@@ -13,11 +13,9 @@ class AppConfig(
   @Value("\${app.hostedAt}") private val hostedAt: String,
   @Value("\${app.scheduling.checkin-notification.cron}") val checkinNotificationCron: String,
   @Value("\${app.features.esup-1239}") val esup1239ProxyLinks: Boolean,
-  @Value("\${app.features.esup-1183}") val esup1183SendInviteOnlyWhenActiveEvent: Boolean,
   @Value("\${app.features.upload-content-hash.require:false}") val uploadContentHashRequire: Boolean,
   val enabledFeatures: Set<Feature> = listOfNotNull(
     if (esup1239ProxyLinks) Feature.ESUP_1239 else null,
-    if (esup1183SendInviteOnlyWhenActiveEvent) Feature.ESUP_1183 else null,
     if (uploadContentHashRequire) Feature.ESUP_1672_REQUIRE_UPLOAD_CONTENT_HASH else null,
   ).toSet(),
 ) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/Feature.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/Feature.kt
@@ -7,11 +7,6 @@ enum class Feature {
   ESUP_1239,
 
   /**
-   * ESUP-1183: Ensure a POP is still on probation before sending them a check in link
-   */
-  ESUP_1183,
-
-  /**
    * ESUP-1672: Require a SHA-256 content hash when requesting presigned upload URLs
    */
   ESUP_1672_REQUIRE_UPLOAD_CONTENT_HASH,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorV2Service.kt
@@ -4,7 +4,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.esupervisionapi.config.AppConfig
-import uk.gov.justice.digital.hmpps.esupervisionapi.config.Feature
 import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.NotificationType
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.today
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.audit.EventAuditV2Service
@@ -214,14 +213,6 @@ class NotificationOrchestratorV2Service(
     checkin: OffenderCheckinV2,
     contactDetails: ContactDetails,
   ) {
-    if (appConfig.enabledFeatures.contains(Feature.ESUP_1183)) {
-      val activeEventNumber = activeEventNumber(checkin.offender, contactDetails)
-      if (activeEventNumber == null) {
-        LOGGER.warn("Skipping checkin created notifications for checkin {}: no active events found", checkin.uuid)
-        return
-      }
-    }
-
     domainEventService.publishDomainEvent(
       eventType = DomainEventType.V2_CHECKIN_CREATED,
       uuid = checkin.uuid,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
@@ -76,6 +76,16 @@ data class ContactDetails(
     required = false,
   )
   val events: List<Event>? = null,
+
+  /**
+   * Note: true when the person is "in reset" - their contact has been suspended in NDelius
+   * and we should stop sending them online check-ins.
+   */
+  @field:Schema(
+    description = "True when the person's contact has been suspended (in reset) in NDelius.",
+    required = false,
+  )
+  val contactSuspended: Boolean = false,
 )
 
 /** Person's name from Ndilius */

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Repositories.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Repositories.kt
@@ -150,6 +150,17 @@ interface OffenderCheckinV2Repository : JpaRepository<OffenderCheckinV2, Long> {
 
   @Query(
     """
+    UPDATE OffenderCheckinV2 c
+    SET c.status = :newStatus
+    WHERE c.offender = :offender
+      AND c.status = :currentStatus
+    """,
+  )
+  @Modifying
+  fun updateStatusForOffender(offender: OffenderV2, currentStatus: CheckinV2Status, newStatus: CheckinV2Status): Int
+
+  @Query(
+    """
     SELECT c FROM OffenderCheckinV2 c
     JOIN FETCH c.offender
     WHERE c.status = 'CREATED'

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/audit/EventAuditV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/audit/EventAuditV2Service.kt
@@ -112,9 +112,14 @@ class EventAuditV2Service(
   fun recordCheckinReminded(checkins: Iterable<Pair<OffenderCheckinV2, ContactDetails?>>) = recordCheckinEvents(CheckinAuditEventType.CHECKIN_REMINDER, checkins)
 
   fun recordOffenderEvent(eventType: OffenderAuditEventType, offender: OffenderV2, contactDetails: ContactDetails?, notes: String?, sensitive: Boolean = false) {
-    if (contactDetails?.practitioner == null) {
-      LOGGER.warn("Cannot record audit event {} for CRN {}: practitioner details not found", eventType.name, offender.crn)
+    if (contactDetails == null) {
+      LOGGER.warn("Cannot record audit event {} for CRN {}: contact details not found", eventType.name, offender.crn)
       return
+    }
+    if (contactDetails.practitioner == null) {
+      // Still record the event (e.g. an automated deactivation of a POP in reset) - the practitioner
+      // org-unit columns are nullable, so we keep the audit trail rather than dropping it entirely.
+      LOGGER.warn("Recording audit event {} for CRN {} without practitioner organisation details", eventType.name, offender.crn)
     }
 
     try {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/audit/EventAuditV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/audit/EventAuditV2Service.kt
@@ -17,8 +17,16 @@ import java.util.UUID
 
 enum class OffenderAuditEventType {
   SETUP_COMPLETED,
+
+  /** Practitioner-initiated deactivation via the deactivate endpoint. */
   OFFENDER_DEACTIVATED,
   OFFENDER_REACTIVATED,
+
+  /** Automated deactivation by a scheduled job because the POP's NDelius contact is suspended (in reset). */
+  OFFENDER_AUTO_DEACTIVATED_CONTACT_SUSPENDED,
+
+  /** Automated deactivation by a scheduled job because the POP has no active probation events in NDelius. */
+  OFFENDER_AUTO_DEACTIVATED_NO_ACTIVE_EVENTS,
 }
 
 enum class CheckinAuditEventType {
@@ -173,6 +181,8 @@ class EventAuditV2Service(
       OffenderAuditEventType.SETUP_COMPLETED,
       OffenderAuditEventType.OFFENDER_REACTIVATED,
       OffenderAuditEventType.OFFENDER_DEACTIVATED,
+      OffenderAuditEventType.OFFENDER_AUTO_DEACTIVATED_CONTACT_SUSPENDED,
+      OffenderAuditEventType.OFFENDER_AUTO_DEACTIVATED_NO_ACTIVE_EVENTS,
       -> buildAudit(
         eventType.name,
         offender,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/Utils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/Utils.kt
@@ -25,6 +25,38 @@ fun activeEventNumber(offender: OffenderV2, details: ContactDetails): Long? {
 }
 
 /**
+ * Reasons a verified offender should no longer receive online check-ins.
+ * The [auditNote] is recorded against the automated deactivation audit event.
+ */
+enum class CheckinIneligibilityReason(val description: String) {
+  CONTACT_SUSPENDED("contact is suspended (in reset) in NDelius"),
+  NO_ACTIVE_EVENTS("there are no active probation events in NDelius"),
+  ;
+
+  /** Reason text recorded against an automated deactivation audit event. */
+  val auditNote: String get() = "Automatically deactivated: $description"
+}
+
+/**
+ * Determines whether an offender should be stopped from receiving online check-ins, based on the
+ * latest Delius contact details. Returns the reason, or null if the offender is still eligible.
+ *
+ * Stops check-ins when the person is in reset (contact suspended) or has no active probation events.
+ *
+ * Note on no-active-events: we only treat this as grounds for stopping when NDelius returns an
+ * explicitly empty events list. An absent/null events list is treated as indeterminate (e.g. a
+ * partial or degraded response) and does NOT stop check-ins, so a transient data gap can't wrongly
+ * off-board an active person. A cached [OffenderV2.currentEvent] always counts as an active event.
+ *
+ * @see activeEventNumber
+ */
+fun checkinIneligibilityReason(offender: OffenderV2, details: ContactDetails): CheckinIneligibilityReason? = when {
+  details.contactSuspended -> CheckinIneligibilityReason.CONTACT_SUSPENDED
+  offender.currentEvent == null && details.events?.isEmpty() == true -> CheckinIneligibilityReason.NO_ACTIVE_EVENTS
+  else -> null
+}
+
+/**
  * Check if the date is a checkin day for the given offender
  */
 fun isCheckinDay(offender: CheckinSchedule, date: LocalDate): Boolean {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/Utils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/Utils.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.esupervisionapi.v2.checkin
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinSchedule
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.ContactDetails
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.audit.OffenderAuditEventType
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 
@@ -28,12 +29,22 @@ fun activeEventNumber(offender: OffenderV2, details: ContactDetails): Long? {
  * Reasons a verified offender should no longer receive online check-ins.
  * The [auditNote] is recorded against the automated deactivation audit event.
  */
-enum class CheckinIneligibilityReason(val description: String) {
-  CONTACT_SUSPENDED("contact is suspended (in reset) in NDelius"),
-  NO_ACTIVE_EVENTS("there are no active probation events in NDelius"),
+enum class CheckinIneligibilityReason(
+  val description: String,
+  /** The audit event type recorded when a scheduled job stops check-ins for this reason. */
+  val auditEventType: OffenderAuditEventType,
+) {
+  CONTACT_SUSPENDED(
+    "contact is suspended (in reset) in NDelius",
+    OffenderAuditEventType.OFFENDER_AUTO_DEACTIVATED_CONTACT_SUSPENDED,
+  ),
+  NO_ACTIVE_EVENTS(
+    "there are no active probation events in NDelius",
+    OffenderAuditEventType.OFFENDER_AUTO_DEACTIVATED_NO_ACTIVE_EVENTS,
+  ),
   ;
 
-  /** Reason text recorded against an automated deactivation audit event. */
+  /** Human-readable reason text recorded in the audit event's notes. */
   val auditNote: String get() = "Automatically deactivated: $description"
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/V2CheckinCreationJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/V2CheckinCreationJob.kt
@@ -9,8 +9,6 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
-import uk.gov.justice.digital.hmpps.esupervisionapi.config.AppConfig
-import uk.gov.justice.digital.hmpps.esupervisionapi.config.Feature
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.ContactDetails
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.INdiliusApiClient
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.JobLogV2
@@ -23,7 +21,8 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2Reposito
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.checkin.BatchCheckinCreationException
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.checkin.CheckinCreationService
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.checkin.activeEventNumber
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.checkin.checkinIneligibilityReason
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.offender.OffenderDeactivationV2Service
 import java.time.Clock
 import java.time.Duration
 import java.time.LocalDate
@@ -33,6 +32,7 @@ import kotlin.streams.asSequence
 private class JobMetrics {
   var processed = 0
   var created = 0
+  var deactivated = 0
   var errors = 0
   var notifsSent = 0
   var chunks = 0
@@ -40,10 +40,11 @@ private class JobMetrics {
 
 private fun JobMetrics.info(logger: Logger, jobId: Long, duration: Duration) {
   logger.info(
-    "Checkin Creation Job(id={}) completed: processed={}, created={}, failed={}, notifications={}, chunks={}, took={}",
+    "Checkin Creation Job(id={}) completed: processed={}, created={}, deactivated={}, failed={}, notifications={}, chunks={}, took={}",
     jobId,
     this.processed,
     this.created,
+    this.deactivated,
     this.errors,
     this.notifsSent,
     this.chunks,
@@ -64,10 +65,10 @@ class V2CheckinCreationJob(
   private val ndiliusApiClient: INdiliusApiClient,
   private val checkinCreationService: CheckinCreationService,
   private val notificationService: NotificationV2Service,
+  private val offenderDeactivationV2Service: OffenderDeactivationV2Service,
   private val jobLogRepository: JobLogV2Repository,
   @PersistenceContext private val entityManager: EntityManager,
   @param:Value("\${app.scheduling.v2-checkin-creation.chunk-size}") private val chunkSize: Int,
-  private val appConfig: AppConfig,
 ) {
   @Scheduled(cron = "\${app.scheduling.v2-checkin-creation.cron}")
   @SchedulerLock(
@@ -105,17 +106,22 @@ class V2CheckinCreationJob(
 
               val checkinsToCreate = mutableListOf<Pair<OffenderCheckinV2, ContactDetails>>()
               for (crn in contactDetailsMap.keys) {
-                val checkin = checkinCreationService.prepareCheckinForOffender(offendersByCrn[crn]!!, today)
+                val offender = offendersByCrn[crn]!!
                 val contactDetails = contactDetailsMap[crn]!!
-                if (appConfig.enabledFeatures.contains(Feature.ESUP_1183)) {
-                  val eventNumber = activeEventNumber(checkin.offender, contactDetails)
-                  if (eventNumber != null) {
-                    checkinsToCreate.add(Pair(checkin, contactDetails))
-                    LOGGER.debug("Will create checkin for CRN {}: active event number is {}", crn, eventNumber)
-                  } else {
-                    LOGGER.info("Skipping checkin for CRN {}: no active events found", crn)
+                val ineligibility = checkinIneligibilityReason(offender, contactDetails)
+                if (ineligibility != null) {
+                  // POP is no longer eligible (no active events, or in reset) - stop their online check-ins.
+                  // Isolate failures per-offender so one bad deactivation doesn't abort the whole run.
+                  LOGGER.info("Deactivating CRN {} instead of creating checkin: {}", crn, ineligibility.name)
+                  try {
+                    offenderDeactivationV2Service.deactivateOffender(offender, ineligibility.auditNote, contactDetails)
+                    metrics.deactivated += 1
+                  } catch (e: Exception) {
+                    LOGGER.warn("Failed to deactivate CRN {} in chunk {}", crn, metrics.chunks, e)
+                    metrics.errors += 1
                   }
                 } else {
+                  val checkin = checkinCreationService.prepareCheckinForOffender(offender, today)
                   checkinsToCreate.add(Pair(checkin, contactDetails))
                 }
               }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/V2CheckinCreationJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/V2CheckinCreationJob.kt
@@ -114,7 +114,12 @@ class V2CheckinCreationJob(
                   // Isolate failures per-offender so one bad deactivation doesn't abort the whole run.
                   LOGGER.info("Deactivating CRN {} instead of creating checkin: {}", crn, ineligibility.name)
                   try {
-                    offenderDeactivationV2Service.deactivateOffender(offender, ineligibility.auditNote, contactDetails)
+                    offenderDeactivationV2Service.deactivateOffender(
+                      offender,
+                      ineligibility.auditNote,
+                      contactDetails,
+                      auditEventType = ineligibility.auditEventType,
+                    )
                     metrics.deactivated += 1
                   } catch (e: Exception) {
                     LOGGER.warn("Failed to deactivate CRN {} in chunk {}", crn, metrics.chunks, e)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/V2CheckinReminderJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/V2CheckinReminderJob.kt
@@ -17,6 +17,8 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.NotificationV2Service
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.audit.EventAuditV2Service
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.checkin.checkinIneligibilityReason
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.offender.OffenderDeactivationV2Service
 import java.time.Clock
 import java.time.Duration
 
@@ -33,6 +35,7 @@ class V2CheckinReminderJob(
   private val checkinRepository: OffenderCheckinV2Repository,
   private val ndiliusApiClient: INdiliusApiClient,
   private val notificationService: NotificationV2Service,
+  private val offenderDeactivationV2Service: OffenderDeactivationV2Service,
   private val jobLogRepository: JobLogV2Repository,
   private val transactionTemplate: TransactionTemplate,
   private val eventAuditService: EventAuditV2Service,
@@ -66,6 +69,7 @@ class V2CheckinReminderJob(
       }!!
 
     var totalReminded = 0
+    var totalDeactivated = 0
 
     // Find checkins eligible for reminder (if they were already sent one today, don't send again)
     // the prod job should only run once a day but local/dev environments could be sending duplicate reminders if they're set more frequently
@@ -83,8 +87,6 @@ class V2CheckinReminderJob(
       LOGGER.info("Found {} checkins eligible for reminder", checkins.size)
 
       if (checkins.isNotEmpty()) {
-        totalReminded = checkins.size
-
         // Fetch contact details in batches - NO transaction
         val crns = checkins.map { it.offender.crn }.distinct()
         val contactDetailsMap = mutableMapOf<String, ContactDetails>()
@@ -106,11 +108,24 @@ class V2CheckinReminderJob(
         checkins.forEachIndexed { index, checkin ->
           try {
             val contactDetails = contactDetailsMap[checkin.offender.crn]
-            if (contactDetails != null) {
-              notificationService.sendCheckinReminderNotifications(checkin, contactDetails)
-              sentNotifications.add(Pair(checkin, contactDetails))
-            } else {
-              notSentNotifications.add(index)
+            val ineligibility = contactDetails?.let { checkinIneligibilityReason(checkin.offender, it) }
+            val outcome = when {
+              contactDetails == null -> {
+                notSentNotifications.add(index)
+                "not sent (missing details)"
+              }
+              ineligibility != null -> {
+                // POP is no longer eligible (no active events, or in reset) - stop their online check-ins.
+                // Deactivation cancels this check-in, so it is NOT recorded as a reminder (notSent) below.
+                offenderDeactivationV2Service.deactivateOffender(checkin.offender, ineligibility.auditNote, contactDetails)
+                totalDeactivated += 1
+                "not sent (deactivated: ${ineligibility.name})"
+              }
+              else -> {
+                notificationService.sendCheckinReminderNotifications(checkin, contactDetails)
+                sentNotifications.add(Pair(checkin, contactDetails))
+                "sent"
+              }
             }
 
             LOGGER.info(
@@ -118,13 +133,15 @@ class V2CheckinReminderJob(
               checkin.uuid,
               checkin.offender.crn,
               checkin.dueDate,
-              if (contactDetails == null) "not sent (missing details)" else "sent",
+              outcome,
             )
           } catch (e: Exception) {
             LOGGER.warn("Failed to send reminder notification for checkin {}", checkin.uuid, e)
             notSentNotifications.add(index)
           }
         }
+
+        totalReminded = sentNotifications.size
 
         eventAuditService.recordCheckinReminded(sentNotifications)
 
@@ -145,8 +162,9 @@ class V2CheckinReminderJob(
     }
 
     LOGGER.info(
-      "V2 Checkin Reminder Job completed: reminded={}, took={}",
+      "V2 Checkin Reminder Job completed: reminded={}, deactivated={}, took={}",
       totalReminded,
+      totalDeactivated,
       Duration.between(now, endTime),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/V2CheckinReminderJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/V2CheckinReminderJob.kt
@@ -117,7 +117,12 @@ class V2CheckinReminderJob(
               ineligibility != null -> {
                 // POP is no longer eligible (no active events, or in reset) - stop their online check-ins.
                 // Deactivation cancels this check-in, so it is NOT recorded as a reminder (notSent) below.
-                offenderDeactivationV2Service.deactivateOffender(checkin.offender, ineligibility.auditNote, contactDetails)
+                offenderDeactivationV2Service.deactivateOffender(
+                  checkin.offender,
+                  ineligibility.auditNote,
+                  contactDetails,
+                  auditEventType = ineligibility.auditEventType,
+                )
                 totalDeactivated += 1
                 "not sent (deactivated: ${ineligibility.name})"
               }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderDeactivationV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderDeactivationV2Service.kt
@@ -6,7 +6,6 @@ import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinV2Status
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.ContactDetails
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.INdiliusApiClient
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.NotificationV2Service
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderSetupV2Repository
@@ -40,14 +39,13 @@ class OffenderDeactivationV2Service(
   private val questionService: QuestionService,
   private val eventAuditService: EventAuditV2Service,
   private val notificationService: NotificationV2Service,
-  private val ndiliusApiClient: INdiliusApiClient,
 ) {
 
   /**
    * Deactivate a VERIFIED offender. Idempotent: a no-op if the offender is not VERIFIED.
    *
    * @param reason recorded against the deactivation audit event
-   * @param contactDetails pre-fetched Delius details (avoids an extra call); fetched when null
+   * @param contactDetails Delius details fetched by the caller; downstream audit/notifications are skipped when null
    * @param sensitive whether the reason contains sensitive information
    * @param auditEventType the audit event type to record; defaults to a manual practitioner
    *   deactivation. Scheduled jobs pass a criterion-specific automated type so the reason an offender
@@ -81,25 +79,16 @@ class OffenderDeactivationV2Service(
     questionService.deleteUpcomingAssignment(saved.crn)
 
     // set any pending check ins to cancelled
-    val pendingCheckins = checkinRepository.findAllByOffenderAndStatus(saved, CheckinV2Status.CREATED)
-    if (pendingCheckins.isNotEmpty()) {
-      pendingCheckins.forEach { it.status = CheckinV2Status.CANCELLED }
-      checkinRepository.saveAll(pendingCheckins)
-      LOGGER.info("Cancelled {} created/pending check ins for CRN {} due to offender deactivation", pendingCheckins.size, saved.crn)
+    val cancelled = checkinRepository.updateStatusForOffender(saved, CheckinV2Status.CREATED, CheckinV2Status.CANCELLED)
+    if (cancelled > 0) {
+      LOGGER.info("Cancelled {} created/pending check ins for CRN {} due to offender deactivation", cancelled, saved.crn)
     }
 
-    val details = contactDetails ?: try {
-      ndiliusApiClient.getContactDetails(saved.crn)
-    } catch (e: Exception) {
-      LOGGER.info("Failed to get contact details for CRN {} from NDelius during deactivation", saved.crn, e)
-      null
-    }
-
-    eventAuditService.recordOffenderEvent(auditEventType, saved, details, reason, sensitive)
+    eventAuditService.recordOffenderEvent(auditEventType, saved, contactDetails, reason, sensitive)
 
     val setup = offenderSetupRepository.findByOffender(saved).orElse(null)
     try {
-      notificationService.sendDeactivationCompletedNotifications(saved, details, setup?.setupId())
+      notificationService.sendDeactivationCompletedNotifications(saved, contactDetails, setup?.setupId())
     } catch (e: Exception) {
       LOGGER.warn("Failed to send deactivation completed notifications for offender {}", saved.uuid, e)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderDeactivationV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderDeactivationV2Service.kt
@@ -91,14 +91,18 @@ class OffenderDeactivationV2Service(
     val details = contactDetails ?: try {
       ndiliusApiClient.getContactDetails(saved.crn)
     } catch (e: Exception) {
-      LOGGER.info("Failed to get contact details for CRN {} from NDelius during deactivation", saved.crn)
+      LOGGER.info("Failed to get contact details for CRN {} from NDelius during deactivation", saved.crn, e)
       null
     }
 
     eventAuditService.recordOffenderEvent(auditEventType, saved, details, reason, sensitive)
 
     val setup = offenderSetupRepository.findByOffender(saved).orElse(null)
-    notificationService.sendDeactivationCompletedNotifications(saved, details, setup?.setupId())
+    try {
+      notificationService.sendDeactivationCompletedNotifications(saved, details, setup?.setupId())
+    } catch (e: Exception) {
+      LOGGER.warn("Failed to send deactivation completed notifications for offender {}", saved.uuid, e)
+    }
 
     return saved
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderDeactivationV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderDeactivationV2Service.kt
@@ -49,6 +49,9 @@ class OffenderDeactivationV2Service(
    * @param reason recorded against the deactivation audit event
    * @param contactDetails pre-fetched Delius details (avoids an extra call); fetched when null
    * @param sensitive whether the reason contains sensitive information
+   * @param auditEventType the audit event type to record; defaults to a manual practitioner
+   *   deactivation. Scheduled jobs pass a criterion-specific automated type so the reason an offender
+   *   was stopped (in reset vs no active events) is queryable via the audit event_type.
    * @return the (possibly unchanged) offender
    *
    * Runs in its own transaction (REQUIRES_NEW) so that a deactivation commits independently of any
@@ -64,6 +67,7 @@ class OffenderDeactivationV2Service(
     reason: String,
     contactDetails: ContactDetails? = null,
     sensitive: Boolean = false,
+    auditEventType: OffenderAuditEventType = OffenderAuditEventType.OFFENDER_DEACTIVATED,
   ): OffenderV2 {
     if (offender.status != OffenderStatus.VERIFIED) {
       LOGGER.info("Skipping deactivation for CRN {}: status is {}", offender.crn, offender.status)
@@ -91,7 +95,7 @@ class OffenderDeactivationV2Service(
       null
     }
 
-    eventAuditService.recordOffenderEvent(OffenderAuditEventType.OFFENDER_DEACTIVATED, saved, details, reason, sensitive)
+    eventAuditService.recordOffenderEvent(auditEventType, saved, details, reason, sensitive)
 
     val setup = offenderSetupRepository.findByOffender(saved).orElse(null)
     notificationService.sendDeactivationCompletedNotifications(saved, details, setup?.setupId())

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderDeactivationV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderDeactivationV2Service.kt
@@ -1,0 +1,105 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.v2.offender
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinV2Status
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.ContactDetails
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.INdiliusApiClient
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.NotificationV2Service
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2Repository
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderSetupV2Repository
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2Repository
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.audit.EventAuditV2Service
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.audit.OffenderAuditEventType
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.OffenderStatus
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.question.QuestionService
+import java.time.Clock
+
+/**
+ * Encapsulates the offender deactivation flow so it can be reused by both the
+ * practitioner-initiated endpoint ([OffenderV2Resource.deactivateOffender]) and the
+ * scheduled jobs that detect offenders who should no longer receive online check-ins
+ * (no active probation events, or contact suspended/in reset in NDelius).
+ *
+ * Deactivating an offender:
+ * - sets their status to INACTIVE
+ * - cancels any pending (CREATED) check-ins
+ * - deletes any upcoming question list assignment
+ * - records an OFFENDER_DEACTIVATED audit event
+ * - sends "check-ins stopped" notifications (publishes V2_SETUP_REMOVED)
+ */
+@Service
+class OffenderDeactivationV2Service(
+  private val clock: Clock,
+  private val offenderRepository: OffenderV2Repository,
+  private val checkinRepository: OffenderCheckinV2Repository,
+  private val offenderSetupRepository: OffenderSetupV2Repository,
+  private val questionService: QuestionService,
+  private val eventAuditService: EventAuditV2Service,
+  private val notificationService: NotificationV2Service,
+  private val ndiliusApiClient: INdiliusApiClient,
+) {
+
+  /**
+   * Deactivate a VERIFIED offender. Idempotent: a no-op if the offender is not VERIFIED.
+   *
+   * @param reason recorded against the deactivation audit event
+   * @param contactDetails pre-fetched Delius details (avoids an extra call); fetched when null
+   * @param sensitive whether the reason contains sensitive information
+   * @return the (possibly unchanged) offender
+   *
+   * Runs in its own transaction (REQUIRES_NEW) so that a deactivation commits independently of any
+   * surrounding work. In particular, when called from [V2CheckinCreationJob]'s long-lived job
+   * transaction this prevents a failure in one offender's audit/persistence (which would otherwise
+   * mark the shared transaction rollback-only) from rolling back every other offender's check-in
+   * creation and deactivation in the same run. It also makes each deactivation atomic for the
+   * non-transactional callers (the reminder job and the deactivate endpoint).
+   */
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  fun deactivateOffender(
+    offender: OffenderV2,
+    reason: String,
+    contactDetails: ContactDetails? = null,
+    sensitive: Boolean = false,
+  ): OffenderV2 {
+    if (offender.status != OffenderStatus.VERIFIED) {
+      LOGGER.info("Skipping deactivation for CRN {}: status is {}", offender.crn, offender.status)
+      return offender
+    }
+
+    offender.status = OffenderStatus.INACTIVE
+    offender.updatedAt = clock.instant()
+    val saved = offenderRepository.save(offender)
+
+    questionService.deleteUpcomingAssignment(saved.crn)
+
+    // set any pending check ins to cancelled
+    val pendingCheckins = checkinRepository.findAllByOffenderAndStatus(saved, CheckinV2Status.CREATED)
+    if (pendingCheckins.isNotEmpty()) {
+      pendingCheckins.forEach { it.status = CheckinV2Status.CANCELLED }
+      checkinRepository.saveAll(pendingCheckins)
+      LOGGER.info("Cancelled {} created/pending check ins for CRN {} due to offender deactivation", pendingCheckins.size, saved.crn)
+    }
+
+    val details = contactDetails ?: try {
+      ndiliusApiClient.getContactDetails(saved.crn)
+    } catch (e: Exception) {
+      LOGGER.info("Failed to get contact details for CRN {} from NDelius during deactivation", saved.crn)
+      null
+    }
+
+    eventAuditService.recordOffenderEvent(OffenderAuditEventType.OFFENDER_DEACTIVATED, saved, details, reason, sensitive)
+
+    val setup = offenderSetupRepository.findByOffender(saved).orElse(null)
+    notificationService.sendDeactivationCompletedNotifications(saved, details, setup?.setupId())
+
+    return saved
+  }
+
+  companion object {
+    private val LOGGER = LoggerFactory.getLogger(OffenderDeactivationV2Service::class.java)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderV2Resource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderV2Resource.kt
@@ -29,12 +29,12 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.INdiliusApiClient
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.Name
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.NotificationV2Service
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2Repository
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderSetupV2Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.audit.EventAuditV2Service
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.audit.OffenderAuditEventType
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.checkin.CheckinCreationService
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.checkin.checkinIneligibilityReason
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.CheckinInterval
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ContactPreference
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ExternalUserId
@@ -44,7 +44,6 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.dto.Upload
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.dto.UploadLocationResponse
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.storage.S3UploadService
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.storage.resolveUploadHash
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.question.QuestionService
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.setup.OffenderSetupV2Service
 import java.time.Clock
 import java.time.Duration
@@ -63,9 +62,8 @@ class OffenderV2Resource(
   private val ndiliusApiClient: INdiliusApiClient,
   private val notificationV2Service: NotificationV2Service,
   private val checkinRepository: OffenderCheckinV2Repository,
-  private val offenderSetupRepository: OffenderSetupV2Repository,
   private val offenderSetupV2Service: OffenderSetupV2Service,
-  private val questionService: QuestionService,
+  private val offenderDeactivationV2Service: OffenderDeactivationV2Service,
   private val appConfig: AppConfig,
 ) {
 
@@ -221,25 +219,12 @@ class OffenderV2Resource(
       )
     }
 
-    offender.status = OffenderStatus.INACTIVE
-    offender.updatedAt = clock.instant()
-    val saved = offenderRepository.save(offender)
-
-    questionService.deleteUpcomingAssignment(offender.crn)
-
-    // set any pending check ins to cancelled
-    val pendingCheckins = checkinRepository.findAllByOffenderAndStatus(saved, CheckinV2Status.CREATED)
-    if (pendingCheckins.isNotEmpty()) {
-      pendingCheckins.forEach {
-        it.status = CheckinV2Status.CANCELLED
-      }
-      checkinRepository.saveAll(pendingCheckins)
-      LOGGER.info("Cancelled ${pendingCheckins.size} created/pending check ins for CRN ${saved.crn} due to offender deactivation")
-    }
-
-    recordOffenderAuditEvent(OffenderAuditEventType.OFFENDER_DEACTIVATED, offender, request.reason, request.sensitive)
-
-    val photoUrl = getOffenderPhotoUrl(saved)
+    val saved = offenderDeactivationV2Service.deactivateOffender(
+      offender,
+      reason = request.reason,
+      contactDetails = contactDetails,
+      sensitive = request.sensitive,
+    )
 
     LOGGER.info(
       "Deactivated offender: uuid={}, crn={}, requestedBy={}, reason={}, sensitive={}",
@@ -250,10 +235,7 @@ class OffenderV2Resource(
       request.sensitive,
     )
 
-    val setup = offenderSetupRepository.findByOffender(offender).orElse(null)
-    notificationV2Service.sendDeactivationCompletedNotifications(offender, contactDetails, setup?.setupId())
-
-    return ResponseEntity.ok(saved.toSummaryDto(photoUrl))
+    return ResponseEntity.ok(saved.toSummaryDto(getOffenderPhotoUrl(saved)))
   }
 
   @PreAuthorize("hasRole('ROLE_ESUPERVISION__ESUPERVISION_UI')")
@@ -294,6 +276,15 @@ class OffenderV2Resource(
       throw ResponseStatusException(
         HttpStatus.BAD_REQUEST,
         "Could not verify contact details in NDelius for ${offender.crn}.",
+      )
+    }
+
+    // Don't reactivate a POP who is no longer eligible for online check-ins (in reset, or no active
+    // events). Otherwise reactivation would send a check-in invite that the daily job then undoes.
+    checkinIneligibilityReason(offender, contactDetails)?.let { reason ->
+      throw ResponseStatusException(
+        HttpStatus.BAD_REQUEST,
+        "Cannot reactivate ${offender.crn}: ${reason.description}",
       )
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupV2Service.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2Dto
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.audit.EventAuditV2Service
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.checkin.checkinIneligibilityReason
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.OffenderStatus
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.exceptions.BadArgumentException
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.storage.S3UploadService
@@ -183,6 +184,15 @@ class OffenderSetupV2Service(
         LOGGER.warn("Failed to fetch contact details for CRN={}", offender.crn, e)
         null
       }
+
+    // Don't onboard a POP who is no longer eligible for online check-ins (no active events, or in
+    // reset). We only block when NDelius details are available - a transient fetch failure must not
+    // prevent setup completion. The daily creation job applies the same check on an ongoing basis.
+    if (contactDetails != null) {
+      checkinIneligibilityReason(offender, contactDetails)?.let { reason ->
+        throw BadArgumentException("Cannot complete setup for CRN ${offender.crn}: ${reason.description}")
+      }
+    }
 
     val now = clock.instant()
     offender.status = OffenderStatus.VERIFIED

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupV2Service.kt
@@ -221,7 +221,11 @@ class OffenderSetupV2Service(
       uuid,
       checkin?.uuid ?: "not due",
     )
-    notificationService.sendSetupCompletedNotifications(savedOffender, contactDetails, setup.setupId())
+    try {
+      notificationService.sendSetupCompletedNotifications(savedOffender, contactDetails, setup.setupId())
+    } catch (e: Exception) {
+      LOGGER.warn("Failed to send setup completed notifications for offender {}", savedOffender.uuid, e)
+    }
 
     checkin?.let {
       try {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -59,8 +59,6 @@ app:
   features:
     # publish media proxy links to NDelius
     esup-1239: true
-    # ensure a POP is still on probation before sending them a check in link
-    esup-1183: true
     # bind presigned upload URLs to the SHA-256 of the file content.
     # When a client supplies a hash the API always signs it into the URL and echoes
     # x-amz-checksum-sha256 in requiredHeaders. The flag below controls whether a hash is mandatory.

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/ContactDetailsDeserializationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/ContactDetailsDeserializationTest.kt
@@ -1,0 +1,35 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.v2
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Locks in the JSON contract for the NDelius `contactSuspended` flag - the trigger for the
+ * "in reset" deactivation. If the field name drifts, contactSuspended would silently default to
+ * false in production (feature no-op) while code that constructs the DTO directly still passes.
+ */
+class ContactDetailsDeserializationTest {
+
+  private val mapper = jacksonObjectMapper()
+
+  @Test
+  fun `contactSuspended deserializes from the NDelius json field`() {
+    val json = """{"crn":"X123456","name":{"forename":"John","surname":"Doe"},"contactSuspended":true}"""
+
+    val details = mapper.readValue<ContactDetails>(json)
+
+    assertTrue(details.contactSuspended)
+  }
+
+  @Test
+  fun `contactSuspended defaults to false when absent from the json`() {
+    val json = """{"crn":"X123456","name":{"forename":"John","surname":"Doe"}}"""
+
+    val details = mapper.readValue<ContactDetails>(json)
+
+    assertFalse(details.contactSuspended)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/audit/EventAuditV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/audit/EventAuditV2ServiceTest.kt
@@ -1,0 +1,78 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.v2.audit
+
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.springframework.transaction.support.TransactionCallback
+import org.springframework.transaction.support.TransactionTemplate
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.ContactDetails
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.EventAuditV2
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.EventAuditV2Repository
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.Name
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.PractitionerDetails
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.CheckinInterval
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ContactPreference
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.OffenderStatus
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.util.UUID
+
+class EventAuditV2ServiceTest {
+
+  private val clock = Clock.fixed(Instant.parse("2025-12-10T09:00:00Z"), ZoneId.of("UTC"))
+  private val auditRepository: EventAuditV2Repository = mock {
+    on { save(any<EventAuditV2>()) } doAnswer { it.arguments[0] as EventAuditV2 }
+  }
+  private val transactionTemplate: TransactionTemplate = mock {
+    on { execute<Any?>(any()) } doAnswer {
+      (it.getArgument(0) as TransactionCallback<Any?>).doInTransaction(mock())
+    }
+  }
+
+  private val service = EventAuditV2Service(auditRepository, clock, transactionTemplate)
+
+  private val offender = OffenderV2(
+    uuid = UUID.randomUUID(),
+    crn = "X123456",
+    practitionerId = "PRACT001",
+    status = OffenderStatus.INACTIVE,
+    firstCheckin = LocalDate.now(clock),
+    checkinInterval = CheckinInterval.WEEKLY.duration,
+    createdAt = clock.instant(),
+    createdBy = "SYSTEM",
+    updatedAt = clock.instant(),
+    contactPreference = ContactPreference.EMAIL,
+  )
+
+  @Test
+  fun `records the offender event when practitioner details are present`() {
+    val details = ContactDetails(crn = offender.crn, name = Name("John", "Doe"), practitioner = PractitionerDetails(Name("P", "Q")))
+
+    service.recordOffenderEvent(OffenderAuditEventType.OFFENDER_DEACTIVATED, offender, details, "reason")
+
+    verify(auditRepository).save(any())
+  }
+
+  @Test
+  fun `records the offender event even when practitioner details are missing`() {
+    // e.g. an automated deactivation of a POP in reset whose NDelius record has no practitioner
+    val details = ContactDetails(crn = offender.crn, name = Name("John", "Doe"), practitioner = null)
+
+    service.recordOffenderEvent(OffenderAuditEventType.OFFENDER_DEACTIVATED, offender, details, "no active events")
+
+    verify(auditRepository).save(any())
+  }
+
+  @Test
+  fun `skips recording when contact details are entirely absent`() {
+    service.recordOffenderEvent(OffenderAuditEventType.OFFENDER_DEACTIVATED, offender, null, "reason")
+
+    verify(auditRepository, never()).save(any())
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/UtilsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/UtilsTest.kt
@@ -1,16 +1,80 @@
 package uk.gov.justice.digital.hmpps.esupervisionapi.v2.checkin
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.esupervisionapi.datagen.offenderTemplate
 import uk.gov.justice.digital.hmpps.esupervisionapi.datagen.toEntity
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.today
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CodedDescription
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.ContactDetails
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.Event
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.Name
 import java.time.Clock
 import java.time.ZoneId
 
 class UtilsTest {
 
   val clock: Clock = Clock.system(ZoneId.of("Europe/London"))
+
+  private fun contactDetails(
+    events: List<Event>? = null,
+    contactSuspended: Boolean = false,
+  ) = ContactDetails(
+    crn = "X000000",
+    name = Name("John", "Doe"),
+    events = events,
+    contactSuspended = contactSuspended,
+  )
+
+  private val anEvent = Event(number = 1L, mainOffence = CodedDescription("X", "An offence"), sentence = null)
+
+  @Test
+  fun `checkinIneligibilityReason - contact suspended takes priority even with active events`() {
+    val offender = offenderTemplate.toEntity()
+    assertEquals(
+      CheckinIneligibilityReason.CONTACT_SUSPENDED,
+      checkinIneligibilityReason(offender, contactDetails(events = listOf(anEvent), contactSuspended = true)),
+    )
+  }
+
+  @Test
+  fun `checkinIneligibilityReason - no active events when events list is explicitly empty`() {
+    val offender = offenderTemplate.toEntity()
+    assertEquals(
+      CheckinIneligibilityReason.NO_ACTIVE_EVENTS,
+      checkinIneligibilityReason(offender, contactDetails(events = emptyList())),
+    )
+  }
+
+  @Test
+  fun `checkinIneligibilityReason - eligible when events list is absent (indeterminate, not empty)`() {
+    // A null/absent events list may indicate a partial or degraded NDelius response; it must not
+    // off-board an active person. Only an explicit empty list counts as "no active events".
+    val offender = offenderTemplate.toEntity()
+    assertNull(checkinIneligibilityReason(offender, contactDetails(events = null)))
+  }
+
+  @Test
+  fun `checkinIneligibilityReason - contact suspended deactivates even when events are absent`() {
+    val offender = offenderTemplate.toEntity()
+    assertEquals(
+      CheckinIneligibilityReason.CONTACT_SUSPENDED,
+      checkinIneligibilityReason(offender, contactDetails(events = null, contactSuspended = true)),
+    )
+  }
+
+  @Test
+  fun `checkinIneligibilityReason - eligible when an active event exists and not suspended`() {
+    val offender = offenderTemplate.toEntity()
+    assertNull(checkinIneligibilityReason(offender, contactDetails(events = listOf(anEvent))))
+  }
+
+  @Test
+  fun `checkinIneligibilityReason - eligible when offender has a cached current event`() {
+    val offender = offenderTemplate.toEntity().apply { currentEvent = 7L }
+    assertNull(checkinIneligibilityReason(offender, contactDetails(events = emptyList())))
+  }
 
   @Test
   fun `next checkin day`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/UtilsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/UtilsTest.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CodedDescription
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.ContactDetails
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.Event
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.Name
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.audit.OffenderAuditEventType
 import java.time.Clock
 import java.time.ZoneId
 
@@ -74,6 +75,18 @@ class UtilsTest {
   fun `checkinIneligibilityReason - eligible when offender has a cached current event`() {
     val offender = offenderTemplate.toEntity().apply { currentEvent = 7L }
     assertNull(checkinIneligibilityReason(offender, contactDetails(events = emptyList())))
+  }
+
+  @Test
+  fun `ineligibility reasons map to criterion-specific audit event types`() {
+    assertEquals(
+      OffenderAuditEventType.OFFENDER_AUTO_DEACTIVATED_CONTACT_SUSPENDED,
+      CheckinIneligibilityReason.CONTACT_SUSPENDED.auditEventType,
+    )
+    assertEquals(
+      OffenderAuditEventType.OFFENDER_AUTO_DEACTIVATED_NO_ACTIVE_EVENTS,
+      CheckinIneligibilityReason.NO_ACTIVE_EVENTS.auditEventType,
+    )
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/V2CheckinCreationJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/V2CheckinCreationJobTest.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2Repository
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.audit.OffenderAuditEventType
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.checkin.CheckinCreationService
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.CheckinInterval
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ContactPreference
@@ -73,7 +74,7 @@ class V2CheckinCreationJobTest {
     verify(checkinCreationService).prepareCheckinForOffender(eq(offender), any())
     verify(checkinCreationService).batchCreateCheckins(any())
     verify(notificationService).sendCheckinCreatedNotifications(any(), any())
-    verify(deactivationService, never()).deactivateOffender(any(), any(), any(), any())
+    verify(deactivationService, never()).deactivateOffender(any(), any(), any(), any(), any())
   }
 
   @Test
@@ -83,7 +84,7 @@ class V2CheckinCreationJobTest {
 
     job.process()
 
-    verify(deactivationService).deactivateOffender(eq(offender), any(), any(), any())
+    verify(deactivationService).deactivateOffender(eq(offender), any(), any(), any(), eq(OffenderAuditEventType.OFFENDER_AUTO_DEACTIVATED_CONTACT_SUSPENDED))
     verify(checkinCreationService, never()).prepareCheckinForOffender(any(), any())
     verify(notificationService, never()).sendCheckinCreatedNotifications(any(), any())
   }
@@ -95,7 +96,7 @@ class V2CheckinCreationJobTest {
 
     job.process()
 
-    verify(deactivationService).deactivateOffender(eq(offender), any(), any(), any())
+    verify(deactivationService).deactivateOffender(eq(offender), any(), any(), any(), eq(OffenderAuditEventType.OFFENDER_AUTO_DEACTIVATED_NO_ACTIVE_EVENTS))
     verify(checkinCreationService, never()).prepareCheckinForOffender(any(), any())
   }
 
@@ -107,7 +108,7 @@ class V2CheckinCreationJobTest {
     job.process()
 
     verify(checkinCreationService).prepareCheckinForOffender(eq(offender), any())
-    verify(deactivationService, never()).deactivateOffender(any(), any(), any(), any())
+    verify(deactivationService, never()).deactivateOffender(any(), any(), any(), any(), any())
   }
 
   @Test
@@ -121,7 +122,7 @@ class V2CheckinCreationJobTest {
         eligible.crn to details(eligible.crn, events = listOf(anEvent)),
       ),
     )
-    whenever(deactivationService.deactivateOffender(any(), any(), any(), any()))
+    whenever(deactivationService.deactivateOffender(any(), any(), any(), any(), any()))
       .thenThrow(RuntimeException("boom"))
 
     job.process()
@@ -129,7 +130,7 @@ class V2CheckinCreationJobTest {
     // the failure on the ineligible offender is isolated; the eligible offender is still processed.
     // NB: V2BaseEntity.equals() is id-based and unsaved test offenders share id=0, so match by
     // reference identity (same()) rather than eq() to assert the correct offender each time.
-    verify(deactivationService).deactivateOffender(same(ineligible), any(), any(), any())
+    verify(deactivationService).deactivateOffender(same(ineligible), any(), any(), any(), any())
     verify(checkinCreationService).prepareCheckinForOffender(same(eligible), any())
     verify(notificationService).sendCheckinCreatedNotifications(any(), any())
   }
@@ -142,7 +143,7 @@ class V2CheckinCreationJobTest {
 
     job.process()
 
-    verify(deactivationService, never()).deactivateOffender(any(), any(), any(), any())
+    verify(deactivationService, never()).deactivateOffender(any(), any(), any(), any(), any())
     verify(checkinCreationService, never()).prepareCheckinForOffender(any(), any())
   }
 
@@ -151,7 +152,7 @@ class V2CheckinCreationJobTest {
     whenever(ndiliusApiClient.getContactDetailsForMultiple(any())).thenReturn(detailsByCrn.values.toList())
     whenever(checkinCreationService.prepareCheckinForOffender(any(), any())).thenReturn(mock<OffenderCheckinV2>())
     whenever(checkinCreationService.batchCreateCheckins(any())).thenAnswer { it.getArgument(0) }
-    whenever(deactivationService.deactivateOffender(any(), any(), any(), any())).thenAnswer { it.getArgument<OffenderV2>(0) }
+    whenever(deactivationService.deactivateOffender(any(), any(), any(), any(), any())).thenAnswer { it.getArgument<OffenderV2>(0) }
   }
 
   private fun details(crn: String, events: List<Event>? = null, suspended: Boolean = false) = ContactDetails(crn = crn, name = Name("John", "Doe"), events = events, contactSuspended = suspended)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/V2CheckinCreationJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/V2CheckinCreationJobTest.kt
@@ -7,6 +7,7 @@ import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.same
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CodedDescription
@@ -125,9 +126,11 @@ class V2CheckinCreationJobTest {
 
     job.process()
 
-    // the failure on the ineligible offender is isolated; the eligible offender is still processed
-    verify(deactivationService).deactivateOffender(eq(ineligible), any(), any(), any())
-    verify(checkinCreationService).prepareCheckinForOffender(eq(eligible), any())
+    // the failure on the ineligible offender is isolated; the eligible offender is still processed.
+    // NB: V2BaseEntity.equals() is id-based and unsaved test offenders share id=0, so match by
+    // reference identity (same()) rather than eq() to assert the correct offender each time.
+    verify(deactivationService).deactivateOffender(same(ineligible), any(), any(), any())
+    verify(checkinCreationService).prepareCheckinForOffender(same(eligible), any())
     verify(notificationService).sendCheckinCreatedNotifications(any(), any())
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/V2CheckinCreationJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/V2CheckinCreationJobTest.kt
@@ -1,0 +1,168 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.v2.jobs
+
+import jakarta.persistence.EntityManager
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CodedDescription
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.ContactDetails
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.Event
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.INdiliusApiClient
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.JobLogV2
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.JobLogV2Repository
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.Name
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.NotificationV2Service
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2Repository
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2Repository
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.checkin.CheckinCreationService
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.CheckinInterval
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ContactPreference
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.OffenderStatus
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.offender.OffenderDeactivationV2Service
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.util.UUID
+import java.util.stream.Stream
+
+class V2CheckinCreationJobTest {
+
+  private val clock = Clock.fixed(Instant.parse("2025-12-10T09:00:00Z"), ZoneId.of("UTC"))
+  private val offenderRepository: OffenderV2Repository = mock()
+  private val checkinRepository: OffenderCheckinV2Repository = mock()
+  private val ndiliusApiClient: INdiliusApiClient = mock()
+  private val checkinCreationService: CheckinCreationService = mock()
+  private val notificationService: NotificationV2Service = mock()
+  private val deactivationService: OffenderDeactivationV2Service = mock()
+  private val jobLogRepository: JobLogV2Repository = mock {
+    on { saveAndFlush(any<JobLogV2>()) } doAnswer { it.arguments[0] as JobLogV2 }
+  }
+  private val entityManager: EntityManager = mock()
+
+  private val job = V2CheckinCreationJob(
+    clock,
+    offenderRepository,
+    checkinRepository,
+    ndiliusApiClient,
+    checkinCreationService,
+    notificationService,
+    deactivationService,
+    jobLogRepository,
+    entityManager,
+    chunkSize = 100,
+  )
+
+  private val anEvent = Event(number = 1L, mainOffence = CodedDescription("X", "An offence"), sentence = null)
+
+  @Test
+  fun `eligible offender - creates checkin, notifies, does not deactivate`() {
+    val offender = offender("X000001")
+    stubEligible(listOf(offender), mapOf(offender.crn to details(offender.crn, events = listOf(anEvent))))
+
+    job.process()
+
+    verify(checkinCreationService).prepareCheckinForOffender(eq(offender), any())
+    verify(checkinCreationService).batchCreateCheckins(any())
+    verify(notificationService).sendCheckinCreatedNotifications(any(), any())
+    verify(deactivationService, never()).deactivateOffender(any(), any(), any(), any())
+  }
+
+  @Test
+  fun `ineligible (contact suspended) - deactivates and creates no checkin`() {
+    val offender = offender("X000002")
+    stubEligible(listOf(offender), mapOf(offender.crn to details(offender.crn, events = listOf(anEvent), suspended = true)))
+
+    job.process()
+
+    verify(deactivationService).deactivateOffender(eq(offender), any(), any(), any())
+    verify(checkinCreationService, never()).prepareCheckinForOffender(any(), any())
+    verify(notificationService, never()).sendCheckinCreatedNotifications(any(), any())
+  }
+
+  @Test
+  fun `ineligible (explicitly no active events) - deactivates`() {
+    val offender = offender("X000003")
+    stubEligible(listOf(offender), mapOf(offender.crn to details(offender.crn, events = emptyList())))
+
+    job.process()
+
+    verify(deactivationService).deactivateOffender(eq(offender), any(), any(), any())
+    verify(checkinCreationService, never()).prepareCheckinForOffender(any(), any())
+  }
+
+  @Test
+  fun `absent events list is indeterminate - treated as eligible, not deactivated`() {
+    val offender = offender("X000004")
+    stubEligible(listOf(offender), mapOf(offender.crn to details(offender.crn, events = null)))
+
+    job.process()
+
+    verify(checkinCreationService).prepareCheckinForOffender(eq(offender), any())
+    verify(deactivationService, never()).deactivateOffender(any(), any(), any(), any())
+  }
+
+  @Test
+  fun `a deactivation failure for one offender does not abort the rest of the run`() {
+    val ineligible = offender("X000005")
+    val eligible = offender("X000006")
+    stubEligible(
+      listOf(ineligible, eligible),
+      mapOf(
+        ineligible.crn to details(ineligible.crn, events = emptyList()),
+        eligible.crn to details(eligible.crn, events = listOf(anEvent)),
+      ),
+    )
+    whenever(deactivationService.deactivateOffender(any(), any(), any(), any()))
+      .thenThrow(RuntimeException("boom"))
+
+    job.process()
+
+    // the failure on the ineligible offender is isolated; the eligible offender is still processed
+    verify(deactivationService).deactivateOffender(eq(ineligible), any(), any(), any())
+    verify(checkinCreationService).prepareCheckinForOffender(eq(eligible), any())
+    verify(notificationService).sendCheckinCreatedNotifications(any(), any())
+  }
+
+  @Test
+  fun `missing contact details - offender is neither deactivated nor given a checkin`() {
+    val offender = offender("X000007")
+    // contact details map is empty (NDelius returned nothing for this CRN)
+    stubEligible(listOf(offender), emptyMap())
+
+    job.process()
+
+    verify(deactivationService, never()).deactivateOffender(any(), any(), any(), any())
+    verify(checkinCreationService, never()).prepareCheckinForOffender(any(), any())
+  }
+
+  private fun stubEligible(offenders: List<OffenderV2>, detailsByCrn: Map<String, ContactDetails>) {
+    whenever(offenderRepository.findEligibleForCheckinCreation(any(), any())).thenReturn(Stream.of(*offenders.toTypedArray()))
+    whenever(ndiliusApiClient.getContactDetailsForMultiple(any())).thenReturn(detailsByCrn.values.toList())
+    whenever(checkinCreationService.prepareCheckinForOffender(any(), any())).thenReturn(mock<OffenderCheckinV2>())
+    whenever(checkinCreationService.batchCreateCheckins(any())).thenAnswer { it.getArgument(0) }
+    whenever(deactivationService.deactivateOffender(any(), any(), any(), any())).thenAnswer { it.getArgument<OffenderV2>(0) }
+  }
+
+  private fun details(crn: String, events: List<Event>? = null, suspended: Boolean = false) = ContactDetails(crn = crn, name = Name("John", "Doe"), events = events, contactSuspended = suspended)
+
+  private fun offender(crn: String) = OffenderV2(
+    uuid = UUID.randomUUID(),
+    crn = crn,
+    practitionerId = "PRACT001",
+    status = OffenderStatus.VERIFIED,
+    firstCheckin = LocalDate.now(clock),
+    checkinInterval = CheckinInterval.WEEKLY.duration,
+    createdAt = clock.instant(),
+    createdBy = "SYSTEM",
+    updatedAt = clock.instant(),
+    contactPreference = ContactPreference.EMAIL,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/V2CheckinReminderJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/V2CheckinReminderJobTest.kt
@@ -8,6 +8,7 @@ import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.same
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.transaction.support.TransactionCallback
@@ -76,7 +77,7 @@ class V2CheckinReminderJobTest {
 
     job.process()
 
-    verify(notificationService).sendCheckinReminderNotifications(eq(checkin), eq(cd))
+    verify(notificationService).sendCheckinReminderNotifications(same(checkin), eq(cd))
     verify(deactivationService, never()).deactivateOffender(any(), any(), any(), any())
   }
 
@@ -92,16 +93,19 @@ class V2CheckinReminderJobTest {
 
     job.process()
 
-    verify(deactivationService).deactivateOffender(eq(ineligible.offender), any(), any(), any())
-    verify(notificationService).sendCheckinReminderNotifications(eq(eligible), eq(eligibleCd))
-    verify(notificationService, never()).sendCheckinReminderNotifications(eq(ineligible), any())
+    // NB: V2BaseEntity.equals() is id-based and all unsaved test entities share id=0, so eq() cannot
+    // tell the instances apart - match by reference identity (same()/===) instead.
+    verify(deactivationService).deactivateOffender(same(ineligible.offender), any(), any(), any())
+    verify(notificationService).sendCheckinReminderNotifications(same(eligible), eq(eligibleCd))
+    verify(notificationService, never()).sendCheckinReminderNotifications(same(ineligible), any())
 
     // the deactivated checkin must NOT appear in any CHECKIN_REMINDER audit (it was cancelled)
     val captor = argumentCaptor<Iterable<Pair<OffenderCheckinV2, ContactDetails?>>>()
     verify(eventAuditService, org.mockito.kotlin.atLeastOnce()).recordCheckinReminded(captor.capture())
     val allAudited = captor.allValues.flatMap { it.toList() }.map { it.first }
-    assertThat(allAudited).contains(eligible, missing)
-    assertThat(allAudited).doesNotContain(ineligible)
+    assertThat(allAudited.any { it === eligible }).isTrue()
+    assertThat(allAudited.any { it === missing }).isTrue()
+    assertThat(allAudited.none { it === ineligible }).isTrue()
   }
 
   private fun stub(checkins: List<OffenderCheckinV2>, details: List<ContactDetails>) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/V2CheckinReminderJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/V2CheckinReminderJobTest.kt
@@ -1,0 +1,136 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.v2.jobs
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.transaction.support.TransactionCallback
+import org.springframework.transaction.support.TransactionTemplate
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CodedDescription
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.ContactDetails
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.Event
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.GenericNotificationV2Repository
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.INdiliusApiClient
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.JobLogV2
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.JobLogV2Repository
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.Name
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.NotificationV2Service
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2Repository
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.audit.EventAuditV2Service
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.CheckinInterval
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ContactPreference
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.OffenderStatus
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.offender.OffenderDeactivationV2Service
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.util.UUID
+import java.util.stream.Stream
+
+class V2CheckinReminderJobTest {
+
+  private val clock = Clock.fixed(Instant.parse("2025-12-10T09:00:00Z"), ZoneId.of("UTC"))
+  private val checkinRepository: OffenderCheckinV2Repository = mock()
+  private val ndiliusApiClient: INdiliusApiClient = mock()
+  private val notificationService: NotificationV2Service = mock()
+  private val deactivationService: OffenderDeactivationV2Service = mock()
+  private val jobLogRepository: JobLogV2Repository = mock {
+    on { saveAndFlush(any<JobLogV2>()) } doAnswer { it.arguments[0] as JobLogV2 }
+  }
+  private val transactionTemplate: TransactionTemplate = mock {
+    on { execute<Any?>(any()) } doAnswer {
+      (it.getArgument(0) as TransactionCallback<Any?>).doInTransaction(mock())
+    }
+  }
+  private val eventAuditService: EventAuditV2Service = mock()
+  private val genericNotificationV2Repository: GenericNotificationV2Repository = mock()
+
+  private val job = V2CheckinReminderJob(
+    clock,
+    checkinRepository,
+    ndiliusApiClient,
+    notificationService,
+    deactivationService,
+    jobLogRepository,
+    transactionTemplate,
+    eventAuditService,
+    genericNotificationV2Repository,
+  )
+
+  private val anEvent = Event(number = 1L, mainOffence = CodedDescription("X", "An offence"), sentence = null)
+
+  @Test
+  fun `eligible checkin is reminded and not deactivated`() {
+    val checkin = checkin("X000001")
+    val cd = details("X000001", events = listOf(anEvent))
+    stub(listOf(checkin), listOf(cd))
+
+    job.process()
+
+    verify(notificationService).sendCheckinReminderNotifications(eq(checkin), eq(cd))
+    verify(deactivationService, never()).deactivateOffender(any(), any(), any(), any())
+  }
+
+  @Test
+  fun `ineligible checkin is deactivated, not reminded, and excluded from the reminder audit`() {
+    val eligible = checkin("X000001")
+    val ineligible = checkin("X000002")
+    val missing = checkin("X000003")
+    val eligibleCd = details("X000001", events = listOf(anEvent))
+    val ineligibleCd = details("X000002", suspended = true)
+    // X000003 deliberately absent from the NDelius response
+    stub(listOf(eligible, ineligible, missing), listOf(eligibleCd, ineligibleCd))
+
+    job.process()
+
+    verify(deactivationService).deactivateOffender(eq(ineligible.offender), any(), any(), any())
+    verify(notificationService).sendCheckinReminderNotifications(eq(eligible), eq(eligibleCd))
+    verify(notificationService, never()).sendCheckinReminderNotifications(eq(ineligible), any())
+
+    // the deactivated checkin must NOT appear in any CHECKIN_REMINDER audit (it was cancelled)
+    val captor = argumentCaptor<Iterable<Pair<OffenderCheckinV2, ContactDetails?>>>()
+    verify(eventAuditService, org.mockito.kotlin.atLeastOnce()).recordCheckinReminded(captor.capture())
+    val allAudited = captor.allValues.flatMap { it.toList() }.map { it.first }
+    assertThat(allAudited).contains(eligible, missing)
+    assertThat(allAudited).doesNotContain(ineligible)
+  }
+
+  private fun stub(checkins: List<OffenderCheckinV2>, details: List<ContactDetails>) {
+    whenever(checkinRepository.findEligibleForReminder(any(), any(), any())).thenReturn(Stream.of(*checkins.toTypedArray()))
+    whenever(ndiliusApiClient.getContactDetailsForMultiple(any())).thenReturn(details)
+    whenever(deactivationService.deactivateOffender(any(), any(), any(), any())).thenAnswer { it.getArgument<OffenderV2>(0) }
+  }
+
+  private fun details(crn: String, events: List<Event>? = null, suspended: Boolean = false) = ContactDetails(crn = crn, name = Name("John", "Doe"), events = events, contactSuspended = suspended)
+
+  private fun checkin(crn: String) = OffenderCheckinV2(
+    uuid = UUID.randomUUID(),
+    offender = offender(crn),
+    status = uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinV2Status.CREATED,
+    dueDate = LocalDate.now(clock).minusDays(2),
+    createdAt = clock.instant(),
+    createdBy = "SYSTEM",
+  )
+
+  private fun offender(crn: String) = OffenderV2(
+    uuid = UUID.randomUUID(),
+    crn = crn,
+    practitionerId = "PRACT001",
+    status = OffenderStatus.VERIFIED,
+    firstCheckin = LocalDate.now(clock).minusDays(2),
+    checkinInterval = CheckinInterval.WEEKLY.duration,
+    createdAt = clock.instant(),
+    createdBy = "SYSTEM",
+    updatedAt = clock.instant(),
+    contactPreference = ContactPreference.EMAIL,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/V2CheckinReminderJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/V2CheckinReminderJobTest.kt
@@ -26,6 +26,7 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.audit.EventAuditV2Service
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.audit.OffenderAuditEventType
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.CheckinInterval
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ContactPreference
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.OffenderStatus
@@ -78,7 +79,7 @@ class V2CheckinReminderJobTest {
     job.process()
 
     verify(notificationService).sendCheckinReminderNotifications(same(checkin), eq(cd))
-    verify(deactivationService, never()).deactivateOffender(any(), any(), any(), any())
+    verify(deactivationService, never()).deactivateOffender(any(), any(), any(), any(), any())
   }
 
   @Test
@@ -95,7 +96,7 @@ class V2CheckinReminderJobTest {
 
     // NB: V2BaseEntity.equals() is id-based and all unsaved test entities share id=0, so eq() cannot
     // tell the instances apart - match by reference identity (same()/===) instead.
-    verify(deactivationService).deactivateOffender(same(ineligible.offender), any(), any(), any())
+    verify(deactivationService).deactivateOffender(same(ineligible.offender), any(), any(), any(), eq(OffenderAuditEventType.OFFENDER_AUTO_DEACTIVATED_CONTACT_SUSPENDED))
     verify(notificationService).sendCheckinReminderNotifications(same(eligible), eq(eligibleCd))
     verify(notificationService, never()).sendCheckinReminderNotifications(same(ineligible), any())
 
@@ -111,7 +112,7 @@ class V2CheckinReminderJobTest {
   private fun stub(checkins: List<OffenderCheckinV2>, details: List<ContactDetails>) {
     whenever(checkinRepository.findEligibleForReminder(any(), any(), any())).thenReturn(Stream.of(*checkins.toTypedArray()))
     whenever(ndiliusApiClient.getContactDetailsForMultiple(any())).thenReturn(details)
-    whenever(deactivationService.deactivateOffender(any(), any(), any(), any())).thenAnswer { it.getArgument<OffenderV2>(0) }
+    whenever(deactivationService.deactivateOffender(any(), any(), any(), any(), any())).thenAnswer { it.getArgument<OffenderV2>(0) }
   }
 
   private fun details(crn: String, events: List<Event>? = null, suspended: Boolean = false) = ContactDetails(crn = crn, name = Name("John", "Doe"), events = events, contactSuspended = suspended)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderDeactivationV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderDeactivationV2ServiceTest.kt
@@ -11,10 +11,8 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinV2Status
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.ContactDetails
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.INdiliusApiClient
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.Name
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.NotificationV2Service
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderSetupV2Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2
@@ -41,7 +39,6 @@ class OffenderDeactivationV2ServiceTest {
   private val questionService: QuestionService = mock()
   private val eventAuditService: EventAuditV2Service = mock()
   private val notificationService: NotificationV2Service = mock()
-  private val ndiliusApiClient: INdiliusApiClient = mock()
 
   private val service = OffenderDeactivationV2Service(
     clock,
@@ -51,7 +48,6 @@ class OffenderDeactivationV2ServiceTest {
     questionService,
     eventAuditService,
     notificationService,
-    ndiliusApiClient,
   )
 
   private val contactDetails = ContactDetails(crn = "X123456", name = Name("John", "Doe"), mobile = "07700900123")
@@ -102,23 +98,12 @@ class OffenderDeactivationV2ServiceTest {
   @Test
   fun `cancels pending CREATED check-ins on deactivation`() {
     val offender = offender(OffenderStatus.VERIFIED)
-    val pending = OffenderCheckinV2(
-      uuid = UUID.randomUUID(),
-      offender = offender,
-      status = CheckinV2Status.CREATED,
-      dueDate = LocalDate.now(clock),
-      createdAt = clock.instant(),
-      createdBy = "SYSTEM",
-    )
     whenever(offenderRepository.save(any())).thenAnswer { it.getArgument(0) }
     whenever(offenderSetupRepository.findByOffender(any())).thenReturn(Optional.empty())
-    whenever(checkinRepository.findAllByOffenderAndStatus(offender, CheckinV2Status.CREATED))
-      .thenReturn(listOf(pending))
 
     service.deactivateOffender(offender, "in reset", contactDetails)
 
-    assertEquals(CheckinV2Status.CANCELLED, pending.status)
-    verify(checkinRepository).saveAll(listOf(pending))
+    verify(checkinRepository).updateStatusForOffender(offender, CheckinV2Status.CREATED, CheckinV2Status.CANCELLED)
   }
 
   @Test
@@ -134,16 +119,14 @@ class OffenderDeactivationV2ServiceTest {
   }
 
   @Test
-  fun `fetches contact details from NDelius when not supplied`() {
+  fun `passes null contact details through when not supplied by caller`() {
     val offender = offender(OffenderStatus.VERIFIED)
     whenever(offenderRepository.save(any())).thenAnswer { it.getArgument(0) }
     whenever(offenderSetupRepository.findByOffender(any())).thenReturn(Optional.empty())
-    whenever(ndiliusApiClient.getContactDetails(offender.crn)).thenReturn(contactDetails)
 
     service.deactivateOffender(offender, "no active events")
 
-    verify(ndiliusApiClient).getContactDetails(offender.crn)
-    verify(notificationService).sendDeactivationCompletedNotifications(eq(offender), eq(contactDetails), isNull())
+    verify(notificationService).sendDeactivationCompletedNotifications(eq(offender), isNull(), isNull())
   }
 
   private fun offender(status: OffenderStatus) = OffenderV2(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderDeactivationV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderDeactivationV2ServiceTest.kt
@@ -78,6 +78,28 @@ class OffenderDeactivationV2ServiceTest {
   }
 
   @Test
+  fun `records the supplied audit event type (automated deactivation)`() {
+    val offender = offender(OffenderStatus.VERIFIED)
+    whenever(offenderRepository.save(any())).thenAnswer { it.getArgument(0) }
+    whenever(offenderSetupRepository.findByOffender(any())).thenReturn(Optional.empty())
+
+    service.deactivateOffender(
+      offender,
+      "no active events",
+      contactDetails,
+      auditEventType = OffenderAuditEventType.OFFENDER_AUTO_DEACTIVATED_NO_ACTIVE_EVENTS,
+    )
+
+    verify(eventAuditService).recordOffenderEvent(
+      eq(OffenderAuditEventType.OFFENDER_AUTO_DEACTIVATED_NO_ACTIVE_EVENTS),
+      eq(offender),
+      eq(contactDetails),
+      eq("no active events"),
+      eq(false),
+    )
+  }
+
+  @Test
   fun `cancels pending CREATED check-ins on deactivation`() {
     val offender = offender(OffenderStatus.VERIFIED)
     val pending = OffenderCheckinV2(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderDeactivationV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderDeactivationV2ServiceTest.kt
@@ -1,0 +1,139 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.v2.offender
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinV2Status
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.ContactDetails
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.INdiliusApiClient
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.Name
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.NotificationV2Service
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2Repository
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderSetupV2Repository
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2Repository
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.audit.EventAuditV2Service
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.audit.OffenderAuditEventType
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.CheckinInterval
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ContactPreference
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.OffenderStatus
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.question.QuestionService
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.util.Optional
+import java.util.UUID
+
+class OffenderDeactivationV2ServiceTest {
+
+  private val clock = Clock.fixed(Instant.parse("2025-12-10T10:00:00Z"), ZoneId.of("UTC"))
+  private val offenderRepository: OffenderV2Repository = mock()
+  private val checkinRepository: OffenderCheckinV2Repository = mock()
+  private val offenderSetupRepository: OffenderSetupV2Repository = mock()
+  private val questionService: QuestionService = mock()
+  private val eventAuditService: EventAuditV2Service = mock()
+  private val notificationService: NotificationV2Service = mock()
+  private val ndiliusApiClient: INdiliusApiClient = mock()
+
+  private val service = OffenderDeactivationV2Service(
+    clock,
+    offenderRepository,
+    checkinRepository,
+    offenderSetupRepository,
+    questionService,
+    eventAuditService,
+    notificationService,
+    ndiliusApiClient,
+  )
+
+  private val contactDetails = ContactDetails(crn = "X123456", name = Name("John", "Doe"), mobile = "07700900123")
+
+  @Test
+  fun `deactivates a VERIFIED offender - status, audit and notification`() {
+    val offender = offender(OffenderStatus.VERIFIED)
+    whenever(offenderRepository.save(any())).thenAnswer { it.getArgument(0) }
+    whenever(offenderSetupRepository.findByOffender(any())).thenReturn(Optional.empty())
+
+    val result = service.deactivateOffender(offender, "no active events", contactDetails, sensitive = true)
+
+    assertEquals(OffenderStatus.INACTIVE, result.status)
+    verify(offenderRepository).save(offender)
+    verify(questionService).deleteUpcomingAssignment(offender.crn)
+    verify(eventAuditService).recordOffenderEvent(
+      eq(OffenderAuditEventType.OFFENDER_DEACTIVATED),
+      eq(offender),
+      eq(contactDetails),
+      eq("no active events"),
+      eq(true),
+    )
+    verify(notificationService).sendDeactivationCompletedNotifications(eq(offender), eq(contactDetails), isNull())
+  }
+
+  @Test
+  fun `cancels pending CREATED check-ins on deactivation`() {
+    val offender = offender(OffenderStatus.VERIFIED)
+    val pending = OffenderCheckinV2(
+      uuid = UUID.randomUUID(),
+      offender = offender,
+      status = CheckinV2Status.CREATED,
+      dueDate = LocalDate.now(clock),
+      createdAt = clock.instant(),
+      createdBy = "SYSTEM",
+    )
+    whenever(offenderRepository.save(any())).thenAnswer { it.getArgument(0) }
+    whenever(offenderSetupRepository.findByOffender(any())).thenReturn(Optional.empty())
+    whenever(checkinRepository.findAllByOffenderAndStatus(offender, CheckinV2Status.CREATED))
+      .thenReturn(listOf(pending))
+
+    service.deactivateOffender(offender, "in reset", contactDetails)
+
+    assertEquals(CheckinV2Status.CANCELLED, pending.status)
+    verify(checkinRepository).saveAll(listOf(pending))
+  }
+
+  @Test
+  fun `is a no-op when offender is not VERIFIED`() {
+    val offender = offender(OffenderStatus.INACTIVE)
+
+    val result = service.deactivateOffender(offender, "in reset", contactDetails)
+
+    assertEquals(OffenderStatus.INACTIVE, result.status)
+    verify(offenderRepository, never()).save(any())
+    verify(questionService, never()).deleteUpcomingAssignment(any())
+    verify(notificationService, never()).sendDeactivationCompletedNotifications(any(), any(), any())
+  }
+
+  @Test
+  fun `fetches contact details from NDelius when not supplied`() {
+    val offender = offender(OffenderStatus.VERIFIED)
+    whenever(offenderRepository.save(any())).thenAnswer { it.getArgument(0) }
+    whenever(offenderSetupRepository.findByOffender(any())).thenReturn(Optional.empty())
+    whenever(ndiliusApiClient.getContactDetails(offender.crn)).thenReturn(contactDetails)
+
+    service.deactivateOffender(offender, "no active events")
+
+    verify(ndiliusApiClient).getContactDetails(offender.crn)
+    verify(notificationService).sendDeactivationCompletedNotifications(eq(offender), eq(contactDetails), isNull())
+  }
+
+  private fun offender(status: OffenderStatus) = OffenderV2(
+    uuid = UUID.randomUUID(),
+    crn = "X123456",
+    practitionerId = "PRACT001",
+    status = status,
+    firstCheckin = LocalDate.now(clock),
+    checkinInterval = CheckinInterval.WEEKLY.duration,
+    createdAt = clock.instant(),
+    createdBy = "PRACT001",
+    updatedAt = clock.instant(),
+    contactPreference = ContactPreference.PHONE,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderV2ResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderV2ResourceTest.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2Reposito
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.audit.EventAuditV2Service
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.audit.OffenderAuditEventType
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.checkin.CheckinCreationService
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.CheckinInterval
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ContactPreference
@@ -93,7 +94,7 @@ class OffenderV2ResourceTest {
     )
     whenever(offenderRepository.findByUuid(uuid)).thenReturn(Optional.of(offender))
     whenever(ndiliusApiClient.getContactDetails(offender.crn)).thenReturn(contactDetails)
-    whenever(offenderDeactivationV2Service.deactivateOffender(any(), any(), any(), any())).thenAnswer {
+    whenever(offenderDeactivationV2Service.deactivateOffender(any(), any(), any(), any(), any())).thenAnswer {
       val o = it.getArgument<OffenderV2>(0)
       o.status = OffenderStatus.INACTIVE
       o
@@ -109,6 +110,7 @@ class OffenderV2ResourceTest {
       eq("No longer on supervision"),
       eq(contactDetails),
       eq(false),
+      eq(OffenderAuditEventType.OFFENDER_DEACTIVATED),
     )
   }
 
@@ -129,7 +131,7 @@ class OffenderV2ResourceTest {
 
     whenever(offenderRepository.findByUuid(uuid)).thenReturn(Optional.of(offender))
     whenever(ndiliusApiClient.getContactDetails(offender.crn)).thenReturn(contactDetails)
-    whenever(offenderDeactivationV2Service.deactivateOffender(any(), any(), any(), any())).thenAnswer {
+    whenever(offenderDeactivationV2Service.deactivateOffender(any(), any(), any(), any(), any())).thenAnswer {
       it.getArgument<OffenderV2>(0)
     }
 
@@ -140,6 +142,7 @@ class OffenderV2ResourceTest {
       eq("Safety concerns disclosed"),
       eq(contactDetails),
       eq(true),
+      eq(OffenderAuditEventType.OFFENDER_DEACTIVATED),
     )
   }
 
@@ -213,7 +216,7 @@ class OffenderV2ResourceTest {
     val presignedUrl = URI("https://s3.amazonaws.com/bucket/photo.jpg?presigned=true").toURL()
     whenever(offenderRepository.findByUuid(uuid)).thenReturn(Optional.of(offender))
     whenever(ndiliusApiClient.getContactDetails(offender.crn)).thenReturn(contactDetails)
-    whenever(offenderDeactivationV2Service.deactivateOffender(any(), any(), any(), any())).thenAnswer {
+    whenever(offenderDeactivationV2Service.deactivateOffender(any(), any(), any(), any(), any())).thenAnswer {
       val o = it.getArgument<OffenderV2>(0)
       o.status = OffenderStatus.INACTIVE
       o

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderV2ResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderV2ResourceTest.kt
@@ -21,20 +21,16 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.utils.today
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinV2Status
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.INdiliusApiClient
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.NotificationV2Service
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2Repository
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderSetupV2Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.audit.EventAuditV2Service
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.audit.OffenderAuditEventType
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.checkin.CheckinCreationService
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.CheckinInterval
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ContactPreference
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.OffenderStatus
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.storage.PresignedUpload
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.storage.S3UploadService
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.question.QuestionService
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.setup.OffenderSetupV2Service
 import java.net.URI
 import java.time.Clock
@@ -55,9 +51,8 @@ class OffenderV2ResourceTest {
   private val ndiliusApiClient: INdiliusApiClient = mock()
   private val notificationV2Service: NotificationV2Service = mock()
   private val checkinRepository: OffenderCheckinV2Repository = mock()
-  private val offenderSetupRepository: OffenderSetupV2Repository = mock()
   private val offenderSetupV2Service: OffenderSetupV2Service = mock()
-  private val questionService: QuestionService = mock()
+  private val offenderDeactivationV2Service: OffenderDeactivationV2Service = mock()
   private val appConfig: AppConfig = mock()
 
   private lateinit var resource: OffenderV2Resource
@@ -73,9 +68,8 @@ class OffenderV2ResourceTest {
       ndiliusApiClient,
       notificationV2Service,
       checkinRepository,
-      offenderSetupRepository,
       offenderSetupV2Service,
-      questionService,
+      offenderDeactivationV2Service,
       appConfig,
     )
   }
@@ -85,7 +79,7 @@ class OffenderV2ResourceTest {
   // ========================================
 
   @Test
-  fun `deactivateOffender - happy path - changes VERIFIED to INACTIVE`() {
+  fun `deactivateOffender - happy path - delegates to deactivation service and returns INACTIVE`() {
     val uuid = UUID.randomUUID()
     val offender = createOffender(uuid, OffenderStatus.VERIFIED)
     val request = DeactivateOffenderRequest(
@@ -98,16 +92,55 @@ class OffenderV2ResourceTest {
       name = uk.gov.justice.digital.hmpps.esupervisionapi.v2.Name("John", "Doe"),
     )
     whenever(offenderRepository.findByUuid(uuid)).thenReturn(Optional.of(offender))
-    whenever(offenderRepository.save(any())).thenAnswer { it.getArgument(0) }
     whenever(ndiliusApiClient.getContactDetails(offender.crn)).thenReturn(contactDetails)
+    whenever(offenderDeactivationV2Service.deactivateOffender(any(), any(), any(), any())).thenAnswer {
+      val o = it.getArgument<OffenderV2>(0)
+      o.status = OffenderStatus.INACTIVE
+      o
+    }
+
     val result = resource.deactivateOffender(uuid, request)
 
     assertEquals(HttpStatus.OK, result.statusCode)
     assertEquals(OffenderStatus.INACTIVE, result.body?.status)
     assertEquals(uuid, result.body?.uuid)
-    verify(questionService).deleteUpcomingAssignment(eq(offender.crn))
-    verify(offenderRepository).save(any())
-    verify(notificationV2Service).sendDeactivationCompletedNotifications(eq(offender), eq(contactDetails), isNull())
+    verify(offenderDeactivationV2Service).deactivateOffender(
+      eq(offender),
+      eq("No longer on supervision"),
+      eq(contactDetails),
+      eq(false),
+    )
+  }
+
+  @Test
+  fun `deactivateOffender - passes sensitive flag through to deactivation service`() {
+    val uuid = UUID.randomUUID()
+    val offender = createOffender(uuid, OffenderStatus.VERIFIED)
+    val request = DeactivateOffenderRequest(
+      requestedBy = "PRACT001",
+      reason = "Safety concerns disclosed",
+      sensitive = true,
+    )
+    val contactDetails = uk.gov.justice.digital.hmpps.esupervisionapi.v2.ContactDetails(
+      crn = offender.crn,
+      mobile = "07700900123",
+      name = uk.gov.justice.digital.hmpps.esupervisionapi.v2.Name("John", "Doe"),
+    )
+
+    whenever(offenderRepository.findByUuid(uuid)).thenReturn(Optional.of(offender))
+    whenever(ndiliusApiClient.getContactDetails(offender.crn)).thenReturn(contactDetails)
+    whenever(offenderDeactivationV2Service.deactivateOffender(any(), any(), any(), any())).thenAnswer {
+      it.getArgument<OffenderV2>(0)
+    }
+
+    resource.deactivateOffender(uuid, request)
+
+    verify(offenderDeactivationV2Service).deactivateOffender(
+      eq(offender),
+      eq("Safety concerns disclosed"),
+      eq(contactDetails),
+      eq(true),
+    )
   }
 
   @Test
@@ -179,8 +212,12 @@ class OffenderV2ResourceTest {
 
     val presignedUrl = URI("https://s3.amazonaws.com/bucket/photo.jpg?presigned=true").toURL()
     whenever(offenderRepository.findByUuid(uuid)).thenReturn(Optional.of(offender))
-    whenever(offenderRepository.save(any())).thenAnswer { it.getArgument(0) }
     whenever(ndiliusApiClient.getContactDetails(offender.crn)).thenReturn(contactDetails)
+    whenever(offenderDeactivationV2Service.deactivateOffender(any(), any(), any(), any())).thenAnswer {
+      val o = it.getArgument<OffenderV2>(0)
+      o.status = OffenderStatus.INACTIVE
+      o
+    }
     // mock s3
     whenever(s3UploadService.getOffenderPhoto(any())).thenReturn(presignedUrl)
 
@@ -190,108 +227,6 @@ class OffenderV2ResourceTest {
     assertEquals(OffenderStatus.INACTIVE, result.body?.status)
     assertEquals(uuid, result.body?.uuid)
     assertEquals("https://s3.amazonaws.com/bucket/photo.jpg?presigned=true", result.body?.photoUrl)
-    verify(notificationV2Service).sendDeactivationCompletedNotifications(eq(offender), eq(contactDetails), isNull())
-  }
-
-  @Test
-  fun `deactivateOffender - happy path - changes any pending check ins to CANCELLED`() {
-    val uuid = UUID.randomUUID()
-    val offender = createOffender(uuid, OffenderStatus.VERIFIED)
-    val request = DeactivateOffenderRequest(
-      requestedBy = "PRACT001",
-      reason = "No longer on supervision",
-    )
-
-    val contactDetails = uk.gov.justice.digital.hmpps.esupervisionapi.v2.ContactDetails(
-      crn = offender.crn,
-      mobile = "07700900123",
-      name = uk.gov.justice.digital.hmpps.esupervisionapi.v2.Name("John", "Doe"),
-    )
-
-    val pendingCheckin = OffenderCheckinV2(
-      uuid = UUID.randomUUID(),
-      offender = offender,
-      status = CheckinV2Status.CREATED,
-      dueDate = LocalDate.now(clock),
-      createdAt = clock.instant(),
-      createdBy = "PRACT001",
-    )
-
-    whenever(offenderRepository.findByUuid(uuid)).thenReturn(Optional.of(offender))
-    whenever(offenderRepository.save(any<OffenderV2>())).thenAnswer { it.getArgument(0) }
-    whenever(ndiliusApiClient.getContactDetails(offender.crn)).thenReturn(contactDetails)
-    whenever(checkinRepository.findAllByOffenderAndStatus(offender, CheckinV2Status.CREATED))
-      .thenReturn(listOf(pendingCheckin))
-
-    val result = resource.deactivateOffender(uuid, request)
-
-    assertEquals(HttpStatus.OK, result.statusCode)
-    assertEquals(OffenderStatus.INACTIVE, result.body?.status)
-    assertEquals(CheckinV2Status.CANCELLED, pendingCheckin.status)
-
-    verify(offenderRepository).save(offender)
-  }
-
-  @Test
-  fun `deactivateOffender - happy path - passes sensitive flag as TRUE to audit service`() {
-    val uuid = UUID.randomUUID()
-    val offender = createOffender(uuid, OffenderStatus.VERIFIED)
-    val request = DeactivateOffenderRequest(
-      requestedBy = "PRACT001",
-      reason = "Safety concerns disclosed",
-      sensitive = true,
-    )
-    val contactDetails = uk.gov.justice.digital.hmpps.esupervisionapi.v2.ContactDetails(
-      crn = offender.crn,
-      mobile = "07700900123",
-      name = uk.gov.justice.digital.hmpps.esupervisionapi.v2.Name("John", "Doe"),
-    )
-
-    whenever(offenderRepository.findByUuid(uuid)).thenReturn(Optional.of(offender))
-    whenever(offenderRepository.save(any())).thenAnswer { it.getArgument(0) }
-    whenever(ndiliusApiClient.getContactDetails(offender.crn)).thenReturn(contactDetails)
-
-    val result = resource.deactivateOffender(uuid, request)
-
-    assertEquals(HttpStatus.OK, result.statusCode)
-
-    verify(eventAuditV2Service).recordOffenderEvent(
-      eq(OffenderAuditEventType.OFFENDER_DEACTIVATED),
-      eq(offender),
-      eq(contactDetails),
-      eq("Safety concerns disclosed"),
-      eq(true),
-    )
-  }
-
-  @Test
-  fun `deactivateOffender - happy path - passes sensitive flag as FALSE to audit service`() {
-    val uuid = UUID.randomUUID()
-    val offender = createOffender(uuid, OffenderStatus.VERIFIED)
-    val request = DeactivateOffenderRequest(
-      requestedBy = "PRACT001",
-      reason = "Standard deactivation",
-      sensitive = false,
-    )
-    val contactDetails = uk.gov.justice.digital.hmpps.esupervisionapi.v2.ContactDetails(
-      crn = offender.crn,
-      mobile = "07700900123",
-      name = uk.gov.justice.digital.hmpps.esupervisionapi.v2.Name("John", "Doe"),
-    )
-
-    whenever(offenderRepository.findByUuid(uuid)).thenReturn(Optional.of(offender))
-    whenever(offenderRepository.save(any())).thenAnswer { it.getArgument(0) }
-    whenever(ndiliusApiClient.getContactDetails(offender.crn)).thenReturn(contactDetails)
-
-    resource.deactivateOffender(uuid, request)
-
-    verify(eventAuditV2Service).recordOffenderEvent(
-      eq(OffenderAuditEventType.OFFENDER_DEACTIVATED),
-      eq(offender),
-      eq(contactDetails),
-      eq("Standard deactivation"),
-      eq(false),
-    )
   }
 
   // ========================================
@@ -605,6 +540,57 @@ class OffenderV2ResourceTest {
 
     verify(checkinCreationService, times(0)).createCheckin(any(), any(), any())
     verify(notificationV2Service).sendReactivationCompletedNotifications(eq(offender), eq(myContactDetails), isNull())
+  }
+
+  @Test
+  fun `reactivateOffender - blocked when contact suspended (in reset) in NDelius`() {
+    val uuid = UUID.randomUUID()
+    val offender = createOffender(uuid, OffenderStatus.INACTIVE).apply {
+      contactPreference = ContactPreference.PHONE
+    }
+    val request = ReactivateOffenderRequest(requestedBy = "PRACT001", reason = "Reactivating")
+    val contactDetails = uk.gov.justice.digital.hmpps.esupervisionapi.v2.ContactDetails(
+      offender.crn,
+      uk.gov.justice.digital.hmpps.esupervisionapi.v2.Name("John", "Doe"),
+      mobile = "07700900123",
+      contactSuspended = true,
+    )
+
+    whenever(offenderRepository.findByUuid(uuid)).thenReturn(Optional.of(offender))
+    whenever(ndiliusApiClient.getContactDetails(offender.crn)).thenReturn(contactDetails)
+
+    val exception = assertThrows(ResponseStatusException::class.java) {
+      resource.reactivateOffender(uuid, request)
+    }
+
+    assertEquals(HttpStatus.BAD_REQUEST, exception.statusCode)
+    verify(offenderSetupV2Service, times(0)).activateOffenderAndIncrementSetupCounter(any())
+    verify(checkinCreationService, times(0)).createCheckin(any(), any(), any())
+  }
+
+  @Test
+  fun `reactivateOffender - blocked when there are no active events in NDelius`() {
+    val uuid = UUID.randomUUID()
+    val offender = createOffender(uuid, OffenderStatus.INACTIVE).apply {
+      contactPreference = ContactPreference.PHONE
+    }
+    val request = ReactivateOffenderRequest(requestedBy = "PRACT001", reason = "Reactivating")
+    val contactDetails = uk.gov.justice.digital.hmpps.esupervisionapi.v2.ContactDetails(
+      offender.crn,
+      uk.gov.justice.digital.hmpps.esupervisionapi.v2.Name("John", "Doe"),
+      mobile = "07700900123",
+      events = emptyList(),
+    )
+
+    whenever(offenderRepository.findByUuid(uuid)).thenReturn(Optional.of(offender))
+    whenever(ndiliusApiClient.getContactDetails(offender.crn)).thenReturn(contactDetails)
+
+    val exception = assertThrows(ResponseStatusException::class.java) {
+      resource.reactivateOffender(uuid, request)
+    }
+
+    assertEquals(HttpStatus.BAD_REQUEST, exception.statusCode)
+    verify(offenderSetupV2Service, times(0)).activateOffenderAndIncrementSetupCounter(any())
   }
 
   // ========================================

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupV2ServiceTest.kt
@@ -14,7 +14,11 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.transaction.support.TransactionTemplate
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CodedDescription
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.ContactDetails
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.Event
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.INdiliusApiClient
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.Name
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.NotificationV2Service
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderInfoInitial
@@ -213,6 +217,103 @@ class OffenderSetupV2ServiceTest {
   }
 
   @Test
+  fun `completeOffenderSetup - blocked when contact suspended (in reset) in NDelius`() {
+    val offender = makeOffender(clock, LocalDate.now(clock).plusDays(1))
+    val setup = OffenderSetupV2(
+      uuid = UUID.randomUUID(),
+      offender = offender,
+      practitionerId = "PRACT001",
+      createdAt = clock.instant(),
+      startedAt = null,
+    )
+
+    whenever(offenderSetupRepository.findByUuid(setup.uuid)).thenReturn(Optional.of(setup))
+    whenever(s3UploadService.isSetupPhotoUploaded(setup)).thenReturn(true)
+    // Suspended even though an active event is present - suspension wins.
+    whenever(ndiliusApiClient.getContactDetails(offender.crn)).thenReturn(
+      ContactDetails(crn = offender.crn, name = Name("John", "Doe"), events = listOf(activeEvent), contactSuspended = true),
+    )
+
+    assertThrows(BadArgumentException::class.java) {
+      service.completeOffenderSetup(setup.uuid)
+    }
+    verify(offenderRepository, never()).save(any())
+    verify(notificationService, never()).sendSetupCompletedNotifications(any(), any(), any())
+  }
+
+  @Test
+  fun `completeOffenderSetup - blocked when there are no active events in NDelius`() {
+    val offender = makeOffender(clock, LocalDate.now(clock).plusDays(1))
+    val setup = OffenderSetupV2(
+      uuid = UUID.randomUUID(),
+      offender = offender,
+      practitionerId = "PRACT001",
+      createdAt = clock.instant(),
+      startedAt = null,
+    )
+
+    whenever(offenderSetupRepository.findByUuid(setup.uuid)).thenReturn(Optional.of(setup))
+    whenever(s3UploadService.isSetupPhotoUploaded(setup)).thenReturn(true)
+    whenever(ndiliusApiClient.getContactDetails(offender.crn)).thenReturn(
+      ContactDetails(crn = offender.crn, name = Name("John", "Doe"), events = emptyList()),
+    )
+
+    assertThrows(BadArgumentException::class.java) {
+      service.completeOffenderSetup(setup.uuid)
+    }
+    verify(offenderRepository, never()).save(any())
+    verify(notificationService, never()).sendSetupCompletedNotifications(any(), any(), any())
+  }
+
+  @Test
+  fun `completeOffenderSetup - completes when NDelius contact details are unavailable (does not block)`() {
+    // A transient NDelius failure must not block onboarding - the eligibility gate only applies
+    // when contact details are available. The daily job re-checks eligibility later.
+    val offender = makeOffender(clock, LocalDate.now(clock).plusDays(1))
+    val setup = OffenderSetupV2(
+      uuid = UUID.randomUUID(),
+      offender = offender,
+      practitionerId = "PRACT001",
+      createdAt = clock.instant(),
+      startedAt = null,
+    )
+
+    whenever(offenderSetupRepository.findByUuid(setup.uuid)).thenReturn(Optional.of(setup))
+    whenever(s3UploadService.isSetupPhotoUploaded(setup)).thenReturn(true)
+    whenever(ndiliusApiClient.getContactDetails(offender.crn)).thenReturn(null)
+    whenever(offenderRepository.save(any())).thenAnswer { it.getArgument(0) }
+
+    val result = service.completeOffenderSetup(setup.uuid)
+
+    assertEquals(OffenderStatus.VERIFIED, result.status)
+    verify(offenderRepository).save(any())
+  }
+
+  @Test
+  fun `completeOffenderSetup - completes when offender has an active event`() {
+    val offender = makeOffender(clock, LocalDate.now(clock).plusDays(1))
+    val setup = OffenderSetupV2(
+      uuid = UUID.randomUUID(),
+      offender = offender,
+      practitionerId = "PRACT001",
+      createdAt = clock.instant(),
+      startedAt = null,
+    )
+
+    whenever(offenderSetupRepository.findByUuid(setup.uuid)).thenReturn(Optional.of(setup))
+    whenever(s3UploadService.isSetupPhotoUploaded(setup)).thenReturn(true)
+    whenever(ndiliusApiClient.getContactDetails(offender.crn)).thenReturn(
+      ContactDetails(crn = offender.crn, name = Name("John", "Doe"), events = listOf(activeEvent)),
+    )
+    whenever(offenderRepository.save(any())).thenAnswer { it.getArgument(0) }
+
+    val result = service.completeOffenderSetup(setup.uuid)
+
+    assertEquals(OffenderStatus.VERIFIED, result.status)
+    verify(offenderRepository).save(any())
+  }
+
+  @Test
   fun `terminateOffenderSetup - happy path - marks offender as inactive`() {
     // Given
     val setupUuid = UUID.randomUUID()
@@ -392,6 +493,8 @@ class OffenderSetupV2ServiceTest {
     assertEquals(firstSetupId, secondSetupId)
   }
 }
+
+private val activeEvent = Event(number = 1L, mainOffence = CodedDescription("X", "An offence"), sentence = null)
 
 fun makeOffender(clock: Clock, firstCheckin: LocalDate) = OffenderV2(
   uuid = UUID.randomUUID(),


### PR DESCRIPTION
Core behaviour
  - New contactSuspended boolean on Delius ContactDetails (the "in reset" signal).
  - New checkinIneligibilityReason(offender, details) helper → CONTACT_SUSPENDED, NO_ACTIVE_EVENTS, or null. No-active-events fires only on an explicitly empty events list; absent/null events is treated as indeterminate (won't deactivate);
  contactSuspended always deactivates.
  - Ineligible offenders are deactivated (status INACTIVE, pending check-ins cancelled, question assignment removed, "check-ins stopped" notification, audit + domain event) via a new reusable OffenderDeactivationV2Service —
  @Transactional(REQUIRES_NEW) so each commits independently.

Where it's enforced
  - V2CheckinCreationJob — deactivates ineligible CRNs instead of creating a check-in; failures isolated per-offender.
  - V2CheckinReminderJob — deactivates ineligible CRNs before reminding; excludes them from reminder audit/counts.
  - completeOffenderSetup — blocks (422) when ineligible (skipped if Delius details unavailable).
  - reactivateOffender — blocks (400) when ineligible.

Refactors / cleanup
  - deactivateOffender logic extracted from the controller into the shared service.
  - ESUP_1183 feature flag fully retired (always-on) — removed from Feature, AppConfig, application.yml, all helm values.
  - recordOffenderEvent now still audits when the practitioner is absent (only skips when no contact details at all).
  - Removed a duplicate deactivation log line.

Tests
  - New: V2CheckinCreationJobTest, V2CheckinReminderJobTest, EventAuditV2ServiceTest, ContactDetailsDeserializationTest.
  - Updated: UtilsTest, OffenderV2ResourceTest, OffenderSetupV2ServiceTest, plus new OffenderDeactivationV2ServiceTest.