### PR TITLE
Add feature flag for ESUP-1763

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -32,6 +32,7 @@ generic-service:
     CHECKIN_LEGACY_CLEANUP_DRY_RUN: "false"
     APP_FEATURES_ESUP_1239: "true"
     APP_FEATURES_ESUP_1183: "true"
+    APP_FEATURES_ESUP_1763: "true"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -32,6 +32,7 @@ generic-service:
     CHECKIN_LEGACY_CLEANUP_DRY_RUN: "false"
     APP_FEATURES_ESUP_1239: "true"
     APP_FEATURES_ESUP_1183: "true"
+    APP_FEATURES_ESUP_1763: "true"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -28,6 +28,7 @@ generic-service:
     CHECKIN_LEGACY_CLEANUP_DRY_RUN: "false"
     APP_FEATURES_ESUP_1239: "true"
     APP_FEATURES_ESUP_1183: "true"
+    APP_FEATURES_ESUP_1763: "false"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -23,6 +23,7 @@ generic-service:
     APP_SCHEDULING_MIGRATION_EVENT_REPLAY_CRON: "-"
     APP_FEATURES_ESUP_1239: "true"
     APP_FEATURES_ESUP_1183: "true"
+    APP_FEATURES_ESUP_1763: "true"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/AppConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/AppConfig.kt
@@ -14,10 +14,12 @@ class AppConfig(
   @Value("\${app.scheduling.checkin-notification.cron}") val checkinNotificationCron: String,
   @Value("\${app.features.esup-1239}") val esup1239ProxyLinks: Boolean,
   @Value("\${app.features.esup-1183}") val esup1183SendInviteOnlyWhenActiveEvent: Boolean,
+  @Value("\${app.features.esup-1763}") val esup1763RemoveSnapshots: Boolean,
   @Value("\${app.features.upload-content-hash.require:false}") val uploadContentHashRequire: Boolean,
   val enabledFeatures: Set<Feature> = listOfNotNull(
     if (esup1239ProxyLinks) Feature.ESUP_1239 else null,
     if (esup1183SendInviteOnlyWhenActiveEvent) Feature.ESUP_1183 else null,
+    if (esup1763RemoveSnapshots) Feature.ESUP_1763 else null,
     if (uploadContentHashRequire) Feature.ESUP_1672_REQUIRE_UPLOAD_CONTENT_HASH else null,
   ).toSet(),
 ) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/Feature.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/Feature.kt
@@ -15,4 +15,9 @@ enum class Feature {
    * ESUP-1672: Require a SHA-256 content hash when requesting presigned upload URLs
    */
   ESUP_1672_REQUIRE_UPLOAD_CONTENT_HASH,
+
+  /**
+   * ESUP-1763: Remove snapshots from checkins if the manual check confirms it is a match
+   */
+  ESUP_1763,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/CheckinV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/CheckinV2Service.kt
@@ -365,7 +365,7 @@ class CheckinV2Service(
     val event = checkin.toCheckinReviewedEvent(contactDetails, clock = clock, checkinWindow = checkinWindowPeriod, videoUrl = videoUrl, snapshotUrl = snapshotUrl)
     checkinPersistenceService.checkinReview(checkin, event, reviewInfo)
 
-    if (checkin.manualIdCheck == ManualIdVerificationResult.MATCH) {
+    if (appConfig.enabledFeatures.contains(Feature.ESUP_1763) && checkin.manualIdCheck == ManualIdVerificationResult.MATCH) {
       s3UploadService.deleteCheckinSnapshot(uuid, 0)
       s3UploadService.deleteCheckinVideo(uuid)
       return checkin.dto(contactDetails, null, null, clock = clock, checkinWindow = checkinWindowPeriod)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -67,6 +67,8 @@ app:
     upload-content-hash:
       # if true, reject upload_location requests that don't carry a hash
       require: ${UPLOAD_CONTENT_HASH_REQUIRE:false}
+    # remove the checkin snapshot if the manual id check confirms it is a match without concern
+    esup-1763: ${APP_FEATURES_ESUP_1763:false}
   offender-survey:
     # expand form values into human-readable strings in NDelius notes
     expansions:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/CheckinV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/CheckinV2ServiceTest.kt
@@ -116,7 +116,6 @@ class CheckinV2ServiceTest {
 
     whenever(s3UploadService.getCheckinSnapshot(any(), any())).thenReturn(URI.create("https://snapshot/1").toURL())
     whenever(s3UploadService.getCheckinVideo(any())).thenReturn(URI.create("https://video/1").toURL())
-    whenever(appConfig.enabledFeatures).thenReturn(setOf(Feature.ESUP_1763))
   }
 
   @Test
@@ -312,7 +311,46 @@ class CheckinV2ServiceTest {
   }
 
   @Test
-  fun `reviewCheckin - happy path - completes review and updates status`() {
+  fun `reviewCheckin - happy path & Feature ESUP_1763 TRUE - completes review and updates status`() {
+    val uuid = UUID.randomUUID()
+    val offender = createOffender()
+    val checkin = OffenderCheckinV2(
+      uuid = uuid,
+      offender = offender,
+      status = CheckinV2Status.SUBMITTED,
+      dueDate = LocalDate.now(clock),
+      createdAt = clock.instant(),
+      createdBy = "SYSTEM",
+      submittedAt = clock.instant(),
+      reviewStartedAt = clock.instant(),
+      reviewStartedBy = "PRACT001",
+    )
+
+    val request = ReviewCheckinV2Request(
+      reviewedBy = "PRACT001",
+      manualIdCheck = ManualIdVerificationResult.MATCH,
+      notes = "Approved",
+    )
+
+    whenever(checkinPersistenceService.findCheckin(any())).thenReturn(checkin)
+    whenever(checkinRepository.save(any())).thenAnswer { it.getArgument(0) }
+    whenever(appConfig.enabledFeatures).thenReturn(setOf(Feature.ESUP_1763))
+
+    val result = service.reviewCheckin(uuid, request)
+
+    assertEquals(CheckinV2Status.REVIEWED, result.status)
+    assertNotNull(result.reviewedAt)
+    assertNull(result.videoUrl)
+    assertNull(result.snapshotUrl)
+    assertEquals("PRACT001", result.reviewedBy)
+    assertEquals(ManualIdVerificationResult.MATCH, result.manualIdCheck)
+    verify(checkinPersistenceService).checkinReview(any(), any(), any())
+    verify(s3UploadService).deleteCheckinSnapshot(uuid, 0)
+    verify(s3UploadService).deleteCheckinVideo(uuid)
+  }
+
+  @Test
+  fun `reviewCheckin - happy path & Feature ESUP_1763 FALSE - completes review and updates status`() {
     val uuid = UUID.randomUUID()
     val offender = createOffender()
     val checkin = OffenderCheckinV2(
@@ -340,13 +378,13 @@ class CheckinV2ServiceTest {
 
     assertEquals(CheckinV2Status.REVIEWED, result.status)
     assertNotNull(result.reviewedAt)
-    assertNull(result.videoUrl)
-    assertNull(result.snapshotUrl)
+    assertNotNull(result.videoUrl)
+    assertNotNull(result.snapshotUrl)
     assertEquals("PRACT001", result.reviewedBy)
     assertEquals(ManualIdVerificationResult.MATCH, result.manualIdCheck)
     verify(checkinPersistenceService).checkinReview(any(), any(), any())
-    verify(s3UploadService).deleteCheckinSnapshot(uuid, 0)
-    verify(s3UploadService).deleteCheckinVideo(uuid)
+    verify(s3UploadService, never()).deleteCheckinSnapshot(any(), any())
+    verify(s3UploadService, never()).deleteCheckinVideo(any())
   }
 
   @Test
@@ -372,6 +410,7 @@ class CheckinV2ServiceTest {
     )
 
     whenever(checkinPersistenceService.findCheckin(any())).thenReturn(checkin)
+    whenever(appConfig.enabledFeatures).thenReturn(setOf(Feature.ESUP_1763))
 
     val result = service.reviewCheckin(uuid, request)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/CheckinV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/CheckinV2ServiceTest.kt
@@ -25,6 +25,7 @@ import software.amazon.awssdk.services.rekognition.model.AuditImage
 import software.amazon.awssdk.services.rekognition.model.GetFaceLivenessSessionResultsResponse
 import software.amazon.awssdk.services.rekognition.model.RekognitionException
 import uk.gov.justice.digital.hmpps.esupervisionapi.config.AppConfig
+import uk.gov.justice.digital.hmpps.esupervisionapi.config.Feature
 import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.NotificationType
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.AnnotateCheckinV2Request
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinPersistenceService
@@ -115,6 +116,7 @@ class CheckinV2ServiceTest {
 
     whenever(s3UploadService.getCheckinSnapshot(any(), any())).thenReturn(URI.create("https://snapshot/1").toURL())
     whenever(s3UploadService.getCheckinVideo(any())).thenReturn(URI.create("https://video/1").toURL())
+    whenever(appConfig.enabledFeatures).thenReturn(setOf(Feature.ESUP_1763))
   }
 
   @Test


### PR DESCRIPTION
[ESUP-1763](https://dsdmoj.atlassian.net/browse/ESUP-1763)

The UI changes that correspond to this ticket are currently turned off behind a feature flag on MPOP
I didn't realise there are other tickets that need to be completed before this feature should be turned on 
[ESUP-1583](https://dsdmoj.atlassian.net/browse/ESUP-1583) and [ESUP-1580](https://dsdmoj.atlassian.net/browse/ESUP-1580)

This isn't the worst thing to be live as it's the behaviour we want to move to but until the UI changes are live there's no explanation that the snapshots will be removed

[ESUP-1763]: https://dsdmoj.atlassian.net/browse/ESUP-1763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ESUP-1583]: https://dsdmoj.atlassian.net/browse/ESUP-1583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ESUP-1580]: https://dsdmoj.atlassian.net/browse/ESUP-1580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ