### PR TITLE
ESUP-1886 Events are non-optional. Update tests

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/MigrationEventReplayService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/utils/MigrationEventReplayService.kt
@@ -351,7 +351,7 @@ class MigrationEventReplayService(
         }
         try {
           val details = contactsByCrn[offender.crn]
-          if (details == null || details.events.isNullOrEmpty()) {
+          if (details == null || details.events.isEmpty()) {
             logger.info("Skipping V2_SETUP_COMPLETED for crn={}: no active Delius events", offender.crn)
             row.eventSent = true
             row.eventSentAt = clock.instant()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
@@ -73,9 +73,9 @@ data class ContactDetails(
    */
   @field:Schema(
     description = "Collection of active events.",
-    required = false,
+    required = true,
   )
-  val events: List<Event>? = null,
+  val events: List<Event> = emptyList(),
 
   /**
    * Note: true when the person is "in reset" - their contact has been suspended in NDelius

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/Utils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/Utils.kt
@@ -22,7 +22,7 @@ fun activeEventNumber(offender: OffenderV2, details: ContactDetails): Long? {
     return offender.currentEvent
   }
 
-  return details.events?.firstOrNull()?.number
+  return details.events.firstOrNull()?.number
 }
 
 /**
@@ -52,18 +52,20 @@ enum class CheckinIneligibilityReason(
  * Determines whether an offender should be stopped from receiving online check-ins, based on the
  * latest Delius contact details. Returns the reason, or null if the offender is still eligible.
  *
- * Stops check-ins when the person is in reset (contact suspended) or has no active probation events.
+ * Stops check-ins when the person has no active probation events or is in reset (contact suspended).
  *
- * Note on no-active-events: we only treat this as grounds for stopping when NDelius returns an
- * explicitly empty events list. An absent/null events list is treated as indeterminate (e.g. a
- * partial or degraded response) and does NOT stop check-ins, so a transient data gap can't wrongly
- * off-board an active person. A cached [OffenderV2.currentEvent] always counts as an active event.
+ * Note on ordering: no-active-events takes priority over contact-suspended, because an active event
+ * is a prerequisite for check-ins at all. So when a person is both in reset and has no events, we
+ * report NO_ACTIVE_EVENTS as the reason.
+ *
+ * Note on no-active-events: an empty events list means NDelius reports no active probation events.
+ * A cached [OffenderV2.currentEvent] always counts as an active event.
  *
  * @see activeEventNumber
  */
 fun checkinIneligibilityReason(offender: OffenderV2, details: ContactDetails): CheckinIneligibilityReason? = when {
+  offender.currentEvent == null && details.events.isEmpty() -> CheckinIneligibilityReason.NO_ACTIVE_EVENTS
   details.contactSuspended -> CheckinIneligibilityReason.CONTACT_SUSPENDED
-  offender.currentEvent == null && details.events?.isEmpty() == true -> CheckinIneligibilityReason.NO_ACTIVE_EVENTS
   else -> null
 }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/UtilsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/UtilsTest.kt
@@ -19,7 +19,7 @@ class UtilsTest {
   val clock: Clock = Clock.system(ZoneId.of("Europe/London"))
 
   private fun contactDetails(
-    events: List<Event>? = null,
+    events: List<Event> = emptyList(),
     contactSuspended: Boolean = false,
   ) = ContactDetails(
     crn = "X000000",
@@ -49,19 +49,11 @@ class UtilsTest {
   }
 
   @Test
-  fun `checkinIneligibilityReason - eligible when events list is absent (indeterminate, not empty)`() {
-    // A null/absent events list may indicate a partial or degraded NDelius response; it must not
-    // off-board an active person. Only an explicit empty list counts as "no active events".
-    val offender = offenderTemplate.toEntity()
-    assertNull(checkinIneligibilityReason(offender, contactDetails(events = null)))
-  }
-
-  @Test
-  fun `checkinIneligibilityReason - contact suspended deactivates even when events are absent`() {
+  fun `checkinIneligibilityReason - no active events takes priority over contact suspended`() {
     val offender = offenderTemplate.toEntity()
     assertEquals(
-      CheckinIneligibilityReason.CONTACT_SUSPENDED,
-      checkinIneligibilityReason(offender, contactDetails(events = null, contactSuspended = true)),
+      CheckinIneligibilityReason.NO_ACTIVE_EVENTS,
+      checkinIneligibilityReason(offender, contactDetails(events = emptyList(), contactSuspended = true)),
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/V2CheckinCreationJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/V2CheckinCreationJobTest.kt
@@ -101,17 +101,6 @@ class V2CheckinCreationJobTest {
   }
 
   @Test
-  fun `absent events list is indeterminate - treated as eligible, not deactivated`() {
-    val offender = offender("X000004")
-    stubEligible(listOf(offender), mapOf(offender.crn to details(offender.crn, events = null)))
-
-    job.process()
-
-    verify(checkinCreationService).prepareCheckinForOffender(eq(offender), any())
-    verify(deactivationService, never()).deactivateOffender(any(), any(), any(), any(), any())
-  }
-
-  @Test
   fun `a deactivation failure for one offender does not abort the rest of the run`() {
     val ineligible = offender("X000005")
     val eligible = offender("X000006")
@@ -155,7 +144,7 @@ class V2CheckinCreationJobTest {
     whenever(deactivationService.deactivateOffender(any(), any(), any(), any(), any())).thenAnswer { it.getArgument<OffenderV2>(0) }
   }
 
-  private fun details(crn: String, events: List<Event>? = null, suspended: Boolean = false) = ContactDetails(crn = crn, name = Name("John", "Doe"), events = events, contactSuspended = suspended)
+  private fun details(crn: String, events: List<Event> = emptyList(), suspended: Boolean = false) = ContactDetails(crn = crn, name = Name("John", "Doe"), events = events, contactSuspended = suspended)
 
   private fun offender(crn: String) = OffenderV2(
     uuid = UUID.randomUUID(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/V2CheckinReminderJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/V2CheckinReminderJobTest.kt
@@ -88,7 +88,7 @@ class V2CheckinReminderJobTest {
     val ineligible = checkin("X000002")
     val missing = checkin("X000003")
     val eligibleCd = details("X000001", events = listOf(anEvent))
-    val ineligibleCd = details("X000002", suspended = true)
+    val ineligibleCd = details("X000002", events = listOf(anEvent), suspended = true)
     // X000003 deliberately absent from the NDelius response
     stub(listOf(eligible, ineligible, missing), listOf(eligibleCd, ineligibleCd))
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/V2CheckinReminderJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/V2CheckinReminderJobTest.kt
@@ -115,7 +115,7 @@ class V2CheckinReminderJobTest {
     whenever(deactivationService.deactivateOffender(any(), any(), any(), any(), any())).thenAnswer { it.getArgument<OffenderV2>(0) }
   }
 
-  private fun details(crn: String, events: List<Event>? = null, suspended: Boolean = false) = ContactDetails(crn = crn, name = Name("John", "Doe"), events = events, contactSuspended = suspended)
+  private fun details(crn: String, events: List<Event> = emptyList(), suspended: Boolean = false) = ContactDetails(crn = crn, name = Name("John", "Doe"), events = events, contactSuspended = suspended)
 
   private fun checkin(crn: String) = OffenderCheckinV2(
     uuid = UUID.randomUUID(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderV2ResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderV2ResourceTest.kt
@@ -19,6 +19,8 @@ import org.springframework.web.server.ResponseStatusException
 import uk.gov.justice.digital.hmpps.esupervisionapi.config.AppConfig
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.today
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinV2Status
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CodedDescription
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.Event
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.INdiliusApiClient
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.NotificationV2Service
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2Repository
@@ -57,6 +59,8 @@ class OffenderV2ResourceTest {
   private val appConfig: AppConfig = mock()
 
   private lateinit var resource: OffenderV2Resource
+
+  private val anEvent = Event(number = 1L, mainOffence = CodedDescription("X", "An offence"), sentence = null)
 
   @BeforeEach
   fun setUp() {
@@ -254,6 +258,7 @@ class OffenderV2ResourceTest {
       crn = offender.crn,
       name = uk.gov.justice.digital.hmpps.esupervisionapi.v2.Name("John", "Doe"),
       mobile = "07700900123",
+      events = listOf(anEvent),
     )
 
     whenever(offenderRepository.findByUuid(uuid)).thenReturn(Optional.of(offender))
@@ -295,6 +300,7 @@ class OffenderV2ResourceTest {
       crn = offender.crn,
       mobile = "07700900123",
       name = uk.gov.justice.digital.hmpps.esupervisionapi.v2.Name("John", "Doe"),
+      events = listOf(anEvent),
     )
 
     whenever(offenderRepository.findByUuid(uuid)).thenReturn(Optional.of(offender))
@@ -377,6 +383,7 @@ class OffenderV2ResourceTest {
       crn = offender.crn,
       name = uk.gov.justice.digital.hmpps.esupervisionapi.v2.Name("John", "Doe"),
       mobile = "07700900123",
+      events = listOf(anEvent),
     )
 
     val presignedUrl = URI("https://s3.amazonaws.com/bucket/photo.jpg?presigned=true").toURL()
@@ -406,6 +413,7 @@ class OffenderV2ResourceTest {
       offender.crn,
       uk.gov.justice.digital.hmpps.esupervisionapi.v2.Name("John", "Doe"),
       mobile = null,
+      events = listOf(anEvent),
     )
 
     whenever(offenderRepository.findByUuid(uuid)).thenReturn(Optional.of(offender))
@@ -434,6 +442,7 @@ class OffenderV2ResourceTest {
       offender.crn,
       uk.gov.justice.digital.hmpps.esupervisionapi.v2.Name("Jane", "Smith"),
       email = "",
+      events = listOf(anEvent),
     )
 
     whenever(offenderRepository.findByUuid(uuid)).thenReturn(Optional.of(offender))
@@ -461,6 +470,7 @@ class OffenderV2ResourceTest {
       offender.crn,
       uk.gov.justice.digital.hmpps.esupervisionapi.v2.Name("Jane", "Smith"),
       mobile = "07700900123",
+      events = listOf(anEvent),
     )
 
     val completedCheckin = mock<uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2>()
@@ -493,6 +503,7 @@ class OffenderV2ResourceTest {
       offender.crn,
       uk.gov.justice.digital.hmpps.esupervisionapi.v2.Name("Jane", "Smith"),
       mobile = "07700900123",
+      events = listOf(anEvent),
     )
 
     val cancelledCheckin = mock<uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2>()
@@ -526,6 +537,7 @@ class OffenderV2ResourceTest {
       offender.crn,
       uk.gov.justice.digital.hmpps.esupervisionapi.v2.Name("Jane", "Smith"),
       mobile = "07700900123",
+      events = listOf(anEvent),
     )
 
     whenever(offenderRepository.findByUuid(uuid)).thenReturn(Optional.of(offender))
@@ -556,6 +568,7 @@ class OffenderV2ResourceTest {
       offender.crn,
       uk.gov.justice.digital.hmpps.esupervisionapi.v2.Name("John", "Doe"),
       mobile = "07700900123",
+      events = listOf(anEvent),
       contactSuspended = true,
     )
 


### PR DESCRIPTION
Update to account for events being non-optional from the PI response

I've also flipped the delius contact outcome for when the CRN is both in reset and has no events - no events now reported as the reason for stopping since events are a prerequisite for online check ins 