### PR TITLE
Update wording in the NDelius note after a review

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/EventDetailV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/EventDetailV2Service.kt
@@ -190,8 +190,9 @@ class EventDetailV2Service(
   }
 
   private fun formatManualIdCheckResult(result: String): String = when (result) {
-    "MATCH", "CONFIRMED" -> "Yes"
-    "NO_MATCH", "REJECTED" -> "No"
+    "MATCH", "CONFIRMED" -> "Yes, and there’s nothing concerning"
+    "MATCH_WITH_CONCERN" -> "Yes, and there’s visible concern"
+    "NO_MATCH", "REJECTED" -> "No, it is not the person"
     else -> result
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/EventDetailV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/EventDetailV2ServiceTest.kt
@@ -224,7 +224,7 @@ class EventDetailV2ServiceTest {
     }
 
     @Test
-    fun `includes manual ID check for reviewed events`() {
+    fun `includes manual ID check MATCH for reviewed events`() {
       val uuid = UUID.randomUUID()
       val offender = createOffender(UUID.randomUUID())
       val checkin = createCheckin(
@@ -239,7 +239,45 @@ class EventDetailV2ServiceTest {
       val result = service.getEventDetail("/v2/events/checkin-reviewed/$uuid")
 
       assertThat(result).isNotNull
-      assertThat(result!!.notes).contains("Is the person in the video the correct person: Yes")
+      assertThat(result!!.notes).contains("Is the person in the video the correct person: Yes, and there’s nothing concerning")
+    }
+
+    @Test
+    fun `includes manual ID check MATCH_WITH_CONCERN for reviewed events`() {
+      val uuid = UUID.randomUUID()
+      val offender = createOffender(UUID.randomUUID())
+      val checkin = createCheckin(
+        uuid,
+        offender,
+        autoIdCheck = AutomatedIdVerificationResult.NO_MATCH,
+        manualIdCheck = ManualIdVerificationResult.MATCH_WITH_CONCERN,
+        status = CheckinV2Status.REVIEWED,
+      )
+      whenever(checkinRepository.findByUuid(uuid)).thenReturn(Optional.of(checkin))
+
+      val result = service.getEventDetail("/v2/events/checkin-reviewed/$uuid")
+
+      assertThat(result).isNotNull
+      assertThat(result!!.notes).contains("Is the person in the video the correct person: Yes, and there’s visible concern")
+    }
+
+    @Test
+    fun `includes manual ID check NO_MATCH for reviewed events`() {
+      val uuid = UUID.randomUUID()
+      val offender = createOffender(UUID.randomUUID())
+      val checkin = createCheckin(
+        uuid,
+        offender,
+        autoIdCheck = AutomatedIdVerificationResult.NO_MATCH,
+        manualIdCheck = ManualIdVerificationResult.NO_MATCH,
+        status = CheckinV2Status.REVIEWED,
+      )
+      whenever(checkinRepository.findByUuid(uuid)).thenReturn(Optional.of(checkin))
+
+      val result = service.getEventDetail("/v2/events/checkin-reviewed/$uuid")
+
+      assertThat(result).isNotNull
+      assertThat(result!!.notes).contains("Is the person in the video the correct person: No, it is not the person")
     }
 
     @Test


### PR DESCRIPTION
[ESUP-1580 Update wording in the NDelius note after a review](https://dsdmoj.atlassian.net/browse/ESUP-1580)

A new option `MATCH_WITH_CONCERN` has been added for the manual id check 
Add the new note copy for the new option and update the existing note copy for the `MATCH` & `NO_MATCH` options