### PR TITLE
transition checkin creation to use events

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,6 +53,7 @@ dependencies {
   testImplementation("org.testcontainers:testcontainers-postgresql")
   testImplementation("org.junit.platform:junit-platform-launcher:1.12.2")
   testImplementation("org.testcontainers:junit-jupiter")
+  testImplementation("org.awaitility:awaitility")
 }
 
 kotlin {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/CheckinPersistenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/CheckinPersistenceService.kt
@@ -29,15 +29,16 @@ class CheckinPersistenceService(
   @Transactional
   fun checkinCreation(checkin: OffenderCheckinV2, event: PartialCheckinCreatedEvent) {
     val savedCheckin = checkinRepository.saveAndFlush(checkin)
-    eventAuditService.recordCheckinCreated(savedCheckin, event.checkin.personalDetails)
+    val finalisedEvent = event.finalise(savedCheckin)
+    eventAuditService.recordCheckinCreated(savedCheckin, finalisedEvent)
 
-    appEventPublisher.publishEvent(event.finalise(savedCheckin))
+    appEventPublisher.publishEvent(finalisedEvent)
   }
 
   @Transactional
   fun checkinSubmission(checkin: OffenderCheckinV2, event: CheckinSubmittedEvent) {
     checkinRepository.save(checkin)
-    eventAuditService.recordCheckinSubmitted(checkin, event.checkin.personalDetails)
+    eventAuditService.recordCheckinSubmitted(checkin, event)
 
     appEventPublisher.publishEvent(event)
   }
@@ -46,7 +47,7 @@ class CheckinPersistenceService(
   fun checkinReview(checkin: OffenderCheckinV2, event: CheckinReviewedEvent, reviewInfo: CheckinReviewInfo) {
     require(event.checkin.reviewedBy != null)
     checkinRepository.save(checkin)
-    eventAuditService.recordCheckinReviewed(checkin, event.checkin.personalDetails)
+    eventAuditService.recordCheckinReviewed(checkin, event)
     offenderEventLogRepository.save(
       OffenderEventLogV2(
         comment = reviewInfo.comment,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/CheckinPersistenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/CheckinPersistenceService.kt
@@ -11,7 +11,8 @@ import java.util.UUID
  * Handles composite operations related to checkins. It's meant to be a convenience layer for the [CheckinV2Service]
  * and should not be used anywhere else.
  *
- * The way to use this service is to pass all required data in a state that's ready to be persisted - don't put any logic here.
+ * The way to use this service is to pass all required data in a state that's ready to be persisted - don't put any logic here
+ * (apart from calls to .finalise() on certain events).
  */
 @Service
 class CheckinPersistenceService(
@@ -24,6 +25,14 @@ class CheckinPersistenceService(
 
   @Transactional
   fun findCheckin(uuid: UUID): OffenderCheckinV2? = checkinRepository.findByUuid(uuid).orElse(null)
+
+  @Transactional
+  fun checkinCreation(checkin: OffenderCheckinV2, event: PartialCheckinCreatedEvent) {
+    val savedCheckin = checkinRepository.saveAndFlush(checkin)
+    eventAuditService.recordCheckinCreated(savedCheckin, event.checkin.personalDetails)
+
+    appEventPublisher.publishEvent(event.finalise(savedCheckin))
+  }
 
   @Transactional
   fun checkinSubmission(checkin: OffenderCheckinV2, event: CheckinSubmittedEvent) {
@@ -57,7 +66,7 @@ class CheckinPersistenceService(
   @Transactional
   fun checkinAnnotation(checkin: OffenderCheckinV2, event: PartialCheckinAnnotatedEvent, request: AnnotateCheckinV2Request) {
     checkinRepository.save(checkin)
-    val logEntry = offenderEventLogRepository.save(
+    val logEntry = offenderEventLogRepository.saveAndFlush(
       OffenderEventLogV2(
         comment = request.notes,
         sensitive = checkin.sensitive,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/CheckinV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/CheckinV2Service.kt
@@ -915,8 +915,8 @@ class CheckinV2Service(
       throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Due date must be in the future")
     }
 
-    val personalDetails = ndiliusApiClient.getContactDetails(offender.crn) ?:
-      throw ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Failed to fetch contact details for CRN=${offender.crn}")
+    val personalDetails = ndiliusApiClient.getContactDetails(offender.crn)
+      ?: throw ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Failed to fetch contact details for CRN=${offender.crn}")
     if (activeEventNumber(offender, personalDetails) == null) {
       throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Offender has no active event")
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/CheckinV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/CheckinV2Service.kt
@@ -5,7 +5,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.domain.PageRequest
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionTemplate
 import org.springframework.web.server.ResponseStatusException
 import software.amazon.awssdk.services.rekognition.model.GetFaceLivenessSessionResultsResponse
 import software.amazon.awssdk.services.rekognition.model.RekognitionException
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.NotificationTy
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.logger
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinRequestApplicator.applyRequest
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.checkin.CheckinCreationService
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.checkin.activeEventNumber
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.AutomatedIdVerificationResult
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ExternalUserId
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.LivenessResult
@@ -31,6 +32,7 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.storage.re
 import java.net.URL
 import java.time.Clock
 import java.time.Duration
+import java.time.LocalDate
 import java.time.Period
 import java.util.UUID
 import java.util.concurrent.CompletableFuture
@@ -65,6 +67,7 @@ class CheckinV2Service(
   @param:Value("\${app.scheduling.v2-checkin-expiry.grace-period-days:3}")
   private val gracePeriodDays: Int,
   private val appConfig: AppConfig,
+  private val transactionTemplate: TransactionTemplate,
 ) {
 
   private val checkinWindowPeriod = Period.ofDays(gracePeriodDays)
@@ -114,14 +117,12 @@ class CheckinV2Service(
    * Validate personal details against Ndilius This is called before offender can proceed with
    * checkin
    */
-  @Transactional
   fun validateIdentity(uuid: UUID, personalDetails: PersonalDetails): IdentityValidationResponse {
     val checkin =
       checkinRepository.findByUuid(uuid).orElseThrow {
         ResponseStatusException(HttpStatus.NOT_FOUND, "Checkin not found: $uuid")
       }
 
-    // Verify CRN matches
     if (checkin.offender.crn != personalDetails.crn) {
       LOGGER.warn(
         "CRN mismatch for checkin {}: expected {}, got {}",
@@ -135,7 +136,6 @@ class CheckinV2Service(
       )
     }
 
-    // Validate against Ndilius
     val isValid = ndiliusApiClient.validatePersonalDetails(personalDetails)
 
     if (!isValid) {
@@ -146,10 +146,9 @@ class CheckinV2Service(
       )
     }
 
-    // Mark checkin as started
     if (checkin.checkinStartedAt == null) {
       checkin.checkinStartedAt = clock.instant()
-      checkinRepository.save(checkin)
+      transactionTemplate.executeWithoutResult { checkinRepository.save(checkin) }
     }
 
     LOGGER.info("Identity validated successfully for checkin {}", uuid)
@@ -323,7 +322,6 @@ class CheckinV2Service(
   }
 
   /** Mark checkin review as started */
-  @Transactional
   fun startReview(uuid: UUID, practitionerId: ExternalUserId): CheckinV2Dto {
     val checkin =
       checkinRepository.findByUuid(uuid).orElseThrow {
@@ -339,7 +337,7 @@ class CheckinV2Service(
 
     checkin.reviewStartedAt = clock.instant()
     checkin.reviewStartedBy = practitionerId
-    checkinRepository.save(checkin)
+    transactionTemplate.execute { checkinRepository.save(checkin) }
 
     LOGGER.info("Review started for checkin {} by {}", uuid, practitionerId)
 
@@ -808,10 +806,6 @@ class CheckinV2Service(
     LOGGER.info("Uploaded liveness reference image for checkin {} ({} bytes)", checkin.uuid, referenceImageBytes.size)
   }
 
-  // ========================================
-  // Private Helper Methods
-  // ========================================
-
   /**
    * Run the face-compare call against Rekognition and return the outcome (result + score).
    *
@@ -885,28 +879,19 @@ class CheckinV2Service(
     return outcome
   }
 
-  @Transactional
   fun createCheckin(request: CreateCheckinV2Request): CheckinV2Dto {
     LOGGER.info(
       "DEBUG: Manually creating checkin for offender {} with due date {}",
       request.offender,
       request.dueDate,
     )
+    val offender = offenderRepository.findByUuid(request.offender).orElseThrow {
+      ResponseStatusException(HttpStatus.NOT_FOUND, "Offender not found: $request.offender")
+    }
 
-    // Use CheckinCreationService - single source of truth for checkin creation
-    val checkin =
-      checkinCreationService.createCheckin(
-        offenderUuid = request.offender,
-        dueDate = request.dueDate,
-        createdBy = request.practitioner,
-      )
-
-    // Fetch personal details for response
-    val personalDetails = ndiliusApiClient.getContactDetails(checkin.offender.crn)
-    return checkin.dto(personalDetails, clock = clock, checkinWindow = checkinWindowPeriod)
+    return createCheckin(offender, request.dueDate, request.practitioner)
   }
 
-  @Transactional
   fun createCheckinByCrn(request: CreateCheckinByCrnV2Request): CheckinV2Dto {
     LOGGER.info(
       "DEBUG: Manually creating checkin by crn for offender {} with due date {}",
@@ -918,25 +903,36 @@ class CheckinV2Service(
       ResponseStatusException(HttpStatus.NOT_FOUND, "Offender not found: $request.offender")
     }
 
-    // Use CheckinCreationService - single source of truth for checkin creation
-    val checkin =
-      checkinCreationService.createCheckin(
-        offenderUuid = offender.uuid,
-        dueDate = request.dueDate,
-        createdBy = request.practitioner,
-      )
+    return createCheckin(offender, request.dueDate, request.practitioner)
+  }
 
-    // Fetch personal details for response
-    val personalDetails = ndiliusApiClient.getContactDetails(checkin.offender.crn)
+  private fun createCheckin(offender: OffenderV2, dueDate: LocalDate, requestedBy: ExternalUserId): CheckinV2Dto {
+    if (offender.status != OffenderStatus.VERIFIED) {
+      throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Offender not verified")
+    }
+    if (dueDate.isBefore(LocalDate.now())) {
+      throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Due date must be in the future")
+    }
+
+    val personalDetails = ndiliusApiClient.getContactDetails(offender.crn)
+    val currentEvent = if (personalDetails == null) offender.currentEvent else activeEventNumber(offender, personalDetails)
+    if (currentEvent == null) {
+      throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Offender has no active event")
+    }
+
+    val checkin = checkinCreationService.createCheckin(
+      offenderUuid = offender.uuid,
+      dueDate = dueDate,
+      createdBy = requestedBy,
+    )
+
     return checkin.dto(personalDetails, clock = clock, checkinWindow = checkinWindowPeriod)
   }
 
-  @Transactional
   fun sendInvite(uuid: UUID, request: CheckinNotificationV2Request): CheckinV2Dto {
-    val checkin =
-      checkinRepository.findByUuid(uuid).orElseThrow {
-        ResponseStatusException(HttpStatus.NOT_FOUND, "Checkin not found: $uuid")
-      }
+    val checkin = checkinRepository.findByUuid(uuid).orElseThrow {
+      ResponseStatusException(HttpStatus.NOT_FOUND, "Checkin not found: $uuid")
+    }
 
     LOGGER.info("DEBUG: Manually triggering notification for checkin {}", uuid)
 
@@ -948,8 +944,22 @@ class CheckinV2Service(
         null
       }
 
+    val offender = checkin.offender
+    val currentEvent = if (contactDetails == null) offender.currentEvent else activeEventNumber(offender, contactDetails)
+    if (currentEvent == null) {
+      throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Offender has no active event")
+    }
+
     if (contactDetails != null) {
-      notificationService.sendCheckinCreatedNotifications(checkin, contactDetails)
+      val event = CheckinCreatedEvent(
+        checkinId = checkin.id,
+        offenderId = checkin.offender.id,
+        practitionerId = checkin.createdBy,
+        checkin = checkin.dto(contactDetails, clock = clock, checkinWindow = checkinWindowPeriod),
+        offenderContactPreference = checkin.offender.contactPreference,
+        checkin.offender.currentEvent,
+      )
+      notificationService.sendCheckinCreatedNotifications(event)
     } else {
       LOGGER.warn("Skipping manual notification for checkin {}: contact details not found", uuid)
     }
@@ -957,7 +967,6 @@ class CheckinV2Service(
     return checkin.dto(contactDetails, clock = clock, checkinWindow = checkinWindowPeriod)
   }
 
-  @Transactional
   fun sendReminder(uuid: UUID): CheckinV2Dto {
     val checkin =
       checkinRepository.findByUuid(uuid).orElseThrow {
@@ -994,12 +1003,10 @@ class CheckinV2Service(
     return checkin.dto(contactDetails, clock = clock, checkinWindow = checkinWindowPeriod)
   }
 
-  @Transactional
   fun logCheckinEvent(uuid: UUID, request: LogCheckinEventV2Request): UUID {
-    val checkin =
-      checkinRepository.findByUuid(uuid).orElseThrow {
-        ResponseStatusException(HttpStatus.NOT_FOUND, "Checkin not found: $uuid")
-      }
+    checkinRepository.findByUuid(uuid).orElseThrow {
+      ResponseStatusException(HttpStatus.NOT_FOUND, "Checkin not found: $uuid")
+    }
 
     val eventUuid = UUID.randomUUID()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/CheckinV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/CheckinV2Service.kt
@@ -957,7 +957,7 @@ class CheckinV2Service(
         practitionerId = checkin.createdBy,
         checkin = checkin.dto(contactDetails, clock = clock, checkinWindow = checkinWindowPeriod),
         offenderContactPreference = checkin.offender.contactPreference,
-        checkin.offender.currentEvent,
+        currentEvent = currentEvent,
       )
       notificationService.sendCheckinCreatedNotifications(event)
     } else {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/CheckinV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/CheckinV2Service.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.config.AppConfig
 import uk.gov.justice.digital.hmpps.esupervisionapi.config.Feature
 import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.NotificationType
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.logger
+import uk.gov.justice.digital.hmpps.esupervisionapi.utils.today
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinRequestApplicator.applyRequest
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.checkin.CheckinCreationService
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.checkin.activeEventNumber
@@ -910,7 +911,7 @@ class CheckinV2Service(
     if (offender.status != OffenderStatus.VERIFIED) {
       throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Offender not verified")
     }
-    if (dueDate.isBefore(LocalDate.now())) {
+    if (dueDate.isBefore(clock.today())) {
       throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Due date must be in the future")
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/CheckinV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/CheckinV2Service.kt
@@ -915,9 +915,9 @@ class CheckinV2Service(
       throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Due date must be in the future")
     }
 
-    val personalDetails = ndiliusApiClient.getContactDetails(offender.crn)
-    val currentEvent = if (personalDetails == null) offender.currentEvent else activeEventNumber(offender, personalDetails)
-    if (currentEvent == null) {
+    val personalDetails = ndiliusApiClient.getContactDetails(offender.crn) ?:
+      throw ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Failed to fetch contact details for CRN=${offender.crn}")
+    if (activeEventNumber(offender, personalDetails) == null) {
       throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Offender has no active event")
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/EventDtos.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/EventDtos.kt
@@ -24,6 +24,18 @@ sealed interface ICheckinEvent : IEventBase {
   val outboxItemCoords: Pair<OutboxItemType, Long>? get() = null
 }
 
+data class CheckinCreatedEvent(
+  override val checkinId: Long,
+  override val offenderId: Long,
+  override val practitionerId: ExternalUserId,
+  override val checkin: CheckinV2Dto,
+  override val offenderContactPreference: ContactPreference,
+  override val currentEvent: Long?,
+) : ICheckinEvent,
+  ActiveEvent {
+  override val outboxItemCoords = OutboxItemType.CHECKIN_CREATED to checkinId
+}
+
 data class CheckinSubmittedEvent(
   override val checkinId: Long,
   override val offenderId: Long,
@@ -53,6 +65,32 @@ data class CheckinAnnotatedEvent(
   val annotation: Pair<Long, UUID>,
 ) : ICheckinEvent {
   override val outboxItemCoords = OutboxItemType.CHECKIN_ANNOTATED to annotation.first
+}
+
+/**
+ * Finalised event requires the checkin ID to be set, which we only get after DB insert is done.
+ */
+data class PartialCheckinCreatedEvent(
+  override val checkinId: Long = -1,
+  override val offenderId: Long,
+  override val practitionerId: ExternalUserId,
+  override val checkin: CheckinV2Dto,
+  override val offenderContactPreference: ContactPreference,
+  override val currentEvent: Long?,
+) : IEventBase,
+  IPartialEvent,
+  ActiveEvent {
+  fun finalise(checkin: OffenderCheckinV2): CheckinCreatedEvent {
+    require(checkin.id != 0L) { "Checkin ID must be set after DB insert" }
+    return CheckinCreatedEvent(
+      checkinId = checkin.id,
+      offenderId = offenderId,
+      practitionerId = practitionerId,
+      checkin = this.checkin,
+      offenderContactPreference = offenderContactPreference,
+      currentEvent = currentEvent,
+    )
+  }
 }
 
 /**

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NdiliusApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NdiliusApiClient.kt
@@ -15,6 +15,10 @@ class NdiliusBatchFetchException(val crns: List<CRN>, message: String, cause: Ex
 
 interface INdiliusApiClient {
   fun validatePersonalDetails(personalDetails: PersonalDetails): Boolean
+
+  /**
+   * Get contact details by CRN. Returns null if not found.
+   */
   fun getContactDetails(crn: String): ContactDetails?
   fun getContactDetailsForMultiple(crns: List<String>): List<ContactDetails>
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorV2Service.kt
@@ -444,17 +444,9 @@ class NotificationOrchestratorV2Service(
   ) {
     if (notificationsWithRecipients.isEmpty()) return
 
-    val savedNotifications =
-      notificationPersistence.saveNotifications(
-        notificationsWithRecipients.map { it.notification },
-      )
+    notificationPersistence.saveNotifications(notificationsWithRecipients.map { it.notification },)
 
-    val notificationsToSend =
-      savedNotifications.zip(notificationsWithRecipients).map { (saved, wrapper) ->
-        NotificationWithRecipient(saved, wrapper.recipient)
-      }
-
-    notificationsToSend.forEach { wrapper ->
+    notificationsWithRecipients.forEach { wrapper ->
       val notification = wrapper.notification
       val recipient = wrapper.recipient
 
@@ -472,7 +464,7 @@ class NotificationOrchestratorV2Service(
           "Sent {} notification to {} for offender {}, notificationId={}",
           notification.channel,
           notification.recipientType,
-          notification.offender?.crn ?: "unknown",
+          wrapper.offender?.crn ?: "unknown",
           notifyId,
         )
 
@@ -482,12 +474,7 @@ class NotificationOrchestratorV2Service(
           notifyId = notifyId,
         )
       } catch (e: Exception) {
-        val sanitized =
-          PiiSanitizer.sanitizeException(
-            e,
-            notification.offender?.crn,
-            notification.offender?.uuid,
-          )
+        val sanitized = PiiSanitizer.sanitizeException(e, wrapper.offender?.crn, null)
         LOGGER.warn(
           "Failed to send {} to {}: {}",
           notification.channel,
@@ -499,7 +486,7 @@ class NotificationOrchestratorV2Service(
           notification = notification,
           success = false,
           notifyId = UUID.randomUUID(),
-          error = PiiSanitizer.sanitizeMessage(e.message ?: "Unknown error", null, null),
+          error = PiiSanitizer.sanitizeMessage(e.message ?: "Unknown error", wrapper.offender?.crn, null),
         )
       }
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorV2Service.kt
@@ -444,7 +444,7 @@ class NotificationOrchestratorV2Service(
   ) {
     if (notificationsWithRecipients.isEmpty()) return
 
-    notificationPersistence.saveNotifications(notificationsWithRecipients.map { it.notification },)
+    notificationPersistence.saveNotifications(notificationsWithRecipients.map { it.notification })
 
     notificationsWithRecipients.forEach { wrapper ->
       val notification = wrapper.notification

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorV2Service.kt
@@ -209,21 +209,29 @@ class NotificationOrchestratorV2Service(
   }
 
   /** Send notifications for checkin created event */
-  fun sendCheckinCreatedNotifications(
-    checkin: OffenderCheckinV2,
-    contactDetails: ContactDetails,
-  ) {
-    domainEventService.publishDomainEvent(
-      eventType = DomainEventType.V2_CHECKIN_CREATED,
-      uuid = checkin.uuid,
-      crn = checkin.offender.crn,
-      description = "Check-in created for ${checkin.offender.crn} with due date ${checkin.dueDate}",
-    )
+  fun sendCheckinCreatedNotifications(event: CheckinCreatedEvent) {
+    // NOTE: there's a bit of confusion about what happens when we don't have the offender's contact details.
+    // In principle, we shouldn't get here in the first place (e.g., the service level code returns a 422 error
+    // to the client). But let's say checkin was created, and we somehow got here. We will publish domain event
+    // to reflect what happened in the database and possibly resolve any issues after investigating
+    val checkin = event.checkin
+    val activeEventNumber = if (checkin.personalDetails == null) event.currentEvent else activeEventNumber(event, checkin.personalDetails)
+    if (activeEventNumber == null) {
+      LOGGER.warn("Skipping checkin created notifications for checkin {}, CRN={}: no active events found", checkin.uuid, checkin.crn)
+      return
+    }
+
+    event.publish(domainEventService)
+
+    if (event.checkin.personalDetails == null) {
+      LOGGER.warn("Skipping checkin created notifications for checkin {}, CRN={}: personal details not found", checkin.uuid, checkin.crn)
+      return
+    }
 
     try {
-      // Calculate final checkin date (last day offender can submit)
+      // final checkin date == last day offender can submit
       val finalCheckinDate = checkin.dueDate.plus(checkinWindowPeriod).minusDays(1)
-
+      val contactDetails = checkin.personalDetails
       val personalisation =
         mapOf(
           "firstName" to contactDetails.name.forename,
@@ -232,19 +240,19 @@ class NotificationOrchestratorV2Service(
           "url" to appConfig.checkinSubmitUrlV2(checkin.uuid).toString(),
         )
 
-      // V1 only notifies offender for checkin invite (no practitioner template)
+      // we only notify the offender by sending them a checkin invite
       val notificationsWithRecipients =
         notificationPersistence.buildOffenderNotifications(
-          offenderId = checkin.offender.id,
-          crn = checkin.offender.crn,
-          contactPreference = checkin.offender.contactPreference,
+          offenderId = event.offenderId,
+          crn = checkin.crn,
+          contactPreference = event.offenderContactPreference,
           contactDetails = contactDetails,
           notificationType = NotificationType.OffenderCheckinInvite,
         )
 
       processAndSendNotifications(notificationsWithRecipients, personalisation)
     } catch (e: Exception) {
-      val sanitized = PiiSanitizer.sanitizeException(e, checkin.offender.crn, checkin.offender.uuid)
+      val sanitized = PiiSanitizer.sanitizeException(e, checkin.crn)
       LOGGER.warn(
         "Failed to send checkin created notifications for checkin {}: {}",
         checkin.uuid,
@@ -289,14 +297,9 @@ class NotificationOrchestratorV2Service(
 
   /** Send notifications for checkin submitted event */
   fun sendCheckinSubmittedNotifications(event: CheckinSubmittedEvent) {
-    val checkin = event.checkin
-    domainEventService.publishDomainEvent(
-      eventType = DomainEventType.V2_CHECKIN_SUBMITTED,
-      uuid = checkin.uuid,
-      crn = checkin.crn,
-      description = "Check-in submitted for ${checkin.crn}",
-    )
+    event.publish(domainEventService)
 
+    val checkin = event.checkin
     if (event.checkin.personalDetails == null) {
       LOGGER.debug("Skipping checkin submitted notifications for checkin {}: personal details not found", event.checkin.uuid)
       return
@@ -367,15 +370,7 @@ class NotificationOrchestratorV2Service(
   }
 
   /** Send notifications for checkin reviewed event */
-  fun sendCheckinReviewedNotifications(event: CheckinReviewedEvent) {
-    val checkin = event.checkin
-    domainEventService.publishDomainEvent(
-      eventType = DomainEventType.V2_CHECKIN_REVIEWED,
-      uuid = checkin.uuid,
-      crn = checkin.crn,
-      description = "Check-in reviewed for ${checkin.crn} by ${checkin.reviewedBy}",
-    )
-  }
+  fun sendCheckinReviewedNotifications(event: CheckinReviewedEvent) = event.publish(domainEventService)
 
   /** Send notifications for checkin expired event */
   fun sendCheckinExpiredNotifications(
@@ -414,14 +409,7 @@ class NotificationOrchestratorV2Service(
   )
 
   /** Send notifications for checkin updated event */
-  fun sendCheckinUpdatedNotifications(event: CheckinAnnotatedEvent) {
-    domainEventService.publishDomainEvent(
-      eventType = DomainEventType.V2_CHECKIN_ANNOTATED,
-      uuid = event.annotation.second,
-      crn = event.checkin.crn,
-      description = "Check-in updated for ${event.checkin.crn}",
-    )
-  }
+  fun sendCheckinUpdatedNotifications(event: CheckinAnnotatedEvent) = event.publish(domainEventService)
 
   /** Send reminder for practitioner to add custom questions */
   fun sendPractitionerCustomQuestionsReminder(info: QuestionsReminderInfo) {
@@ -533,4 +521,40 @@ class NotificationOrchestratorV2Service(
       CheckinInterval.EIGHT_WEEKS -> "eight weeks"
     }
   }
+}
+
+fun CheckinCreatedEvent.publish(domainEventService: DomainEventService) {
+  domainEventService.publishDomainEvent(
+    eventType = DomainEventType.V2_CHECKIN_CREATED,
+    uuid = checkin.uuid,
+    crn = checkin.crn,
+    description = "Check-in created for ${checkin.crn} with due date ${checkin.dueDate}",
+  )
+}
+
+fun CheckinSubmittedEvent.publish(domainEventService: DomainEventService) {
+  domainEventService.publishDomainEvent(
+    eventType = DomainEventType.V2_CHECKIN_SUBMITTED,
+    uuid = checkin.uuid,
+    crn = checkin.crn,
+    description = "Check-in submitted for ${checkin.crn}",
+  )
+}
+
+fun CheckinReviewedEvent.publish(domainEventService: DomainEventService) {
+  domainEventService.publishDomainEvent(
+    eventType = DomainEventType.V2_CHECKIN_REVIEWED,
+    uuid = checkin.uuid,
+    crn = checkin.crn,
+    description = "Check-in reviewed for ${checkin.crn} by ${checkin.reviewedBy}",
+  )
+}
+
+fun CheckinAnnotatedEvent.publish(domainEventService: DomainEventService) {
+  domainEventService.publishDomainEvent(
+    eventType = DomainEventType.V2_CHECKIN_ANNOTATED,
+    uuid = annotation.second,
+    crn = checkin.crn,
+    description = "Check-in updated for ${checkin.crn}",
+  )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationPersistenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationPersistenceService.kt
@@ -83,6 +83,7 @@ class NotificationPersistenceService(
             ContactPreference.PHONE -> (pair.second as PhoneNumber).phoneNumber
             ContactPreference.EMAIL -> (pair.second as Email).email
           },
+          AssociatedOffenderInfo(crn),
         ),
       )
     }
@@ -123,7 +124,7 @@ class NotificationPersistenceService(
           sentAt = null,
           updatedAt = null,
         )
-        notifications.add(NotificationWithRecipient(notification, contactDetails.email))
+        notifications.add(NotificationWithRecipient(notification, contactDetails.email, AssociatedOffenderInfo.create(crn)))
       }
     }
 
@@ -161,9 +162,19 @@ class NotificationPersistenceService(
   }
 }
 
+data class AssociatedOffenderInfo(val crn: CRN) {
+  companion object {
+    fun create(crn: CRN?): AssociatedOffenderInfo? = crn?.let { AssociatedOffenderInfo(crn) }
+  }
+}
+
+
 data class NotificationWithRecipient(
   val notification: GenericNotificationV2,
+  /** Phone number or email address */
   val recipient: String,
+  /** Offender associated with the notification (which may be different than the recipient) */
+  val offender: AssociatedOffenderInfo?
 )
 
 data class SendResult(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationPersistenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationPersistenceService.kt
@@ -168,13 +168,12 @@ data class AssociatedOffenderInfo(val crn: CRN) {
   }
 }
 
-
 data class NotificationWithRecipient(
   val notification: GenericNotificationV2,
   /** Phone number or email address */
   val recipient: String,
   /** Offender associated with the notification (which may be different than the recipient) */
-  val offender: AssociatedOffenderInfo?
+  val offender: AssociatedOffenderInfo?,
 )
 
 data class SendResult(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationV2Service.kt
@@ -38,8 +38,8 @@ class NotificationV2Service(
   /**
    * Send notifications for checkin created event
    */
-  fun sendCheckinCreatedNotifications(checkin: OffenderCheckinV2, contactDetails: ContactDetails) {
-    orchestrator.sendCheckinCreatedNotifications(checkin, contactDetails)
+  fun sendCheckinCreatedNotifications(event: CheckinCreatedEvent) {
+    orchestrator.sendCheckinCreatedNotifications(event)
   }
 
   /**

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Entities.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Entities.kt
@@ -40,6 +40,13 @@ interface CheckinSchedule {
 }
 
 /**
+ * Provides current event number for the offender.
+ */
+interface ActiveEvent {
+  val currentEvent: Long?
+}
+
+/**
  * V2 Offender Entity (no PII, only CRN)
  */
 @Entity
@@ -85,9 +92,10 @@ open class OffenderV2(
   open var contactPreference: ContactPreference,
 
   @Column(name = "current_event", nullable = true)
-  open var currentEvent: Long? = null,
+  open override var currentEvent: Long? = null,
 ) : V2BaseEntity(),
-  CheckinSchedule {
+  CheckinSchedule,
+  ActiveEvent {
   fun dto(personalDetails: ContactDetails? = null): OffenderV2Dto = OffenderV2Dto(
     uuid = uuid,
     crn = crn,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Entities.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Entities.kt
@@ -320,10 +320,6 @@ open class GenericNotificationV2(
   @Column(name = "channel", nullable = false, length = 50)
   open var channel: String, // SMS or EMAIL
 
-  @ManyToOne(cascade = [CascadeType.DETACH])
-  @JoinColumn(name = "offender_id", referencedColumnName = "id", nullable = true, insertable = false, updatable = false)
-  open var offender: OffenderV2? = null,
-
   @Column(name = "offender_id", nullable = true)
   open var offenderId: Long? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Repositories.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Repositories.kt
@@ -760,20 +760,4 @@ interface OutboxItemRepository : JpaRepository<OutboxItem, Long> {
 
   @Query
   fun findByTypeAndEntityId(type: OutboxItemType, entityId: Long): Optional<OutboxItem>
-
-  @Query(
-    """
-    select item 
-    from OutboxItem item 
-    where item.type in :type and item.status in :status and cast(item.createdAt as date) >= :lowerBoundInclusive
-    order by item.createdAt desc
-    limit :limit
-  """,
-  )
-  fun findByTypeAndStatus(
-    type: Set<OutboxItemType>,
-    status: Set<OutboxItemStatus>,
-    lowerBoundInclusive: LocalDate,
-    limit: Int = 100,
-  ): List<OutboxItem>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Repositories.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Repositories.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.esupervisionapi.v2
 import com.fasterxml.jackson.core.type.TypeReference
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
@@ -12,7 +13,9 @@ import org.springframework.stereotype.Component
 import org.springframework.stereotype.Repository
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.esupervisionapi.utils.CRN
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.logger
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ContactPreference
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ExternalUserId
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.question.replacePlaceholder
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.stats.StatsProviderDto
@@ -31,6 +34,8 @@ import java.util.stream.Stream
 @Repository
 interface OffenderV2Repository : JpaRepository<OffenderV2, Long> {
   fun findByUuid(uuid: UUID): Optional<OffenderV2>
+
+  @Transactional(readOnly = true)
   fun findByCrn(crn: String): Optional<OffenderV2>
 
   /**
@@ -58,6 +63,36 @@ interface OffenderV2Repository : JpaRepository<OffenderV2, Long> {
     lowerBoundInclusive: LocalDate,
     upperBoundExclusive: LocalDate,
   ): Stream<OffenderV2>
+
+  @Query(
+    value = """
+    SELECT o.id, o.crn, o.practitioner_id, o.contact_preference, o.current_event FROM offender_v2 o
+    WHERE o.status = 'VERIFIED'
+      AND o.first_checkin <= :lowerBoundInclusive
+      AND MOD(CAST(:lowerBoundInclusive - o.first_checkin AS integer), CAST(EXTRACT(DAY FROM o.checkin_interval) AS integer)) = 0
+      AND NOT EXISTS (
+        SELECT 1 FROM offender_checkin_v2 c
+        WHERE c.offender_id = o.id
+          AND :lowerBoundInclusive <= c.due_date
+          AND c.due_date < :upperBoundExclusive
+          AND c.status IN ('CREATED', 'SUBMITTED', 'REVIEWED')
+      )
+    """,
+    nativeQuery = true,
+  )
+  fun findEligibleForCheckinCreation(
+    lowerBoundInclusive: LocalDate,
+    upperBoundExclusive: LocalDate,
+    pageable: Pageable,
+  ): Slice<IOffenderCheckinCreationInfo>
+
+  interface IOffenderCheckinCreationInfo : ActiveEvent {
+    val id: Long
+    val crn: CRN
+    val practitionerId: ExternalUserId
+    val contactPreference: ContactPreference
+    override val currentEvent: Long?
+  }
 
   /**
    * Find offenders whose next checkin due date matches specific offsets from :today
@@ -147,6 +182,21 @@ interface OffenderCheckinV2Repository : JpaRepository<OffenderCheckinV2, Long> {
   @EntityGraph(attributePaths = ["offender"])
   fun findByUuid(uuid: UUID): Optional<OffenderCheckinV2>
   fun findAllByOffenderAndStatus(offender: OffenderV2, status: CheckinV2Status): List<OffenderCheckinV2>
+
+  @Query("""select c from OffenderCheckinV2 c where c.id in :ids""")
+  @EntityGraph(attributePaths = ["offender"])
+  fun findAllByIds(ids: List<Long>): List<OffenderCheckinV2>
+
+  @Query(
+    """
+    select o.crn
+    from offender_checkin_v2 c
+    join offender_v2 o on o.id = c.offender_id
+    where c.id in :ids
+     """,
+    nativeQuery = true,
+  )
+  fun findCrnsByCheckinIds(ids: List<Long>): List<String>
 
   @Query(
     """
@@ -291,6 +341,7 @@ interface GenericNotificationV2Repository : JpaRepository<GenericNotificationV2,
         AND n.createdAt >= :cutoffTime
   """,
   )
+  @Transactional(readOnly = true)
   fun hasNotificationBeenSent(
     offender: OffenderV2,
     eventType: String,
@@ -730,4 +781,20 @@ interface OutboxItemRepository : JpaRepository<OutboxItem, Long> {
 
   @Query
   fun findByTypeAndEntityId(type: OutboxItemType, entityId: Long): Optional<OutboxItem>
+
+  @Query(
+    """
+    select item 
+    from OutboxItem item 
+    where item.type in :type and item.status in :status and cast(item.createdAt as date) >= :lowerBoundInclusive
+    order by item.createdAt desc
+    limit :limit
+  """,
+  )
+  fun findByTypeAndStatus(
+    type: Set<OutboxItemType>,
+    status: Set<OutboxItemStatus>,
+    lowerBoundInclusive: LocalDate,
+    limit: Int = 100,
+  ): List<OutboxItem>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Repositories.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Repositories.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.esupervisionapi.v2
 import com.fasterxml.jackson.core.type.TypeReference
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
-import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
@@ -56,14 +55,18 @@ interface OffenderV2Repository : JpaRepository<OffenderV2, Long> {
           AND c.due_date < :upperBoundExclusive
           AND c.status IN ('CREATED', 'SUBMITTED', 'REVIEWED')
       )
+      AND o.id > coalesce(:lastOffenderId, 0)
+    ORDER BY o.id
+    FETCH FIRST :chunkSize ROWS ONLY
     """,
     nativeQuery = true,
   )
   fun findEligibleForCheckinCreation(
     lowerBoundInclusive: LocalDate,
     upperBoundExclusive: LocalDate,
-    pageable: Pageable,
-  ): Slice<IOffenderCheckinCreationInfo>
+    chunkSize: Int = 10,
+    lastOffenderId: Long? = null,
+  ): List<IOffenderCheckinCreationInfo>
 
   interface IOffenderCheckinCreationInfo : ActiveEvent {
     val id: Long

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Repositories.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Repositories.kt
@@ -38,32 +38,6 @@ interface OffenderV2Repository : JpaRepository<OffenderV2, Long> {
   @Transactional(readOnly = true)
   fun findByCrn(crn: String): Optional<OffenderV2>
 
-  /**
-   * Find offenders eligible for checkin creation
-   * - Status = VERIFIED
-   * - Next checkin due date is today or earlier
-   */
-  @Query(
-    value = """
-    SELECT o.* FROM offender_v2 o
-    WHERE o.status = 'VERIFIED'
-      AND o.first_checkin <= :lowerBoundInclusive
-      AND MOD(CAST(:lowerBoundInclusive - o.first_checkin AS integer), CAST(EXTRACT(DAY FROM o.checkin_interval) AS integer)) = 0
-      AND NOT EXISTS (
-        SELECT 1 FROM offender_checkin_v2 c
-        WHERE c.offender_id = o.id
-          AND :lowerBoundInclusive <= c.due_date
-          AND c.due_date < :upperBoundExclusive
-          AND c.status IN ('CREATED', 'SUBMITTED', 'REVIEWED')
-      )
-    """,
-    nativeQuery = true,
-  )
-  fun findEligibleForCheckinCreation(
-    lowerBoundInclusive: LocalDate,
-    upperBoundExclusive: LocalDate,
-  ): Stream<OffenderV2>
-
   @Query(
     value = """
     SELECT o.id, o.crn, o.practitioner_id, o.contact_preference, o.current_event FROM offender_v2 o

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Repositories.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Repositories.kt
@@ -40,7 +40,12 @@ interface OffenderV2Repository : JpaRepository<OffenderV2, Long> {
 
   @Query(
     value = """
-    SELECT o.id, o.crn, o.practitioner_id, o.contact_preference, o.current_event FROM offender_v2 o
+    SELECT
+        o.id as id, 
+        o.crn as crn, 
+        o.practitioner_id as practitionerId, 
+        o.contact_preference as contactPreference, 
+        o.current_event as currentEvent FROM offender_v2 o
     WHERE o.status = 'VERIFIED'
       AND o.first_checkin <= :lowerBoundInclusive
       AND MOD(CAST(:lowerBoundInclusive - o.first_checkin AS integer), CAST(EXTRACT(DAY FROM o.checkin_interval) AS integer)) = 0

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Repositories.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Repositories.kt
@@ -206,7 +206,7 @@ interface OffenderCheckinV2Repository : JpaRepository<OffenderCheckinV2, Long> {
       AND c.dueDate = :checkinStartDate
       AND NOT EXISTS (
           SELECT n FROM GenericNotificationV2 n
-          WHERE n.offender = o
+          WHERE n.offenderId = o.id
             AND n.eventType = :notificationType
             AND n.createdAt >= :checkinWindowStart
       )
@@ -315,7 +315,7 @@ interface GenericNotificationV2Repository : JpaRepository<GenericNotificationV2,
     """
       SELECT COUNT(n) > 0 
       FROM GenericNotificationV2 n 
-      WHERE n.offender = :offender 
+      WHERE n.offenderId = :#{#offender.id}
         AND n.eventType = :eventType 
         AND n.createdAt >= :cutoffTime
   """,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/audit/EventAuditV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/audit/EventAuditV2Service.kt
@@ -5,14 +5,12 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.support.TransactionTemplate
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.CRN
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinCreatedEvent
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinReviewedEvent
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinSubmittedEvent
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.ContactDetails
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.EventAuditV2
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.EventAuditV2Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.ICheckinEvent
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.IEventBase
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ExternalUserId
@@ -105,32 +103,27 @@ class EventAuditV2Service(
   /**
    * Record checkin created event
    */
-  fun recordCheckinCreated(checkin: OffenderCheckinV2, event: ICheckinEvent) =
-    recordCheckinEvent(CheckinAuditEventType.CHECKIN_CREATED, checkin, event)
+  fun recordCheckinCreated(checkin: OffenderCheckinV2, event: ICheckinEvent) = recordCheckinEvent(CheckinAuditEventType.CHECKIN_CREATED, checkin, event)
 
   /**
    * Record checkin submitted event
    */
-  fun recordCheckinSubmitted(checkin: OffenderCheckinV2, event: CheckinSubmittedEvent) =
-    recordCheckinEvent(CheckinAuditEventType.CHECKIN_SUBMITTED, checkin, event)
+  fun recordCheckinSubmitted(checkin: OffenderCheckinV2, event: CheckinSubmittedEvent) = recordCheckinEvent(CheckinAuditEventType.CHECKIN_SUBMITTED, checkin, event)
 
   /**
    * Record checkin reviewed event
    */
-  fun recordCheckinReviewed(checkin: OffenderCheckinV2, event: CheckinReviewedEvent) =
-    recordCheckinEvent(CheckinAuditEventType.CHECKIN_REVIEWED, checkin, event)
+  fun recordCheckinReviewed(checkin: OffenderCheckinV2, event: CheckinReviewedEvent) = recordCheckinEvent(CheckinAuditEventType.CHECKIN_REVIEWED, checkin, event)
 
   /**
    * Record checkin expired event
    */
-  fun recordCheckinExpired(checkins: Iterable<Pair<OffenderCheckinV2, ContactDetails?>>) =
-    recordCheckinEvents(CheckinAuditEventType.CHECKIN_EXPIRED, checkins)
+  fun recordCheckinExpired(checkins: Iterable<Pair<OffenderCheckinV2, ContactDetails?>>) = recordCheckinEvents(CheckinAuditEventType.CHECKIN_EXPIRED, checkins)
 
   /**
    * Record checkin reminder event
    */
-  fun recordCheckinReminded(checkins: Iterable<Pair<OffenderCheckinV2, ContactDetails?>>) =
-    recordCheckinEvents(CheckinAuditEventType.CHECKIN_REMINDER, checkins)
+  fun recordCheckinReminded(checkins: Iterable<Pair<OffenderCheckinV2, ContactDetails?>>) = recordCheckinEvents(CheckinAuditEventType.CHECKIN_REMINDER, checkins)
 
   fun recordOffenderEvent(eventType: OffenderAuditEventType, offender: OffenderV2, contactDetails: ContactDetails?, notes: String?, sensitive: Boolean = false) {
     if (contactDetails == null) {
@@ -218,7 +211,7 @@ class EventAuditV2Service(
         practitionerId = this.practitionerId,
         contactDetails = checkinDto.personalDetails,
         checkin = checkin,
-        notes = "Created by scheduled job"
+        notes = "Created by scheduled job",
       )
 
       CheckinAuditEventType.CHECKIN_SUBMITTED -> buildAudit(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/audit/EventAuditV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/audit/EventAuditV2Service.kt
@@ -4,11 +4,18 @@ import com.google.common.collect.Lists
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.support.TransactionTemplate
+import uk.gov.justice.digital.hmpps.esupervisionapi.utils.CRN
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinCreatedEvent
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinReviewedEvent
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinSubmittedEvent
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.ContactDetails
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.EventAuditV2
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.EventAuditV2Repository
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.ICheckinEvent
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.IEventBase
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ExternalUserId
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.security.PiiSanitizer
 import java.math.BigDecimal
 import java.time.Clock
@@ -55,22 +62,23 @@ class EventAuditV2Service(
    */
   fun recordSetupCompleted(offender: OffenderV2, contactDetails: ContactDetails?) = recordOffenderEvent(OffenderAuditEventType.SETUP_COMPLETED, offender, contactDetails, null, sensitive = false)
 
-  fun recordCheckinEvent(event: CheckinAuditEventType, checkin: OffenderCheckinV2, contactDetails: ContactDetails?) {
-    if (contactDetails?.practitioner == null) {
-      LOGGER.warn("Cannot record audit event {} for checkin {}: practitioner details not found", event.name, checkin.uuid)
+  fun recordCheckinEvent(eventType: CheckinAuditEventType, checkin: OffenderCheckinV2, event: ICheckinEvent) {
+    if (event.checkin.personalDetails?.practitioner == null) {
+      LOGGER.warn("Cannot record audit event {} for checkin {}: practitioner details not found", eventType.name, checkin.uuid)
       return
     }
 
     try {
-      val payload = checkin.toAudit(event, contactDetails)
+      val payload = event.toAudit(eventType, checkin)
       transactionTemplate.execute { auditRepository.save(payload) }
-      LOGGER.info("Recorded {} audit event for checkin {}", event.name, checkin.uuid)
+      LOGGER.info("Recorded {} audit event for checkin {}", eventType.name, checkin.uuid)
     } catch (e: Exception) {
-      LOGGER.error("Failed to record {} audit event: {}", event.name, PiiSanitizer.sanitizeException(e, checkin.offender.crn, checkin.uuid))
+      LOGGER.error("Failed to record {} audit event: {}", eventType.name, PiiSanitizer.sanitizeException(e, event.checkin.crn, checkin.uuid))
     }
   }
 
   fun recordCheckinEvents(eventType: CheckinAuditEventType, checkins: Iterable<Pair<OffenderCheckinV2, ContactDetails?>>) {
+    assert(eventType == CheckinAuditEventType.CHECKIN_EXPIRED || eventType == CheckinAuditEventType.CHECKIN_REMINDER) // those events are not using the event pattern yet
     val skipped = mutableListOf<UUID>()
     val audits = Lists.newArrayListWithCapacity<EventAuditV2>(checkins.count())
     for ((checkin, contactDetails) in checkins) {
@@ -97,27 +105,32 @@ class EventAuditV2Service(
   /**
    * Record checkin created event
    */
-  fun recordCheckinCreated(checkin: OffenderCheckinV2, contactDetails: ContactDetails?) = recordCheckinEvent(CheckinAuditEventType.CHECKIN_CREATED, checkin, contactDetails)
+  fun recordCheckinCreated(checkin: OffenderCheckinV2, event: ICheckinEvent) =
+    recordCheckinEvent(CheckinAuditEventType.CHECKIN_CREATED, checkin, event)
 
   /**
    * Record checkin submitted event
    */
-  fun recordCheckinSubmitted(checkin: OffenderCheckinV2, contactDetails: ContactDetails?) = recordCheckinEvent(CheckinAuditEventType.CHECKIN_SUBMITTED, checkin, contactDetails)
+  fun recordCheckinSubmitted(checkin: OffenderCheckinV2, event: CheckinSubmittedEvent) =
+    recordCheckinEvent(CheckinAuditEventType.CHECKIN_SUBMITTED, checkin, event)
 
   /**
    * Record checkin reviewed event
    */
-  fun recordCheckinReviewed(checkin: OffenderCheckinV2, contactDetails: ContactDetails?) = recordCheckinEvent(CheckinAuditEventType.CHECKIN_REVIEWED, checkin, contactDetails)
+  fun recordCheckinReviewed(checkin: OffenderCheckinV2, event: CheckinReviewedEvent) =
+    recordCheckinEvent(CheckinAuditEventType.CHECKIN_REVIEWED, checkin, event)
 
   /**
    * Record checkin expired event
    */
-  fun recordCheckinExpired(checkins: Iterable<Pair<OffenderCheckinV2, ContactDetails?>>) = recordCheckinEvents(CheckinAuditEventType.CHECKIN_EXPIRED, checkins)
+  fun recordCheckinExpired(checkins: Iterable<Pair<OffenderCheckinV2, ContactDetails?>>) =
+    recordCheckinEvents(CheckinAuditEventType.CHECKIN_EXPIRED, checkins)
 
   /**
    * Record checkin reminder event
    */
-  fun recordCheckinReminded(checkins: Iterable<Pair<OffenderCheckinV2, ContactDetails?>>) = recordCheckinEvents(CheckinAuditEventType.CHECKIN_REMINDER, checkins)
+  fun recordCheckinReminded(checkins: Iterable<Pair<OffenderCheckinV2, ContactDetails?>>) =
+    recordCheckinEvents(CheckinAuditEventType.CHECKIN_REMINDER, checkins)
 
   fun recordOffenderEvent(eventType: OffenderAuditEventType, offender: OffenderV2, contactDetails: ContactDetails?, notes: String?, sensitive: Boolean = false) {
     if (contactDetails == null) {
@@ -140,7 +153,8 @@ class EventAuditV2Service(
 
   private fun buildAudit(
     eventType: String,
-    offender: OffenderV2,
+    crn: CRN,
+    practitionerId: ExternalUserId,
     contactDetails: ContactDetails,
     checkin: OffenderCheckinV2? = null,
     timeToSubmitHours: BigDecimal? = null,
@@ -154,8 +168,8 @@ class EventAuditV2Service(
   ): EventAuditV2 = EventAuditV2(
     eventType = eventType,
     occurredAt = clock.instant(),
-    crn = offender.crn,
-    practitionerId = offender.practitionerId,
+    crn = crn,
+    practitionerId = practitionerId,
     localAdminUnitCode = contactDetails.practitioner?.localAdminUnit?.code,
     localAdminUnitDescription = contactDetails.practitioner?.localAdminUnit?.description,
     pduCode = contactDetails.practitioner?.probationDeliveryUnit?.code,
@@ -185,7 +199,8 @@ class EventAuditV2Service(
       OffenderAuditEventType.OFFENDER_AUTO_DEACTIVATED_NO_ACTIVE_EVENTS,
       -> buildAudit(
         eventType.name,
-        offender,
+        offender.crn,
+        offender.practitionerId,
         contactDetails,
         notes = notes,
         sensitive = sensitive,
@@ -193,32 +208,42 @@ class EventAuditV2Service(
     }
   }
 
-  private fun OffenderCheckinV2.toAudit(event: CheckinAuditEventType, contactDetails: ContactDetails): EventAuditV2 {
-    val checkin = this
-    return when (event) {
-      CheckinAuditEventType.CHECKIN_CREATED -> buildAudit(event.name, checkin.offender, contactDetails, checkin, notes = "Created by scheduled job")
+  private fun ICheckinEvent.toAudit(eventType: CheckinAuditEventType, checkin: OffenderCheckinV2): EventAuditV2 {
+    val checkinDto = this.checkin
+    require(checkinDto.personalDetails != null)
+    return when (eventType) {
+      CheckinAuditEventType.CHECKIN_CREATED -> buildAudit(
+        eventType = eventType.name,
+        crn = checkinDto.crn,
+        practitionerId = this.practitionerId,
+        contactDetails = checkinDto.personalDetails,
+        checkin = checkin,
+        notes = "Created by scheduled job"
+      )
 
       CheckinAuditEventType.CHECKIN_SUBMITTED -> buildAudit(
-        event.name,
-        checkin.offender,
-        contactDetails,
-        checkin,
+        eventType = eventType.name,
+        crn = checkinDto.crn,
+        practitionerId = this.practitionerId,
+        contactDetails = checkinDto.personalDetails,
+        checkin = checkin,
         timeToSubmitHours = checkin.hoursToSubmit(),
         autoIdCheckResult = checkin.autoIdCheck?.name,
         livenessResult = checkin.livenessResult?.name,
       )
 
       CheckinAuditEventType.CHECKIN_REVIEWED -> {
-        val notes = if (checkin.reviewedBy != null && checkin.reviewedBy != checkin.offender.practitionerId) {
-          "Reviewed by ${checkin.reviewedBy} (possibly covering for ${checkin.offender.practitionerId})"
+        val notes = if (checkin.reviewedBy != null && checkin.reviewedBy != this.practitionerId) {
+          "Reviewed by ${checkin.reviewedBy} (possibly covering for ${this.practitionerId})"
         } else {
           null
         }
         buildAudit(
-          event.name,
-          checkin.offender,
-          contactDetails,
-          checkin,
+          eventType = eventType.name,
+          crn = checkinDto.crn,
+          practitionerId = this.practitionerId,
+          contactDetails = checkinDto.personalDetails,
+          checkin = checkin,
           timeToReviewHours = checkin.hoursToReview(),
           reviewDurationHours = checkin.reviewDurationHours(),
           manualIdCheckResult = checkin.manualIdCheck?.name,
@@ -228,8 +253,32 @@ class EventAuditV2Service(
       }
 
       CheckinAuditEventType.CHECKIN_EXPIRED -> buildAudit(
+        eventType = eventType.name,
+        crn = checkinDto.crn,
+        practitionerId = this.practitionerId,
+        contactDetails = checkinDto.personalDetails,
+        checkin = checkin,
+        notes = "Expired by scheduled job",
+      )
+
+      CheckinAuditEventType.CHECKIN_REMINDER -> buildAudit(
+        eventType = eventType.name,
+        crn = checkinDto.crn,
+        practitionerId = this.practitionerId,
+        contactDetails = checkinDto.personalDetails,
+        checkin = checkin,
+        notes = "Reminder sent by scheduled job",
+      )
+    }
+  }
+
+  private fun OffenderCheckinV2.toAudit(event: CheckinAuditEventType, contactDetails: ContactDetails): EventAuditV2 {
+    val checkin = this
+    return when (event) {
+      CheckinAuditEventType.CHECKIN_EXPIRED -> buildAudit(
         event.name,
-        checkin.offender,
+        checkin.offender.crn,
+        checkin.offender.practitionerId,
         contactDetails,
         checkin,
         notes = "Expired by scheduled job",
@@ -237,11 +286,13 @@ class EventAuditV2Service(
 
       CheckinAuditEventType.CHECKIN_REMINDER -> buildAudit(
         event.name,
-        checkin.offender,
+        checkin.offender.crn,
+        checkin.offender.practitionerId,
         contactDetails,
         checkin,
         notes = "Reminder sent by scheduled job",
       )
+      else -> throw IllegalArgumentException("Unexpected event type: $event")
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/CheckinCreationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/CheckinCreationService.kt
@@ -1,10 +1,13 @@
 package uk.gov.justice.digital.hmpps.esupervisionapi.v2.checkin
 
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionTemplate
 import org.springframework.web.server.ResponseStatusException
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinPersistenceService
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinV2Status
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.INdiliusApiClient
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.NotificationV2Service
@@ -12,13 +15,16 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2Repository
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.PartialCheckinCreatedEvent
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.audit.EventAuditV2Service
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ExternalUserId
 import java.time.Clock
+import java.time.Duration
 import java.time.LocalDate
+import java.time.Period
 import java.util.UUID
 
-class BatchCheckinCreationException(val checkins: List<OffenderCheckinV2>, cause: Exception) : RuntimeException("Failed to batch create checkins", cause)
+class BatchCheckinCreationException(val checkins: List<Pair<OffenderCheckinV2, PartialCheckinCreatedEvent>>, cause: Exception) : RuntimeException("Failed to batch create checkins", cause)
 
 /**
  * Checkin Creation Service
@@ -33,7 +39,12 @@ class CheckinCreationService(
   private val ndiliusApiClient: INdiliusApiClient,
   private val notificationService: NotificationV2Service,
   private val eventAuditService: EventAuditV2Service,
+  @param:Value("\${app.scheduling.checkin-notification.window:72h}") private val checkinWindow: Duration,
+  private val transactionTemplate: TransactionTemplate,
+  private val checkinPersistenceService: CheckinPersistenceService,
 ) {
+
+  val checkinWindowPeriod = Period.ofDays(checkinWindow.toDays().toInt())
 
   /**
    * Create a checkin for an offender
@@ -42,7 +53,6 @@ class CheckinCreationService(
    * @param createdBy Who created the checkin (e.g., "SYSTEM", practitioner ID)
    * @return Created checkin
    */
-  @Transactional
   fun createCheckin(
     offenderUuid: UUID,
     dueDate: LocalDate,
@@ -63,12 +73,14 @@ class CheckinCreationService(
    * @param createdBy Who created the checkin
    * @return Created checkin
    */
-  @Transactional
   fun createCheckinForOffender(
     offender: OffenderV2,
     dueDate: LocalDate,
     createdBy: ExternalUserId,
   ): OffenderCheckinV2 {
+    val contactDetails = ndiliusApiClient.getContactDetails(offender.crn)
+      ?: throw ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Failed to fetch contact details for CRN=${offender.crn}")
+
     val checkin =
       OffenderCheckinV2(
         uuid = UUID.randomUUID(),
@@ -79,64 +91,39 @@ class CheckinCreationService(
         createdBy = createdBy,
       )
 
-    val saved = checkinRepository.save(checkin)
+    val event = PartialCheckinCreatedEvent(
+      offenderId = checkin.offender.id,
+      practitionerId = checkin.createdBy,
+      checkin = checkin.dto(contactDetails, clock = clock, checkinWindow = checkinWindowPeriod),
+      offenderContactPreference = checkin.offender.contactPreference,
+      currentEvent = checkin.offender.currentEvent,
+    )
+
+    checkinPersistenceService.checkinCreation(checkin, event)
 
     LOGGER.info(
-      "Created checkin {} for offender {} (CRN={}) with due date {} by {}",
-      saved.uuid,
-      offender.uuid,
+      "Created checkin {} for offender CRN={} with due date {} by {}",
+      checkin.uuid,
       offender.crn,
       dueDate,
       createdBy,
     )
 
-    // Fetch contact details and send notifications
-    val contactDetails =
-      try {
-        ndiliusApiClient.getContactDetails(offender.crn)
-      } catch (e: Exception) {
-        LOGGER.warn("Failed to fetch contact details for CRN={}", offender.crn, e)
-        null
-      }
-
-    if (contactDetails != null) {
-      try {
-        notificationService.sendCheckinCreatedNotifications(saved, contactDetails)
-      } catch (e: Exception) {
-        LOGGER.info("Failed to send checkin created notifications for checkin {}", saved.uuid, e)
-      }
-    } else {
-      LOGGER.warn("Skipping notifications for checkin {}: contact details not found", saved.uuid)
-    }
-    eventAuditService.recordCheckinCreated(checkin, contactDetails)
-
-    return saved
+    return checkin
   }
 
   /**
-   * Batch create checkins (used by job for efficiency)
    * @param checkins List of checkins to create
    * @return List of saved checkins
    * @throws BatchCheckinCreationException
    */
   @Transactional
-  fun batchCreateCheckins(checkins: List<OffenderCheckinV2>): List<OffenderCheckinV2> {
-    if (checkins.isEmpty()) return emptyList()
-
-    return try {
-      val savedCheckins = checkinRepository.saveAll(checkins).toList()
-
-      LOGGER.info("Batch created {} checkins", savedCheckins.size)
-      savedCheckins.forEach { checkin ->
-        LOGGER.debug(
-          "Created checkin {} for offender {} with due date {}",
-          checkin.uuid,
-          checkin.offender.crn,
-          checkin.dueDate,
-        )
+  fun createCheckins(checkins: List<Pair<OffenderCheckinV2, PartialCheckinCreatedEvent>>) {
+    if (checkins.isEmpty()) return
+    try {
+      for ((checkin, event) in checkins) {
+        checkinPersistenceService.checkinCreation(checkin, event)
       }
-
-      savedCheckins
     } catch (e: Exception) {
       throw BatchCheckinCreationException(checkins, e)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/Utils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/Utils.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.esupervisionapi.v2.checkin
 
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.ActiveEvent
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinSchedule
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.ContactDetails
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2
@@ -17,12 +18,12 @@ import java.time.temporal.ChronoUnit
  *
  * @see uk.gov.justice.digital.hmpps.esupervisionapi.v2.Event
  */
-fun activeEventNumber(offender: OffenderV2, details: ContactDetails): Long? {
+fun activeEventNumber(offender: ActiveEvent, details: ContactDetails): Long? {
   if (offender.currentEvent != null) {
     return offender.currentEvent
   }
 
-  return details.events.firstOrNull()?.number
+  return details.events?.firstOrNull()?.number
 }
 
 /**
@@ -52,18 +53,16 @@ enum class CheckinIneligibilityReason(
  * Determines whether an offender should be stopped from receiving online check-ins, based on the
  * latest Delius contact details. Returns the reason, or null if the offender is still eligible.
  *
- * Stops check-ins when the person has no active probation events or is in reset (contact suspended).
+ * Stops check-ins when the person is in reset (contact suspended) or has no active probation events.
  *
- * Note on ordering: no-active-events takes priority over contact-suspended, because an active event
- * is a prerequisite for check-ins at all. So when a person is both in reset and has no events, we
- * report NO_ACTIVE_EVENTS as the reason.
- *
- * Note on no-active-events: an empty events list means NDelius reports no active probation events.
- * A cached [OffenderV2.currentEvent] always counts as an active event.
+ * Note on no-active-events: we only treat this as grounds for stopping when NDelius returns an
+ * explicitly empty events list. An absent/null events list is treated as indeterminate (e.g. a
+ * partial or degraded response) and does NOT stop check-ins, so a transient data gap can't wrongly
+ * off-board an active person. A cached [OffenderV2.currentEvent] always counts as an active event.
  *
  * @see activeEventNumber
  */
-fun checkinIneligibilityReason(offender: OffenderV2, details: ContactDetails): CheckinIneligibilityReason? = when {
+fun checkinIneligibilityReason(offender: ActiveEvent, details: ContactDetails): CheckinIneligibilityReason? = when {
   offender.currentEvent == null && details.events.isEmpty() -> CheckinIneligibilityReason.NO_ACTIVE_EVENTS
   details.contactSuspended -> CheckinIneligibilityReason.CONTACT_SUSPENDED
   else -> null

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/events/CheckinEventsListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/events/CheckinEventsListener.kt
@@ -7,6 +7,7 @@ import org.springframework.transaction.event.TransactionalEventListener
 import org.springframework.transaction.support.TransactionTemplate
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.logger
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinAnnotatedEvent
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinCreatedEvent
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinReviewedEvent
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinSubmittedEvent
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.ICheckinEvent
@@ -30,6 +31,7 @@ class CheckinEventsListener(
   fun processEvent(event: ICheckinEvent): CompletableFuture<Void> {
     LOGGER.debug("processing checkin event for checkin uuid={} with status={}", event.checkin.uuid, event.checkin.status)
     when (event) {
+      is CheckinCreatedEvent -> notificationService.sendCheckinCreatedNotifications(event)
       is CheckinSubmittedEvent -> notificationService.sendCheckinSubmittedNotifications(event)
       is CheckinReviewedEvent -> notificationService.sendCheckinReviewedNotifications(event)
       is CheckinAnnotatedEvent -> notificationService.sendCheckinUpdatedNotifications(event)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/V2CheckinCreationJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/V2CheckinCreationJob.kt
@@ -6,47 +6,49 @@ import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.data.domain.PageRequest
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
-import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinLogsHintV2
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinLogsV2Dto
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinV2Dto
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.ContactDetails
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.INdiliusApiClient
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.JobLogV2
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.JobLogV2Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.NdiliusBatchFetchException
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.NotificationFailureException
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.NotificationV2Service
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2Repository
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.PartialCheckinCreatedEvent
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.checkin.BatchCheckinCreationException
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.checkin.CheckinCreationService
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.checkin.CheckinIneligibilityReason
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.checkin.activeEventNumber
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.checkin.checkinIneligibilityReason
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.offender.OffenderDeactivationV2Service
 import java.time.Clock
 import java.time.Duration
 import java.time.LocalDate
+import java.time.Period
+import kotlin.jvm.optionals.getOrNull
 import kotlin.math.min
-import kotlin.streams.asSequence
 
 private class JobMetrics {
   var processed = 0
   var created = 0
   var deactivated = 0
   var errors = 0
-  var notifsSent = 0
   var chunks = 0
 }
 
 private fun JobMetrics.info(logger: Logger, jobId: Long, duration: Duration) {
   logger.info(
-    "Checkin Creation Job(id={}) completed: processed={}, created={}, deactivated={}, failed={}, notifications={}, chunks={}, took={}",
+    "Checkin Creation Job(id={}) completed: processed={}, created={}, deactivated={}, failed={}, chunks={}, took={}",
     jobId,
     this.processed,
     this.created,
     this.deactivated,
     this.errors,
-    this.notifsSent,
     this.chunks,
     duration,
   )
@@ -61,22 +63,23 @@ private fun JobMetrics.info(logger: Logger, jobId: Long, duration: Duration) {
 class V2CheckinCreationJob(
   private val clock: Clock,
   private val offenderRepository: OffenderV2Repository,
-  private val checkinRepository: OffenderCheckinV2Repository,
   private val ndiliusApiClient: INdiliusApiClient,
   private val checkinCreationService: CheckinCreationService,
-  private val notificationService: NotificationV2Service,
   private val offenderDeactivationV2Service: OffenderDeactivationV2Service,
   private val jobLogRepository: JobLogV2Repository,
   @PersistenceContext private val entityManager: EntityManager,
   @param:Value("\${app.scheduling.v2-checkin-creation.chunk-size}") private val chunkSize: Int,
+  @param:Value("\${app.scheduling.checkin-notification.window:72h}") private val checkinWindow: Duration,
 ) {
+
+  private val checkinWindowPeriod = Period.ofDays(checkinWindow.toDays().toInt())
+
   @Scheduled(cron = "\${app.scheduling.v2-checkin-creation.cron}")
   @SchedulerLock(
     name = "V2 Checkin Creation Job",
     lockAtLeastFor = "PT5S",
     lockAtMostFor = "PT30M",
   )
-  @Transactional
   fun process() {
     val now = clock.instant()
     val today = LocalDate.now(clock)
@@ -85,73 +88,46 @@ class V2CheckinCreationJob(
     val metrics = JobMetrics()
 
     try {
-      val lowerBound = today
       val upperBound = today.plusDays(1)
       val finalChunkSize = min(chunkSize, INdiliusApiClient.MAX_BATCH_SIZE)
 
-      offenderRepository.findEligibleForCheckinCreation(lowerBound, upperBound).use { stream ->
-        stream.asSequence()
-          .chunked(finalChunkSize)
-          .forEach { chunk ->
-            try {
-              metrics.chunks += 1
-              LOGGER.info("Processing chunk {} with {} offenders", metrics.chunks, chunk.size)
+      do {
+        val pageRequest = PageRequest.of(0, finalChunkSize)
+        val chunk = offenderRepository.findEligibleForCheckinCreation(lowerBoundInclusive = today, upperBound, pageRequest)
+        if (chunk.isEmpty) {
+          break
+        }
 
-              val offendersByCrn = chunk.associateBy { it.crn }
-              val contactDetailsMap = getContactDetailsMap(offendersByCrn.keys.toList(), metrics.chunks)
-              val missing = offendersByCrn.keys.minus(contactDetailsMap.keys)
-              if (missing.isNotEmpty()) {
-                LOGGER.info("Contact details not found for {} CRNs in chunk {}. CRNS: {}", missing.size, metrics.chunks, missing)
-              }
+        metrics.chunks += 1
+        LOGGER.info("Processing chunk {} with {} offenders", metrics.chunks, chunk.size)
 
-              val checkinsToCreate = mutableListOf<Pair<OffenderCheckinV2, ContactDetails>>()
-              for (crn in contactDetailsMap.keys) {
-                val offender = offendersByCrn[crn]!!
-                val contactDetails = contactDetailsMap[crn]!!
-                val ineligibility = checkinIneligibilityReason(offender, contactDetails)
-                if (ineligibility != null) {
-                  // POP is no longer eligible (no active events, or in reset) - stop their online check-ins.
-                  // Isolate failures per-offender so one bad deactivation doesn't abort the whole run.
-                  LOGGER.info("Deactivating CRN {} instead of creating checkin: {}", crn, ineligibility.name)
-                  try {
-                    offenderDeactivationV2Service.deactivateOffender(
-                      offender,
-                      ineligibility.auditNote,
-                      contactDetails,
-                      auditEventType = ineligibility.auditEventType,
-                    )
-                    metrics.deactivated += 1
-                  } catch (e: Exception) {
-                    LOGGER.warn("Failed to deactivate CRN {} in chunk {}", crn, metrics.chunks, e)
-                    metrics.errors += 1
-                  }
-                } else {
-                  val checkin = checkinCreationService.prepareCheckinForOffender(offender, today)
-                  checkinsToCreate.add(Pair(checkin, contactDetails))
-                }
-              }
-              metrics.processed += contactDetailsMap.size
-
-              val savedCheckins = checkinCreationService.batchCreateCheckins(checkinsToCreate.map { it.first })
-              metrics.created += savedCheckins.size
-
-              for ((checkin, contactDetails) in checkinsToCreate) {
-                notificationService.sendCheckinCreatedNotifications(checkin, contactDetails)
-                metrics.notifsSent += 1
-              }
-            } catch (e: NdiliusBatchFetchException) {
-              metrics.errors += e.crns.size // already logged elsewhere
-            } catch (e: BatchCheckinCreationException) {
-              LOGGER.warn("Failed to create {} checkins for chunk {}", e.checkins.size, metrics.chunks, e)
-              metrics.errors += e.checkins.size
-            } catch (e: NotificationFailureException) {
-              LOGGER.warn("Failed to send notifications for chunk {}: {}", metrics.chunks, e.message) // stack logged elsewhere
+        try {
+          val contactDetailsMap = getContactDetailsMap(chunk.map { it.crn }.toList(), metrics.chunks)
+          val checkinsToCreate = ArrayList<Pair<OffenderCheckinV2, PartialCheckinCreatedEvent>>(contactDetailsMap.size)
+          val infoByCrn = chunk.associateBy { it.crn }
+          for (crn in contactDetailsMap.keys) {
+            val info = infoByCrn[crn]!!
+            val contactDetails = contactDetailsMap[crn]!!
+            val ineligibility = checkinIneligibilityReason(info, contactDetails)
+            if (ineligibility != null) {
+              deactivateOffender(checkinIneligibilityReason(info, contactDetails)!!, info, contactDetails, metrics)
+            } else {
+              prepareCheckin(info, today, contactDetails)?.let { checkinsToCreate.add(it) }
             }
-
-            entityManager.flush()
-            entityManager.clear()
           }
-      }
+
+          metrics.processed += contactDetailsMap.size
+          val batchInsertStart = System.currentTimeMillis()
+          checkinCreationService.createCheckins(checkinsToCreate)
+          logCreatedCheckins(checkinsToCreate, today, batchInsertStart)
+          metrics.created += checkinsToCreate.size
+        } catch (e: NdiliusBatchFetchException) {
+          metrics.errors += e.crns.size // already logged elsewhere
+        } catch (e: BatchCheckinCreationException) {
+          LOGGER.warn("Failed to create {} checkins for chunk {}", e.checkins.size, metrics.chunks, e)
+          metrics.errors += e.checkins.size
+        }
+      } while (chunk.hasNext())
     } catch (e: Exception) {
       LOGGER.warn("Checkin Creation Job(id={}) failed, metrics={}", logEntry.id, metrics, e)
     }
@@ -161,6 +137,83 @@ class V2CheckinCreationJob(
     jobLogRepository.saveAndFlush(logEntry)
 
     metrics.info(LOGGER, jobId = logEntry.id, Duration.between(now, endTime))
+  }
+
+  private fun prepareCheckin(
+    info: OffenderV2Repository.IOffenderCheckinCreationInfo,
+    today: LocalDate,
+    contactDetails: ContactDetails,
+  ): Pair<OffenderCheckinV2, PartialCheckinCreatedEvent>? {
+    val offenderRef = offenderRepository.getReferenceById(info.id)
+    val checkin = checkinCreationService.prepareCheckinForOffender(offenderRef, today)
+    val eventNumber = activeEventNumber(info, contactDetails)
+    var result: Pair<OffenderCheckinV2, PartialCheckinCreatedEvent>? = null
+    if (eventNumber != null) {
+      val event = PartialCheckinCreatedEvent(
+        offenderId = info.id,
+        practitionerId = info.practitionerId,
+        checkin = CheckinV2Dto(
+          uuid = checkin.uuid,
+          dueDate = checkin.dueDate,
+          status = checkin.status,
+          createdAt = checkin.createdAt,
+          createdBy = checkin.createdBy,
+          crn = info.crn,
+          personalDetails = contactDetails,
+          checkinLogs = CheckinLogsV2Dto(CheckinLogsHintV2.OMITTED, emptyList()),
+        ),
+        offenderContactPreference = info.contactPreference,
+        currentEvent = eventNumber,
+      )
+      result = Pair(checkin, event)
+    }
+    LOGGER.debug(
+      "Will {} checkin for CRN {}: currentEvent={}",
+      if (eventNumber != null) "create" else "not create",
+      info.crn,
+      eventNumber,
+    )
+    return result
+  }
+
+  private fun deactivateOffender(
+    ineligibility: CheckinIneligibilityReason,
+    offenderInfo: OffenderV2Repository.IOffenderCheckinCreationInfo,
+    contactDetails: ContactDetails,
+    metrics: JobMetrics,
+  ) {
+    // POP is no longer eligible (no active events, or in reset) - stop their online check-ins.
+    // Isolate failures per-offender so one bad deactivation doesn't abort the whole run.
+    LOGGER.info("Deactivating CRN {} instead of creating checkin: {}", offenderInfo.crn, ineligibility.name)
+    val offender = offenderRepository.findById(offenderInfo.id).getOrNull() ?: return
+    try {
+      offenderDeactivationV2Service.deactivateOffender(
+        offender,
+        ineligibility.auditNote,
+        contactDetails,
+        auditEventType = ineligibility.auditEventType,
+      )
+      metrics.deactivated += 1
+    } catch (e: Exception) {
+      LOGGER.warn("Failed to deactivate CRN {} in chunk {}", offenderInfo.crn, metrics.chunks, e)
+      metrics.errors += 1
+    }
+  }
+
+  private fun logCreatedCheckins(checkins: List<Pair<OffenderCheckinV2, PartialCheckinCreatedEvent>>, dueDate: LocalDate, start: Long) {
+    val sb = StringBuilder()
+    for ((checkin, event) in checkins) {
+      sb.append("(CRN=").append(event.checkin.crn)
+      sb.append(", eventNumber=").append(event.currentEvent ?: "NULL")
+      sb.append(", checkin=").append(checkin.uuid).append(")")
+    }
+    LOGGER.info(
+      "Checkins created: {}, with due date {}, took {}, (CRN,eventNumber,uuid): {}",
+      checkins.size,
+      dueDate,
+      "${(System.currentTimeMillis() - start) / 1000} s",
+      sb.toString(),
+    )
   }
 
   private fun getContactDetailsMap(
@@ -173,6 +226,12 @@ class V2CheckinCreationJob(
       LOGGER.warn("Failed to fetch contact details for chunk {}", numChunks, e)
       throw e
     }
+
+    val missing = crns.toSet().minus(contactDetailsMap.keys)
+    if (missing.isNotEmpty()) {
+      LOGGER.info("Contact details not found for {} CRNs in chunk {}. CRNS: {}", missing.size, numChunks, missing)
+    }
+
     return contactDetailsMap
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/V2CheckinCreationJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/V2CheckinCreationJob.kt
@@ -6,7 +6,6 @@ import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.data.domain.PageRequest
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinLogsHintV2
@@ -90,13 +89,14 @@ class V2CheckinCreationJob(
     try {
       val upperBound = today.plusDays(1)
       val finalChunkSize = min(chunkSize, INdiliusApiClient.MAX_BATCH_SIZE)
-
+      var lastOffenderId: Long? = null
+      metrics.chunks = 1
       do {
-        val pageRequest = PageRequest.of(metrics.chunks, finalChunkSize)
-        val chunk = offenderRepository.findEligibleForCheckinCreation(lowerBoundInclusive = today, upperBound, pageRequest)
-        if (chunk.isEmpty) {
+        val chunk = offenderRepository.findEligibleForCheckinCreation(lowerBoundInclusive = today, upperBound, finalChunkSize, lastOffenderId)
+        if (chunk.isEmpty()) {
           break
         }
+        lastOffenderId = chunk[chunk.size - 1].id
 
         LOGGER.info("Processing page {} with {} offenders", metrics.chunks, chunk.size)
 
@@ -129,7 +129,7 @@ class V2CheckinCreationJob(
           metrics.errors += e.checkins.size
           metrics.chunks += 1
         }
-      } while (chunk.hasNext())
+      } while (chunk.size == finalChunkSize)
     } catch (e: Exception) {
       LOGGER.warn("Checkin Creation Job(id={}) failed, metrics={}", logEntry.id, metrics, e)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/V2CheckinCreationJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/V2CheckinCreationJob.kt
@@ -92,14 +92,13 @@ class V2CheckinCreationJob(
       val finalChunkSize = min(chunkSize, INdiliusApiClient.MAX_BATCH_SIZE)
 
       do {
-        val pageRequest = PageRequest.of(0, finalChunkSize)
+        val pageRequest = PageRequest.of(metrics.chunks, finalChunkSize)
         val chunk = offenderRepository.findEligibleForCheckinCreation(lowerBoundInclusive = today, upperBound, pageRequest)
         if (chunk.isEmpty) {
           break
         }
 
-        metrics.chunks += 1
-        LOGGER.info("Processing chunk {} with {} offenders", metrics.chunks, chunk.size)
+        LOGGER.info("Processing page {} with {} offenders", metrics.chunks, chunk.size)
 
         try {
           val contactDetailsMap = getContactDetailsMap(chunk.map { it.crn }.toList(), metrics.chunks)
@@ -121,11 +120,14 @@ class V2CheckinCreationJob(
           checkinCreationService.createCheckins(checkinsToCreate)
           logCreatedCheckins(checkinsToCreate, today, batchInsertStart)
           metrics.created += checkinsToCreate.size
+          metrics.chunks += 1
         } catch (e: NdiliusBatchFetchException) {
           metrics.errors += e.crns.size // already logged elsewhere
+          metrics.chunks += 1
         } catch (e: BatchCheckinCreationException) {
-          LOGGER.warn("Failed to create {} checkins for chunk {}", e.checkins.size, metrics.chunks, e)
+          LOGGER.warn("Failed to create {} checkins for page {}", e.checkins.size, metrics.chunks, e)
           metrics.errors += e.checkins.size
+          metrics.chunks += 1
         }
       } while (chunk.hasNext())
     } catch (e: Exception) {
@@ -218,18 +220,18 @@ class V2CheckinCreationJob(
 
   private fun getContactDetailsMap(
     crns: List<String>,
-    numChunks: Int,
+    page: Int,
   ): Map<String, ContactDetails> {
     val contactDetailsMap = try {
       ndiliusApiClient.getContactDetailsForMultiple(crns).associateBy { it.crn }
     } catch (e: NdiliusBatchFetchException) {
-      LOGGER.warn("Failed to fetch contact details for chunk {}", numChunks, e)
+      LOGGER.warn("Failed to fetch contact details for page {}", page, e)
       throw e
     }
 
     val missing = crns.toSet().minus(contactDetailsMap.keys)
     if (missing.isNotEmpty()) {
-      LOGGER.info("Contact details not found for {} CRNs in chunk {}. CRNS: {}", missing.size, numChunks, missing)
+      LOGGER.info("Contact details not found for {} CRNs in page {}. CRNS: {}", missing.size, page, missing)
     }
 
     return contactDetailsMap

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderV2Resource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderV2Resource.kt
@@ -395,9 +395,9 @@ class OffenderV2Resource(
     if (request.checkinSchedule != null || request.contactPreference != null) {
       val saved = offenderRepository.save(offender)
       val offenderAfter = saved.toSummaryDto()
-      if (newFirstCheckinDateIsToday(offenderBefore, offenderAfter, LocalDate.now(clock))) {
+      if (request.checkinSchedule != null && newFirstCheckinDateIsToday(offenderBefore, offenderAfter, LocalDate.now(clock))) {
         LOGGER.debug("Creating check-in for offender {} as first check-in date is today", offenderAfter.uuid)
-        checkinCreationService.createCheckin(offenderAfter.uuid, offenderAfter.firstCheckin, "")
+        checkinCreationService.createCheckin(offenderAfter.uuid, offenderAfter.firstCheckin, request.checkinSchedule.requestedBy)
       }
       return ResponseEntity.ok(offenderAfter)
     } else {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupV2Service.kt
@@ -2,10 +2,12 @@ package uk.gov.justice.digital.hmpps.esupervisionapi.v2.setup
 
 import org.hibernate.exception.ConstraintViolationException
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.support.TransactionTemplate
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinCreatedEvent
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinV2Status
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.INdiliusApiClient
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.NotificationFailureException
@@ -26,7 +28,9 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.OffenderStatus
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.exceptions.BadArgumentException
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.storage.S3UploadService
 import java.time.Clock
+import java.time.Duration
 import java.time.LocalDate
+import java.time.Period
 import java.util.Optional
 import java.util.UUID
 import kotlin.jvm.optionals.getOrElse
@@ -50,7 +54,10 @@ class OffenderSetupV2Service(
   private val eventAuditService: EventAuditV2Service,
   private val ndiliusApiClient: INdiliusApiClient,
   private val transactionTemplate: TransactionTemplate,
+  @param:Value("\${app.scheduling.checkin-notification.window:72h}") private val checkinWindow: Duration,
 ) {
+
+  private val checkinWindowPeriod = Period.ofDays(checkinWindow.toDays().toInt())
 
   fun findSetupByUuid(uuid: UUID): Optional<OffenderSetupV2> = offenderSetupRepository.findByUuid(uuid)
 
@@ -229,7 +236,15 @@ class OffenderSetupV2Service(
 
     checkin?.let {
       try {
-        contactDetails?.let { notificationService.sendCheckinCreatedNotifications(checkin, contactDetails) }
+        val event = CheckinCreatedEvent(
+          checkinId = it.id,
+          offenderId = offender.id,
+          practitionerId = it.createdBy,
+          checkin = it.dto(contactDetails, clock = clock, checkinWindow = checkinWindowPeriod),
+          offenderContactPreference = it.offender.contactPreference,
+          currentEvent = it.offender.currentEvent,
+        )
+        contactDetails?.let { notificationService.sendCheckinCreatedNotifications(event) }
       } catch (e: NotificationFailureException) {
         LOGGER.info("Notification failure {}", e.message, e)
       } catch (e: Exception) {

--- a/src/main/resources/db/changelog/changesets/67_checkin_creation_outbox.sql
+++ b/src/main/resources/db/changelog/changesets/67_checkin_creation_outbox.sql
@@ -1,0 +1,33 @@
+--liquibase formatted sql
+
+--changeset roland.sadowski:67_checkin_creation_outbox.sql-1 splitStatements:false
+
+CREATE OR REPLACE FUNCTION fn_add_outbox_record_on_checkin_status_update()
+    RETURNS TRIGGER AS $$
+BEGIN
+    INSERT INTO outbox_items(type, entity_id)
+    VALUES (
+               CASE
+                   WHEN NEW.STATUS = 'CREATED'::offender_checkin_status_v2 THEN 'CHECKIN_CREATED'::OutboxItemType
+                   WHEN NEW.status = 'SUBMITTED'::offender_checkin_status_v2 THEN 'CHECKIN_SUBMITTED'::OutboxItemType
+                   WHEN NEW.status = 'REVIEWED'::offender_checkin_status_v2  THEN 'CHECKIN_REVIEWED'::OutboxItemType
+                   --WHEN NEW.STATUS = 'EXPIRED'::offender_checkin_status_v2 THEN 'CHECKIN_EXPIRED'::OutboxItemType
+                   END,
+               NEW.id
+           );
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- we have to drop and recreate the trigger because now we want to handle inserts too
+--DROP TRIGGER IF EXISTS trg_checkin_status_change__outbox ON offender_checkin_v2;
+
+-- we create trigger on insert, but it will point to the same function as the one for update
+CREATE TRIGGER trg_checkin_insert__outbox
+    AFTER INSERT on offender_checkin_v2
+    FOR EACH ROW
+    WHEN (NEW.status in ('CREATED'::offender_checkin_status_v2))
+EXECUTE FUNCTION fn_add_outbox_record_on_checkin_status_update();
+
+--rollback:
+--rollback DROP TRIGGER IF EXISTS trg_checkin_insert__outbox ON offender_checkin_v2;

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -131,3 +131,5 @@ databaseChangeLog:
       file: db/changelog/changesets/65_add_checkin_event_enum_value.sql
   - include:
       file: db/changelog/changesets/66_sum_per_period_stats_over_range.sql
+  - include:
+      file: db/changelog/changesets/67_checkin_creation_outbox.sql

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/jobs/V2CheckinCreationJobIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/jobs/V2CheckinCreationJobIT.kt
@@ -1,0 +1,140 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.integration.jobs
+
+import jakarta.persistence.EntityManager
+import org.awaitility.Awaitility.await
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import uk.gov.justice.digital.hmpps.esupervisionapi.datagen.offenderTemplate
+import uk.gov.justice.digital.hmpps.esupervisionapi.datagen.toEntity
+import uk.gov.justice.digital.hmpps.esupervisionapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.esupervisionapi.utils.today
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CodedDescription
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.ContactDetails
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.Event
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.INdiliusApiClient
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.JobLogV2Repository
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.Name
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.NotifyGatewayService
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2Repository
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2Repository
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OutboxItemRepository
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OutboxItemStatus
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OutboxItemType
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.PractitionerDetails
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.checkin.CheckinCreationService
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.OffenderStatus
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.events.DomainEventPublisher
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.jobs.V2CheckinCreationJob
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.offender.OffenderDeactivationV2Service
+import java.time.Clock
+import java.time.Duration
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+
+class V2CheckinCreationJobIT : IntegrationTestBase() {
+
+  @Autowired lateinit var jdbcTemplate: JdbcTemplate
+
+  @Autowired lateinit var clock: Clock
+
+  @Autowired lateinit var offenderRepository: OffenderV2Repository
+
+  @Autowired lateinit var checkinRespository: OffenderCheckinV2Repository
+
+  @Autowired lateinit var outboxItemRepository: OutboxItemRepository
+
+  @Autowired lateinit var checkinCreationService: CheckinCreationService
+
+  @Autowired lateinit var offenderDeactivationService: OffenderDeactivationV2Service
+
+  @Autowired lateinit var jobLogRepository: JobLogV2Repository
+
+  @Autowired lateinit var entityManager: EntityManager
+
+  @Autowired lateinit var job: V2CheckinCreationJob
+
+  @MockitoBean lateinit var ndeliusApiClient: INdiliusApiClient
+
+  @MockitoBean lateinit var domainEventPublisher: DomainEventPublisher
+
+  @MockitoBean lateinit var notifyGateway: NotifyGatewayService
+
+  @BeforeEach
+  fun setup() {
+    offenderTemplate.copy(crn = "A000001", uuid = UUID.randomUUID(), firstCheckin = clock.today(), status = OffenderStatus.VERIFIED)
+      .toEntity().let { offenderRepository.save(it) }
+    offenderTemplate.copy(crn = "A000002", uuid = UUID.randomUUID(), firstCheckin = clock.today(), status = OffenderStatus.VERIFIED)
+      .toEntity().let { offenderRepository.save(it) }
+
+    val practitionerDetails = PractitionerDetails(Name("John", "Smith"), "foo@example.com")
+    whenever(ndeliusApiClient.getContactDetailsForMultiple(any()))
+      .thenReturn(
+        listOf(
+          ContactDetails(
+            crn = "A000001",
+            name = Name("John", "Smith"),
+            email = "a1@example.com",
+            practitioner = practitionerDetails,
+            events = listOf(
+              Event(
+                number = 1L,
+                mainOffence = CodedDescription("OFF01", "Test"),
+                sentence = null,
+              ),
+            ),
+          ),
+          ContactDetails(
+            crn = "A000002",
+            name = Name("John", "Smith"),
+            email = "a2@example.com",
+            practitioner = practitionerDetails,
+            events = listOf(
+              Event(number = 1L, mainOffence = CodedDescription("OFF01", "Test"), sentence = null),
+            ),
+          ),
+        ),
+      )
+
+    whenever(notifyGateway.send(any(), any(), any(), any(), any()))
+      .thenAnswer { UUID.randomUUID() }
+  }
+
+  @AfterEach
+  fun cleanDb() {
+    jdbcTemplate.update("TRUNCATE TABLE generic_notification_v2 RESTART IDENTITY CASCADE")
+    jdbcTemplate.update("TRUNCATE TABLE offender_checkin_v2 RESTART IDENTITY CASCADE")
+    jdbcTemplate.update("TRUNCATE TABLE event_audit_log_v2 RESTART IDENTITY CASCADE")
+    jdbcTemplate.update("TRUNCATE TABLE outbox_items RESTART IDENTITY CASCADE")
+
+    reset(ndeliusApiClient, domainEventPublisher)
+  }
+
+  @Test
+  fun `run checkin creation job`() {
+    job.process()
+
+    await()
+      .atMost(Duration.ofSeconds(10000))
+      .pollInterval(100, TimeUnit.MILLISECONDS)
+      .untilAsserted {
+        val checkins = checkinRespository.findAll().associateBy { it.offender.crn }
+        outboxItemRepository
+          .findByTypeAndEntityId(OutboxItemType.CHECKIN_CREATED, checkins["A000001"]!!.id)
+          .orElseThrow()
+          .let { assertEquals(OutboxItemStatus.SENT, it.status) }
+
+        outboxItemRepository
+          .findByTypeAndEntityId(OutboxItemType.CHECKIN_CREATED, checkins["A000002"]!!.id)
+          .orElseThrow()
+          .let { assertEquals(OutboxItemStatus.SENT, it.status) }
+      }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/jobs/V2CheckinCreationJobIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/jobs/V2CheckinCreationJobIT.kt
@@ -120,6 +120,7 @@ class V2CheckinCreationJobIT : IntegrationTestBase() {
     jdbcTemplate.update("TRUNCATE TABLE offender_checkin_v2 RESTART IDENTITY CASCADE")
     jdbcTemplate.update("TRUNCATE TABLE event_audit_log_v2 RESTART IDENTITY CASCADE")
     jdbcTemplate.update("TRUNCATE TABLE outbox_items RESTART IDENTITY CASCADE")
+    jdbcTemplate.update("TRUNCATE TABLE offender_v2 RESTART IDENTITY CASCADE")
 
     reset(ndeliusApiClient, domainEventPublisher, notifyGateway)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/jobs/V2CheckinCreationJobIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/jobs/V2CheckinCreationJobIT.kt
@@ -10,7 +10,9 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.reset
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import uk.gov.justice.digital.hmpps.esupervisionapi.datagen.offenderTemplate
 import uk.gov.justice.digital.hmpps.esupervisionapi.datagen.toEntity
@@ -39,7 +41,11 @@ import java.time.Duration
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 
+@TestPropertySource(properties = ["app.scheduling.v2-checkin-creation.chunk-size=1"])
 class V2CheckinCreationJobIT : IntegrationTestBase() {
+
+  @Value("\${app.scheduling.v2-checkin-creation.chunk-size}")
+  var chunkSize: Int = 0
 
   @Autowired lateinit var jdbcTemplate: JdbcTemplate
 
@@ -76,7 +82,8 @@ class V2CheckinCreationJobIT : IntegrationTestBase() {
 
     val practitionerDetails = PractitionerDetails(Name("John", "Smith"), "foo@example.com")
     whenever(ndeliusApiClient.getContactDetailsForMultiple(any()))
-      .thenReturn(
+      .thenAnswer { invocation ->
+        val crns = invocation.getArgument<List<String>>(0)
         listOf(
           ContactDetails(
             crn = "A000001",
@@ -100,8 +107,8 @@ class V2CheckinCreationJobIT : IntegrationTestBase() {
               Event(number = 1L, mainOffence = CodedDescription("OFF01", "Test"), sentence = null),
             ),
           ),
-        ),
-      )
+        ).filter { it.crn in crns }
+      }
 
     whenever(notifyGateway.send(any(), any(), any(), any(), any()))
       .thenAnswer { UUID.randomUUID() }
@@ -126,6 +133,8 @@ class V2CheckinCreationJobIT : IntegrationTestBase() {
       .pollInterval(100, TimeUnit.MILLISECONDS)
       .untilAsserted {
         val checkins = checkinRespository.findAll().associateBy { it.offender.crn }
+        assertEquals(2, checkins.size)
+
         outboxItemRepository
           .findByTypeAndEntityId(OutboxItemType.CHECKIN_CREATED, checkins["A000001"]!!.id)
           .orElseThrow()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/jobs/V2CheckinCreationJobIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/jobs/V2CheckinCreationJobIT.kt
@@ -114,7 +114,7 @@ class V2CheckinCreationJobIT : IntegrationTestBase() {
     jdbcTemplate.update("TRUNCATE TABLE event_audit_log_v2 RESTART IDENTITY CASCADE")
     jdbcTemplate.update("TRUNCATE TABLE outbox_items RESTART IDENTITY CASCADE")
 
-    reset(ndeliusApiClient, domainEventPublisher)
+    reset(ndeliusApiClient, domainEventPublisher, notifyGateway)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorV2ServiceTest.kt
@@ -240,7 +240,7 @@ class NotificationOrchestratorV2ServiceTest {
   @Test
   fun `sendSetupCompletedNotifications - publishes event without eventNumber when no events`() {
     val offender = createOffender()
-    val contactDetails = createContactDetails()
+    val contactDetails = createContactDetails().copy(events = emptyList())
 
     whenever(notificationPersistence.buildOffenderNotifications(any(), any(), any(), any(), any())).thenReturn(emptyList())
     whenever(notificationPersistence.saveNotifications(any())).thenReturn(emptyList())
@@ -280,7 +280,7 @@ class NotificationOrchestratorV2ServiceTest {
   @Test
   fun `sendReactivationCompletedNotifications - publishes event without eventNumber when no events`() {
     val offender = createOffender()
-    val contactDetails = createContactDetails()
+    val contactDetails = createContactDetails().copy(events = emptyList())
 
     whenever(notificationPersistence.buildOffenderNotifications(any(), any(), any(), any(), any())).thenReturn(emptyList())
     whenever(notificationPersistence.saveNotifications(any())).thenReturn(emptyList())
@@ -320,7 +320,7 @@ class NotificationOrchestratorV2ServiceTest {
   @Test
   fun `sendDeactivationCompletedNotifications - publishes event without eventNumber when no events`() {
     val offender = createOffender()
-    val contactDetails = createContactDetails()
+    val contactDetails = createContactDetails().copy(events = emptyList())
 
     whenever(notificationPersistence.buildOffenderNotifications(any(), any(), any(), any(), any())).thenReturn(emptyList())
     whenever(notificationPersistence.saveNotifications(any())).thenReturn(emptyList())
@@ -389,5 +389,6 @@ class NotificationOrchestratorV2ServiceTest {
       probationDeliveryUnit = OrganizationalUnit("PDU01", "Test PDU"),
       provider = OrganizationalUnit("PRV01", "Test Provider"),
     ),
+    events = listOf(Event(1, mainOffence = CodedDescription("OFF01", "Test Offence"), sentence = null)),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorV2ServiceTest.kt
@@ -144,7 +144,7 @@ class NotificationOrchestratorV2ServiceTest {
     service.sendCheckinSubmittedNotifications(event)
 
     verify(domainEventService).publishDomainEvent(any(), eq(checkin.uuid), eq(checkin.offender.crn), any(), eq(null), eq(null))
-    verify(eventAuditService, never()).recordCheckinSubmitted(checkin, contactDetails)
+    verify(eventAuditService, never()).recordCheckinSubmitted(checkin, event)
   }
 
   @Test
@@ -187,7 +187,7 @@ class NotificationOrchestratorV2ServiceTest {
     service.sendCheckinReviewedNotifications(event)
 
     verify(domainEventService).publishDomainEvent(any(), eq(checkin.uuid), eq(checkin.offender.crn), any(), eq(null), eq(null))
-    verify(eventAuditService, never()).recordCheckinReviewed(checkin, contactDetails)
+    verify(eventAuditService, never()).recordCheckinReviewed(checkin, event)
   }
 
   @Test
@@ -206,7 +206,7 @@ class NotificationOrchestratorV2ServiceTest {
     )
 
     whenever(notificationPersistence.buildOffenderNotifications(any(), any(), any(), any(), any()))
-      .thenReturn(notifications.map { NotificationWithRecipient(it, "07700900123") })
+      .thenReturn(notifications.map { NotificationWithRecipient(it, "07700900123", AssociatedOffenderInfo.create(offender.crn)) })
     whenever(notificationPersistence.saveNotifications(any())).thenReturn(notifications)
     whenever(notifyGateway.send(any(), any(), any(), any(), any()))
       .thenThrow(RuntimeException("GOV.UK Notify error"))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorV2ServiceTest.kt
@@ -96,9 +96,17 @@ class NotificationOrchestratorV2ServiceTest {
     whenever(notificationPersistence.buildOffenderNotifications(any(), any(), any(), any(), any())).thenReturn(emptyList())
     whenever(notificationPersistence.saveNotifications(any())).thenReturn(emptyList())
 
-    service.sendCheckinCreatedNotifications(checkin, contactDetails)
+    val event = CheckinCreatedEvent(
+      checkin = checkin.dto(contactDetails, clock = clock),
+      offenderId = offender.id,
+      checkinId = checkin.id,
+      practitionerId = offender.practitionerId,
+      offenderContactPreference = offender.contactPreference,
+      currentEvent = null,
+    )
+    service.sendCheckinCreatedNotifications(event)
 
-    // V1 only notifies offender for checkin invite (no practitioner template)
+    // we only notify the offender about the checkin invite (no practitioner template)
     verify(notificationPersistence).buildOffenderNotifications(any(), any(), any(), any(), eq(NotificationType.OffenderCheckinInvite))
     verify(notificationPersistence, never()).buildPractitionerNotifications(any(), any(), any(), any(), any(), any())
     verify(domainEventService).publishDomainEvent(any(), eq(checkin.uuid), eq(checkin.offender.crn), any(), eq(null), eq(null))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/CheckinV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/CheckinV2ServiceTest.kt
@@ -19,6 +19,7 @@ import org.mockito.kotlin.reset
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.http.HttpStatus
+import org.springframework.transaction.support.TransactionCallback
 import org.springframework.transaction.support.TransactionTemplate
 import org.springframework.web.server.ResponseStatusException
 import software.amazon.awssdk.core.SdkBytes
@@ -306,6 +307,10 @@ class CheckinV2ServiceTest {
     whenever(checkinRepository.findByUuid(uuid)).thenReturn(Optional.of(checkin))
     whenever(checkinRepository.save(any())).thenAnswer { it.getArgument(0) }
     whenever(ndiliusApiClient.getContactDetails(any())).thenReturn(null)
+    whenever(transactionTemplate.execute(any<TransactionCallback<Any>>())).thenAnswer { invocation ->
+      val callback = invocation.arguments[0] as TransactionCallback<*>
+      callback.doInTransaction(mock())
+    }
 
     val result = service.startReview(uuid, "PRACT001")
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/CheckinV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/CheckinV2ServiceTest.kt
@@ -19,6 +19,7 @@ import org.mockito.kotlin.reset
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.http.HttpStatus
+import org.springframework.transaction.support.TransactionTemplate
 import org.springframework.web.server.ResponseStatusException
 import software.amazon.awssdk.core.SdkBytes
 import software.amazon.awssdk.services.rekognition.model.AuditImage
@@ -85,6 +86,7 @@ class CheckinV2ServiceTest {
   private val livenessConfidenceThreshold = 90.0f
   private val appConfig: AppConfig = mock()
   private val objectMapper = jacksonObjectMapper()
+  private val transactionTemplate: TransactionTemplate = mock()
 
   private lateinit var service: CheckinV2Service
 
@@ -112,6 +114,7 @@ class CheckinV2ServiceTest {
       objectMapper,
       3,
       appConfig,
+      transactionTemplate,
     )
 
     whenever(s3UploadService.getCheckinSnapshot(any(), any())).thenReturn(URI.create("https://snapshot/1").toURL())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/events/CheckinEventsListenerIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/events/CheckinEventsListenerIT.kt
@@ -11,6 +11,7 @@ import org.springframework.context.annotation.Primary
 import uk.gov.justice.digital.hmpps.esupervisionapi.datagen.offenderTemplate
 import uk.gov.justice.digital.hmpps.esupervisionapi.datagen.toEntity
 import uk.gov.justice.digital.hmpps.esupervisionapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinCreatedEvent
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinReviewedEvent
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinSubmittedEvent
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinV2Status
@@ -52,6 +53,27 @@ class CheckinEventsListenerIT : IntegrationTestBase() {
     outboxItemRepository.deleteAll()
     checkinV2Repository.deleteAll()
     offenderV2Repository.deleteAll()
+  }
+
+  @Test
+  fun `processEvent - checkin creation - mark outbox item as sent - success`() {
+    val offender = offenderTemplate.copy(firstCheckin = LocalDate.now()).toEntity()
+    offenderV2Repository.save(offender)
+
+    val checkin = checkinV2Repository.save(createCheckin(offender))
+
+    val event = CheckinCreatedEvent(
+      checkinId = checkin.id,
+      offenderId = offender.id,
+      practitionerId = offender.practitionerId,
+      checkin = checkin.dto(null, clock = clock),
+      offenderContactPreference = ContactPreference.PHONE,
+      currentEvent = 1,
+    )
+
+    checkinEventsListener.processEvent(event).get(2, TimeUnit.SECONDS)
+    val outboxItem = outboxItemRepository.findByTypeAndEntityId(OutboxItemType.CHECKIN_CREATED, checkin.id).orElseThrow()
+    assertEquals(OutboxItemStatus.SENT, outboxItem.status)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/V2CheckinCreationJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/V2CheckinCreationJobTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.esupervisionapi.v2.jobs
 import jakarta.persistence.EntityManager
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -149,7 +150,7 @@ class V2CheckinCreationJobTest {
       override val contactPreference: ContactPreference,
       override val currentEvent: Long?,
     ) : OffenderV2Repository.IOffenderCheckinCreationInfo
-    whenever(offenderRepository.findEligibleForCheckinCreation(any(), any(), any(), any()))
+    whenever(offenderRepository.findEligibleForCheckinCreation(any(), any(), any(), anyOrNull()))
       .thenReturn(offenders.map { CheckinCreationInfo(it.id, it.crn, it.practitionerId, it.contactPreference, it.currentEvent) })
     whenever(offenderRepository.getReferenceById(any())).thenReturn(mock<OffenderV2>())
     whenever(ndiliusApiClient.getContactDetailsForMultiple(any())).thenReturn(detailsByCrn.values.toList())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/V2CheckinCreationJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/V2CheckinCreationJobTest.kt
@@ -8,8 +8,14 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.same
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageRequest
+import org.springframework.test.util.ReflectionTestUtils
+import uk.gov.justice.digital.hmpps.esupervisionapi.utils.CRN
+import uk.gov.justice.digital.hmpps.esupervisionapi.utils.today
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinV2Status
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CodedDescription
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.ContactDetails
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.Event
@@ -17,32 +23,32 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.INdiliusApiClient
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.JobLogV2
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.JobLogV2Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.Name
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.NotificationV2Service
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.audit.OffenderAuditEventType
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.checkin.CheckinCreationService
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.CheckinInterval
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ContactPreference
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ExternalUserId
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.OffenderStatus
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.offender.OffenderDeactivationV2Service
 import java.time.Clock
+import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
+import java.util.Optional
 import java.util.UUID
-import java.util.stream.Stream
+
 
 class V2CheckinCreationJobTest {
 
   private val clock = Clock.fixed(Instant.parse("2025-12-10T09:00:00Z"), ZoneId.of("UTC"))
   private val offenderRepository: OffenderV2Repository = mock()
-  private val checkinRepository: OffenderCheckinV2Repository = mock()
   private val ndiliusApiClient: INdiliusApiClient = mock()
   private val checkinCreationService: CheckinCreationService = mock()
-  private val notificationService: NotificationV2Service = mock()
+
   private val deactivationService: OffenderDeactivationV2Service = mock()
   private val jobLogRepository: JobLogV2Repository = mock {
     on { saveAndFlush(any<JobLogV2>()) } doAnswer { it.arguments[0] as JobLogV2 }
@@ -52,14 +58,13 @@ class V2CheckinCreationJobTest {
   private val job = V2CheckinCreationJob(
     clock,
     offenderRepository,
-    checkinRepository,
     ndiliusApiClient,
     checkinCreationService,
-    notificationService,
     deactivationService,
     jobLogRepository,
     entityManager,
     chunkSize = 100,
+    Duration.ofDays(3),
   )
 
   private val anEvent = Event(number = 1L, mainOffence = CodedDescription("X", "An offence"), sentence = null)
@@ -72,8 +77,7 @@ class V2CheckinCreationJobTest {
     job.process()
 
     verify(checkinCreationService).prepareCheckinForOffender(eq(offender), any())
-    verify(checkinCreationService).batchCreateCheckins(any())
-    verify(notificationService).sendCheckinCreatedNotifications(any(), any())
+    verify(checkinCreationService).createCheckins(any())
     verify(deactivationService, never()).deactivateOffender(any(), any(), any(), any(), any())
   }
 
@@ -86,7 +90,6 @@ class V2CheckinCreationJobTest {
 
     verify(deactivationService).deactivateOffender(eq(offender), any(), any(), any(), eq(OffenderAuditEventType.OFFENDER_AUTO_DEACTIVATED_CONTACT_SUSPENDED))
     verify(checkinCreationService, never()).prepareCheckinForOffender(any(), any())
-    verify(notificationService, never()).sendCheckinCreatedNotifications(any(), any())
   }
 
   @Test
@@ -120,8 +123,7 @@ class V2CheckinCreationJobTest {
     // NB: V2BaseEntity.equals() is id-based and unsaved test offenders share id=0, so match by
     // reference identity (same()) rather than eq() to assert the correct offender each time.
     verify(deactivationService).deactivateOffender(same(ineligible), any(), any(), any(), any())
-    verify(checkinCreationService).prepareCheckinForOffender(same(eligible), any())
-    verify(notificationService).sendCheckinCreatedNotifications(any(), any())
+    verify(checkinCreationService, times(1)).prepareCheckinForOffender(any(), any())
   }
 
   @Test
@@ -137,10 +139,40 @@ class V2CheckinCreationJobTest {
   }
 
   private fun stubEligible(offenders: List<OffenderV2>, detailsByCrn: Map<String, ContactDetails>) {
-    whenever(offenderRepository.findEligibleForCheckinCreation(any(), any())).thenReturn(Stream.of(*offenders.toTypedArray()))
+    for (i in 0 until offenders.size) {
+      ReflectionTestUtils.setField(offenders[i], "id", i.toLong())
+      whenever(offenderRepository.findById(eq(i.toLong()))).thenReturn(Optional.of(offenders[i]))
+    }
+
+    data class CheckinCreationInfo(
+      override val id: Long,
+      override val crn: CRN,
+      override val practitionerId: ExternalUserId,
+      override val contactPreference: ContactPreference,
+      override val currentEvent: Long?,
+    ) : OffenderV2Repository.IOffenderCheckinCreationInfo
+    whenever(offenderRepository.findEligibleForCheckinCreation(any(), any(), any()))
+      .thenReturn(
+        org.springframework.data.domain.SliceImpl(
+          offenders.map { CheckinCreationInfo(it.id, it.crn, it.practitionerId, it.contactPreference, it.currentEvent) },
+          PageRequest.of(0, 10),
+          false,
+        ),
+      )
+    whenever(offenderRepository.getReferenceById(any())).thenReturn(mock<OffenderV2>())
     whenever(ndiliusApiClient.getContactDetailsForMultiple(any())).thenReturn(detailsByCrn.values.toList())
-    whenever(checkinCreationService.prepareCheckinForOffender(any(), any())).thenReturn(mock<OffenderCheckinV2>())
-    whenever(checkinCreationService.batchCreateCheckins(any())).thenAnswer { it.getArgument(0) }
+    whenever(checkinCreationService.prepareCheckinForOffender(any(), any())).thenAnswer { arg ->
+      val offender = arg.getArgument<OffenderV2>(0)
+      OffenderCheckinV2(
+        uuid = UUID.randomUUID(),
+        offender = offender,
+        status = CheckinV2Status.CREATED,
+        dueDate = clock.today(),
+        createdAt = clock.instant(),
+        createdBy = "SYSTEM",
+      )
+    }
+    whenever(checkinCreationService.createCheckins(any())).thenAnswer { it.getArgument(0) }
     whenever(deactivationService.deactivateOffender(any(), any(), any(), any(), any())).thenAnswer { it.getArgument<OffenderV2>(0) }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/V2CheckinCreationJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/V2CheckinCreationJobTest.kt
@@ -41,7 +41,6 @@ import java.time.ZoneId
 import java.util.Optional
 import java.util.UUID
 
-
 class V2CheckinCreationJobTest {
 
   private val clock = Clock.fixed(Instant.parse("2025-12-10T09:00:00Z"), ZoneId.of("UTC"))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/V2CheckinCreationJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/V2CheckinCreationJobTest.kt
@@ -11,7 +11,6 @@ import org.mockito.kotlin.same
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.springframework.data.domain.PageRequest
 import org.springframework.test.util.ReflectionTestUtils
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.CRN
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.today
@@ -150,14 +149,8 @@ class V2CheckinCreationJobTest {
       override val contactPreference: ContactPreference,
       override val currentEvent: Long?,
     ) : OffenderV2Repository.IOffenderCheckinCreationInfo
-    whenever(offenderRepository.findEligibleForCheckinCreation(any(), any(), any()))
-      .thenReturn(
-        org.springframework.data.domain.SliceImpl(
-          offenders.map { CheckinCreationInfo(it.id, it.crn, it.practitionerId, it.contactPreference, it.currentEvent) },
-          PageRequest.of(0, 10),
-          false,
-        ),
-      )
+    whenever(offenderRepository.findEligibleForCheckinCreation(any(), any(), any(), any()))
+      .thenReturn(offenders.map { CheckinCreationInfo(it.id, it.crn, it.practitionerId, it.contactPreference, it.currentEvent) })
     whenever(offenderRepository.getReferenceById(any())).thenReturn(mock<OffenderV2>())
     whenever(ndiliusApiClient.getContactDetailsForMultiple(any())).thenReturn(detailsByCrn.values.toList())
     whenever(checkinCreationService.prepareCheckinForOffender(any(), any())).thenAnswer { arg ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/V2OffenderRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/V2OffenderRepositoryTest.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.domain.PageRequest
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.esupervisionapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.NotificationType
@@ -75,7 +76,7 @@ class V2OffenderRepositoryTest : IntegrationTestBase() {
 
     offenderV2Repository.saveAll(listOf(offender1, offender2, offender3, offender4))
 
-    val result = offenderV2Repository.findEligibleForCheckinCreation(today, today.plusDays(1)).toList()
+    val result = offenderV2Repository.findEligibleForCheckinCreation(today, today.plusDays(1), PageRequest.of(0, 10))
 
     // we want only offender 1 and 2
     assertEquals(2, result.size) { "Should only find offenders 1 and 2, but found: ${result.map { it.crn }}" }
@@ -94,7 +95,7 @@ class V2OffenderRepositoryTest : IntegrationTestBase() {
     )
     checkinV2Repository.save(checkin)
 
-    val resultNoOffender1 = offenderV2Repository.findEligibleForCheckinCreation(today, today.plusDays(1)).toList()
+    val resultNoOffender1 = offenderV2Repository.findEligibleForCheckinCreation(today, today.plusDays(1), PageRequest.of(0, 10)).toList()
     assertEquals(1, resultNoOffender1.size)
     assertEquals("V200002", resultNoOffender1.first().crn)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/V2OffenderRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/V2OffenderRepositoryTest.kt
@@ -79,7 +79,7 @@ class V2OffenderRepositoryTest : IntegrationTestBase() {
     val result = offenderV2Repository.findEligibleForCheckinCreation(today, today.plusDays(1), PageRequest.of(0, 10))
 
     // we want only offender 1 and 2
-    assertEquals(2, result.size) { "Should only find offenders 1 and 2, but found: ${result.map { it.crn }}" }
+    assertEquals(2, result.content.size) { "Should only find offenders 1 and 2, but found: ${result.map { it.crn }}" }
     val crns = result.map { it.crn }.toSet()
     assert(crns.contains("V200001"))
     assert(crns.contains("V200002"))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/V2OffenderRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/V2OffenderRepositoryTest.kt
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.data.domain.PageRequest
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.esupervisionapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.NotificationType
@@ -76,10 +75,10 @@ class V2OffenderRepositoryTest : IntegrationTestBase() {
 
     offenderV2Repository.saveAll(listOf(offender1, offender2, offender3, offender4))
 
-    val result = offenderV2Repository.findEligibleForCheckinCreation(today, today.plusDays(1), PageRequest.of(0, 10))
+    val result = offenderV2Repository.findEligibleForCheckinCreation(today, today.plusDays(1))
 
     // we want only offender 1 and 2
-    assertEquals(2, result.content.size) { "Should only find offenders 1 and 2, but found: ${result.map { it.crn }}" }
+    assertEquals(2, result.size) { "Should only find offenders 1 and 2, but found: ${result.map { it.crn }}" }
     val crns = result.map { it.crn }.toSet()
     assert(crns.contains("V200001"))
     assert(crns.contains("V200002"))
@@ -95,7 +94,7 @@ class V2OffenderRepositoryTest : IntegrationTestBase() {
     )
     checkinV2Repository.save(checkin)
 
-    val resultNoOffender1 = offenderV2Repository.findEligibleForCheckinCreation(today, today.plusDays(1), PageRequest.of(0, 10)).toList()
+    val resultNoOffender1 = offenderV2Repository.findEligibleForCheckinCreation(today, today.plusDays(1))
     assertEquals(1, resultNoOffender1.size)
     assertEquals("V200002", resultNoOffender1.first().crn)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/QuestionsIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/QuestionsIT.kt
@@ -35,8 +35,11 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.GenericNotificationV2Repo
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.INdiliusApiClient
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.Language
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2Repository
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderEventLogV2Repository
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderSetupV2Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2Repository
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OutboxItemRepository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.QuestionListAssignmentRepository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.QuestionRepository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.QuestionTemplateDto
@@ -70,6 +73,12 @@ class QuestionsIT(
   @Autowired lateinit var offenderV2Repository: OffenderV2Repository
 
   @Autowired lateinit var offenderCheckinV2Repository: OffenderCheckinV2Repository
+
+  @Autowired lateinit var offenderEventLogV2Repository: OffenderEventLogV2Repository
+
+  @Autowired lateinit var offenderSetupV2Repository: OffenderSetupV2Repository
+
+  @Autowired lateinit var outboxItemRepository: OutboxItemRepository
 
   @Autowired lateinit var genericNotificationV2Repository: GenericNotificationV2Repository
 
@@ -107,10 +116,13 @@ class QuestionsIT(
 
   @AfterEach
   fun tearDown() {
+    outboxItemRepository.deleteAll()
     genericNotificationV2Repository.deleteAll()
+    offenderEventLogV2Repository.deleteAll()
     questionListItemRepository.deleteAllNonSystem()
     questionListAssignmentRepository.deleteAll()
     questionListItemRepository.deleteCustomQuestions()
+    offenderSetupV2Repository.deleteAll()
     offenderCheckinV2Repository.deleteAll()
     offenderV2Repository.deleteAll()
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/QuestionsIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/QuestionsIT.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.datagen.offenderTemplate
 import uk.gov.justice.digital.hmpps.esupervisionapi.datagen.toEntity
 import uk.gov.justice.digital.hmpps.esupervisionapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.NotificationType
+import uk.gov.justice.digital.hmpps.esupervisionapi.utils.GeneratingStubDataProvider
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.MutableTestClock
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.TestClockConfiguration
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.today
@@ -30,6 +31,8 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinV2Dto
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinV2Service
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CreateCheckinByCrnV2Request
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CustomQuestionItem
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.GenericNotificationV2Repository
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.INdiliusApiClient
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.Language
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2
@@ -68,18 +71,25 @@ class QuestionsIT(
 
   @Autowired lateinit var offenderCheckinV2Repository: OffenderCheckinV2Repository
 
+  @Autowired lateinit var genericNotificationV2Repository: GenericNotificationV2Repository
+
   @Autowired lateinit var offenderCheckinService: CheckinV2Service
 
   @Autowired lateinit var clock: Clock
 
   @MockitoBean lateinit var s3UploadService: S3UploadService
 
+  @MockitoBean lateinit var ndiliusApiClient: INdiliusApiClient
+
   @BeforeEach
   fun setUp() {
     (clock as MutableTestClock).advanceTo(Instant.now())
 
-    reset(s3UploadService)
+    reset(s3UploadService, ndiliusApiClient)
     whenever(s3UploadService.isCheckinVideoUploaded(any())).thenReturn(true)
+    whenever(ndiliusApiClient.getContactDetails(any())).thenAnswer { invocation ->
+      GeneratingStubDataProvider().provideCase(invocation.getArgument(0))
+    }
 
     questionDefinitionRepository.defineCustomQuestion(
       "BARRY.WHITE",
@@ -97,6 +107,7 @@ class QuestionsIT(
 
   @AfterEach
   fun tearDown() {
+    genericNotificationV2Repository.deleteAll()
     questionListItemRepository.deleteAllNonSystem()
     questionListAssignmentRepository.deleteAll()
     questionListItemRepository.deleteCustomQuestions()
@@ -259,6 +270,7 @@ class QuestionsIT(
     val upcomingList = questionService.upcomingQuestionListItems(offender.crn, Language.ENGLISH)
     assertEquals(dueDate, upcomingList.expectedCheckinDate)
 
+    ndiliusApiClient
     val checkin = offenderCheckinService.debugCreateCheckin(offender, clock)
     val upcomingListWithCheckin = questionService.upcomingQuestionListItems(offender.crn, Language.ENGLISH)
     assertEquals(dueDate, upcomingListWithCheckin.expectedCheckinDate)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/QuestionsIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/QuestionsIT.kt
@@ -282,7 +282,6 @@ class QuestionsIT(
     val upcomingList = questionService.upcomingQuestionListItems(offender.crn, Language.ENGLISH)
     assertEquals(dueDate, upcomingList.expectedCheckinDate)
 
-    ndiliusApiClient
     val checkin = offenderCheckinService.debugCreateCheckin(offender, clock)
     val upcomingListWithCheckin = questionService.upcomingQuestionListItems(offender.crn, Language.ENGLISH)
     assertEquals(dueDate, upcomingListWithCheckin.expectedCheckinDate)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupV2ServiceTest.kt
@@ -33,6 +33,7 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.OffenderStatus
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.exceptions.BadArgumentException
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.storage.S3UploadService
 import java.time.Clock
+import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
@@ -69,6 +70,7 @@ class OffenderSetupV2ServiceTest {
       eventAuditService,
       ndiliusApiClient,
       transactionTemplate,
+      Duration.ofDays(3),
     )
   }
 


### PR DESCRIPTION
The data flow changed for checkin creation/annotation paths, but the performance should be roughly the same in terms of the number of DB interactions. For example, the old cron job created check-ins in a loop, then called `repository.saveAll(checkins)` (which is a loop in itself...), and then sent notifications (in a loop). The updated cron job does has the same number of loops, but they happen at different times - the notification sending loop is gone but happens implicitly via events emitted after check-ins have been committed. The events get picked up by the `CheckinEventsListener` (so outside of the job, but only when all the inserts succeed).

Another change worth mentioning is returning 422 from checkin creation endpoints in case of missing contact details - IMO, it makes no sense to create the checkin just so that it expires (because if offender has no contact details, we can't send them an invite), and failing early makes the subsequent code less awkward.