### PR TITLE
ESUP-1480: add eligibility field (optional) to offender setup entity/dto

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
@@ -209,24 +209,24 @@ data class OffenderV2Dto(
 
 /** V2 Offender information for starting setup V2 does not store PII - only CRN */
 data class OffenderInfoV2(
-  @get:Schema(description = "Setup UUID", required = true) val setupUuid: UUID,
-  @get:Schema(description = "Practitioner ID", required = true)
+  @field:Schema(description = "Setup UUID", required = true) val setupUuid: UUID,
+  @field:Schema(description = "Practitioner ID", required = true)
   @field:NotBlank
   val practitionerId: ExternalUserId,
-  @get:Schema(description = "Case Reference Number", required = true, example = "X123456")
-  @get:NotBlank
-  @get:Pattern(regexp = "^[A-Z]\\d{6}$", message = "CRN must be in format X123456")
+  @field:Schema(description = "Case Reference Number", required = true, example = "X123456")
+  @field:NotBlank
+  @field:Pattern(regexp = "^[A-Z]\\d{6}$", message = "CRN must be in format X123456")
   val crn: String,
-  @get:Schema(description = "Date of first checkin", required = true)
-  @get:JsonDeserialize(using = LocalDateDeserializer::class)
+  @field:Schema(description = "Date of first checkin", required = true)
+  @field:JsonDeserialize(using = LocalDateDeserializer::class)
   val firstCheckin: LocalDate,
-  @get:Schema(description = "Interval between checkins", required = true)
+  @field:Schema(description = "Interval between checkins", required = true)
   val checkinInterval: CheckinInterval,
-  @get:Schema(description = "POP contact preference", required = true)
+  @field:Schema(description = "POP contact preference", required = true)
   val contactPreference: ContactPreference,
-  @get:Schema(description = "Setup start timestamp (optional)", required = false)
+  @field:Schema(description = "Setup start timestamp (optional)", required = false)
   val startedAt: Instant? = null,
-  @get:Schema(description = "Eligibility choice", required = false)
+  @field:Schema(description = "Eligibility choice", required = false)
   val eligibilityChoice: EligibilityChoice? = null,
 )
 
@@ -254,14 +254,14 @@ data class OffenderInfoInitial(
 
 /** V2 Offender setup DTO (response) */
 data class OffenderSetupV2Dto(
-  @get:Schema(description = "Setup unique identifier", required = true) val uuid: UUID,
-  @get:Schema(description = "Practitioner's unique ID", required = true)
+  @field:Schema(description = "Setup unique identifier", required = true) val uuid: UUID,
+  @field:Schema(description = "Practitioner's unique ID", required = true)
   val practitionerId: ExternalUserId,
-  @get:Schema(description = "Offender's unique ID", required = true) val offenderUuid: UUID,
-  @get:Schema(description = "Created timestamp", required = true) val createdAt: Instant,
-  @get:Schema(description = "Setup started timestamp (optional)", required = false)
+  @field:Schema(description = "Offender's unique ID", required = true) val offenderUuid: UUID,
+  @field:Schema(description = "Created timestamp", required = true) val createdAt: Instant,
+  @field:Schema(description = "Setup started timestamp (optional)", required = false)
   val startedAt: Instant? = null,
-  @get:Schema(description = "Eligibility choice", required = false)
+  @field:Schema(description = "Eligibility choice", required = false)
   val eligibilityChoice: EligibilityChoice? = null,
 )
 
@@ -349,7 +349,7 @@ data class CheckinV2Dto(
   @field:Schema(description = "Presigned S3 URL for reference photo", required = false)
   val photoUrl: URL? = null,
 ) {
-  @get:JsonProperty("flaggedResponses")
+  @field:JsonProperty("flaggedResponses")
   val flaggedResponses: List<String>
     @Schema(description = "Flagged keys of the survey")
     get() {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
@@ -227,8 +227,7 @@ data class OffenderInfoV2(
   @get:Schema(description = "Setup start timestamp (optional)", required = false)
   val startedAt: Instant? = null,
   @get:Schema(description = "Eligibility choice", required = false)
-  val eligibilityChoice: EligibilityChoice?,
-)
+  val eligibilityChoice: EligibilityChoice? = null,
 
 /**
  * Offender information required to start/resume the offender setup process.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
@@ -228,6 +228,7 @@ data class OffenderInfoV2(
   val startedAt: Instant? = null,
   @get:Schema(description = "Eligibility choice", required = false)
   val eligibilityChoice: EligibilityChoice? = null,
+)
 
 /**
  * Offender information required to start/resume the offender setup process.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
@@ -349,7 +349,7 @@ data class CheckinV2Dto(
   @field:Schema(description = "Presigned S3 URL for reference photo", required = false)
   val photoUrl: URL? = null,
 ) {
-  @field:JsonProperty("flaggedResponses")
+  @get:JsonProperty("flaggedResponses")
   val flaggedResponses: List<String>
     @Schema(description = "Flagged keys of the survey")
     get() {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
@@ -230,28 +230,6 @@ data class OffenderInfoV2(
   val eligibilityChoice: EligibilityChoice? = null,
 )
 
-/**
- * Offender information required to start/resume the offender setup process.
- */
-data class OffenderInfoInitial(
-  @field:Schema(description = "Practitioner ID", required = true)
-  @field:NotBlank
-  val practitionerId: ExternalUserId,
-  @field:Schema(description = "Case Reference Number", required = true, example = "X123456")
-  @field:NotBlank
-  @field:Pattern(regexp = "^[A-Z]\\d{6}$", message = "CRN must be in format X123456")
-  val crn: String,
-  @field:Schema(description = "Date of first checkin", required = true)
-  @field:JsonDeserialize(using = LocalDateDeserializer::class)
-  val firstCheckin: LocalDate,
-  @field:Schema(description = "Interval between checkins", required = true)
-  val checkinInterval: CheckinInterval,
-  @field:Schema(description = "POP contact preference", required = true)
-  val contactPreference: ContactPreference,
-  @field:Schema(description = "Setup start timestamp (optional)", required = false)
-  val startedAt: Instant? = null,
-)
-
 /** V2 Offender setup DTO (response) */
 data class OffenderSetupV2Dto(
   @field:Schema(description = "Setup unique identifier", required = true) val uuid: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
@@ -203,45 +203,31 @@ data class OffenderV2Dto(
   val personalDetails: ContactDetails? = null,
 )
 
-/** V2 Offender creation request */
-data class CreateOffenderV2Request(
-  @Schema(description = "Case Reference Number", required = true, example = "X123456")
-  @field:NotBlank
-  @field:Pattern(regexp = "^[A-Z]\\d{6}$", message = "CRN must be in format X123456")
-  val crn: String,
-  @Schema(description = "Practitioner ID", required = true)
-  @field:NotBlank
-  val practitionerId: ExternalUserId,
-  @Schema(description = "Date of first checkin", required = true)
-  @JsonDeserialize(using = LocalDateDeserializer::class)
-  val firstCheckin: LocalDate,
-  @Schema(description = "Interval between checkins", required = true)
-  val checkinInterval: CheckinInterval,
-)
-
 // ========================================
 // V2 Offender Setup DTOs
 // ========================================
 
 /** V2 Offender information for starting setup V2 does not store PII - only CRN */
 data class OffenderInfoV2(
-  @Schema(description = "Setup UUID", required = true) val setupUuid: UUID,
-  @Schema(description = "Practitioner ID", required = true)
+  @get:Schema(description = "Setup UUID", required = true) val setupUuid: UUID,
+  @get:Schema(description = "Practitioner ID", required = true)
   @field:NotBlank
   val practitionerId: ExternalUserId,
-  @Schema(description = "Case Reference Number", required = true, example = "X123456")
-  @field:NotBlank
-  @field:Pattern(regexp = "^[A-Z]\\d{6}$", message = "CRN must be in format X123456")
+  @get:Schema(description = "Case Reference Number", required = true, example = "X123456")
+  @get:NotBlank
+  @get:Pattern(regexp = "^[A-Z]\\d{6}$", message = "CRN must be in format X123456")
   val crn: String,
-  @Schema(description = "Date of first checkin", required = true)
-  @JsonDeserialize(using = LocalDateDeserializer::class)
+  @get:Schema(description = "Date of first checkin", required = true)
+  @get:JsonDeserialize(using = LocalDateDeserializer::class)
   val firstCheckin: LocalDate,
-  @Schema(description = "Interval between checkins", required = true)
+  @get:Schema(description = "Interval between checkins", required = true)
   val checkinInterval: CheckinInterval,
-  @Schema(description = "POP contact preference", required = true)
+  @get:Schema(description = "POP contact preference", required = true)
   val contactPreference: ContactPreference,
-  @Schema(description = "Setup start timestamp (optional)", required = false)
+  @get:Schema(description = "Setup start timestamp (optional)", required = false)
   val startedAt: Instant? = null,
+  @get:Schema(description = "Eligibility choice", required = false)
+  val eligibilityChoice: EligibilityChoice?,
 )
 
 /**
@@ -268,13 +254,15 @@ data class OffenderInfoInitial(
 
 /** V2 Offender setup DTO (response) */
 data class OffenderSetupV2Dto(
-  @Schema(description = "Setup unique identifier", required = true) val uuid: UUID,
-  @Schema(description = "Practitioner's unique ID", required = true)
+  @get:Schema(description = "Setup unique identifier", required = true) val uuid: UUID,
+  @get:Schema(description = "Practitioner's unique ID", required = true)
   val practitionerId: ExternalUserId,
-  @Schema(description = "Offender's unique ID", required = true) val offenderUuid: UUID,
-  @Schema(description = "Created timestamp", required = true) val createdAt: Instant,
-  @Schema(description = "Setup started timestamp (optional)", required = false)
+  @get:Schema(description = "Offender's unique ID", required = true) val offenderUuid: UUID,
+  @get:Schema(description = "Created timestamp", required = true) val createdAt: Instant,
+  @get:Schema(description = "Setup started timestamp (optional)", required = false)
   val startedAt: Instant? = null,
+  @get:Schema(description = "Eligibility choice", required = false)
+  val eligibilityChoice: EligibilityChoice? = null,
 )
 
 // ========================================

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Entities.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Entities.kt
@@ -111,6 +111,11 @@ open class OffenderV2(
   )
 }
 
+enum class EligibilityChoice {
+  REPLACE_F2F,
+  SUPPLEMENT_F2F,
+}
+
 /**
  * V2 Offender Setup Entity
  */
@@ -141,6 +146,10 @@ open class OffenderSetupV2(
 
   @Column(name = "setup_counter", nullable = false)
   open var setupCounter: Int = 1,
+
+  @Column(name = "eligibility_choice", nullable = true)
+  @Enumerated(EnumType.STRING)
+  open var eligibilityChoice: EligibilityChoice? = null,
 ) : V2BaseEntity() {
   fun setupId(): UUID = UUID.nameUUIDFromBytes("$id:$setupCounter".toByteArray())
 
@@ -154,6 +163,7 @@ open class OffenderSetupV2(
     offenderUuid = offender.uuid,
     createdAt = createdAt,
     startedAt = startedAt,
+    eligibilityChoice = eligibilityChoice,
   )
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupV2Service.kt
@@ -14,7 +14,6 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.NotificationFailureExcept
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.NotificationV2Service
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2Repository
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderInfoInitial
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderInfoV2
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderSetupV2
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderSetupV2Dto
@@ -105,6 +104,7 @@ class OffenderSetupV2Service(
       practitionerId = offenderInfo.practitionerId,
       createdAt = now,
       startedAt = offenderInfo.startedAt,
+      eligibilityChoice = offenderInfo.eligibilityChoice,
     )
 
     val saved =
@@ -119,53 +119,7 @@ class OffenderSetupV2Service(
       saved.uuid,
     )
 
-    return OffenderSetupV2Dto(
-      uuid = saved.uuid,
-      practitionerId = saved.practitionerId,
-      offenderUuid = saved.offender.uuid,
-      createdAt = saved.createdAt,
-      startedAt = saved.startedAt,
-    )
-  }
-
-  /**
-   * Initiates or re-starts the setup process for an offender based on the provided offender information.
-   * Checks if an offender setup already exists for the given CRN. If no setup exists, a new setup is initiated.
-   * If a setup exists but the offender's status is not "INITIAL", an exception is thrown.
-   * Otherwise, the existing offender information is updated with the provided details.
-   *
-   * @param offenderInfo the initial information about the offender
-   * @return the updated offender setup
-   * @throws BadArgumentException if the offender exists but has a status other than "INITIAL"
-   */
-  @Transactional
-  fun startOffenderSetup(offenderInfo: OffenderInfoInitial): OffenderSetupV2Dto {
-    LOGGER.info("Initiating offender setup for CRN={}", offenderInfo.crn)
-    val setup = offenderSetupRepository.findByCrn(offenderInfo.crn).orElse(null)
-    if (setup == null) {
-      return startOffenderSetup(offenderInfo.toOffenderInfoV2())
-    } else if (setup.offender.status != OffenderStatus.INITIAL) {
-      throw BadArgumentException("Offender already exists.")
-    }
-
-    val now = clock.instant()
-    val offender = setup.offender
-    offender.practitionerId = offenderInfo.practitionerId
-    offender.firstCheckin = offenderInfo.firstCheckin
-    offender.checkinInterval = offenderInfo.checkinInterval.duration
-    offender.contactPreference = offenderInfo.contactPreference
-    offender.updatedAt = now
-
-    offenderRepository.save(offender)
-
-    LOGGER.info(
-      "Re-started V2 offender setup: offender={}, crn={}, setup={}",
-      offender.uuid,
-      offender.crn,
-      setup.uuid,
-    )
-
-    return setup.dto()
+    return saved.dto()
   }
 
   /**
@@ -347,13 +301,3 @@ fun <T> raiseOnConstraintViolation(
     throw e
   }
 }
-
-private fun OffenderInfoInitial.toOffenderInfoV2(): OffenderInfoV2 = OffenderInfoV2(
-  setupUuid = UUID.randomUUID(),
-  practitionerId = practitionerId,
-  crn = crn,
-  firstCheckin = firstCheckin,
-  checkinInterval = checkinInterval,
-  contactPreference = contactPreference,
-  startedAt = startedAt,
-)

--- a/src/main/resources/db/changelog/changesets/68_add_eligibility_column.sql
+++ b/src/main/resources/db/changelog/changesets/68_add_eligibility_column.sql
@@ -1,0 +1,10 @@
+--liquibase formatted sql
+
+--changeset roland.sadowski:68_add_eligibility_column.sql splitStatements:false
+
+create type eligibility_choice as enum ('REPLACE_F2F', 'SUPPLEMENT_F2F');
+
+alter table offender_setup_v2 add eligibility_choice eligibility_choice;
+
+--rollback alter table offender_setup_v2 drop column eligibility_choice;
+--rollback drop type eligibility_choice;

--- a/src/main/resources/db/changelog/changesets/69_add_eligibility_column.sql
+++ b/src/main/resources/db/changelog/changesets/69_add_eligibility_column.sql
@@ -1,6 +1,6 @@
 --liquibase formatted sql
 
---changeset roland.sadowski:68_add_eligibility_column.sql splitStatements:false
+--changeset roland.sadowski:69_add_eligibility_column.sql splitStatements:false
 
 create type eligibility_choice as enum ('REPLACE_F2F', 'SUPPLEMENT_F2F');
 

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -133,3 +133,5 @@ databaseChangeLog:
       file: db/changelog/changesets/66_sum_per_period_stats_over_range.sql
   - include:
       file: db/changelog/changesets/67_checkin_creation_outbox.sql
+  - include:
+      file: db/changelog/changesets/68_add_eligibility_column.sql

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/CheckinV2ServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/CheckinV2ServiceIntegrationTest.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.AnnotateCheckinV2Request
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinV2Service
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinV2Status
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.ContactDetails
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.GenericNotificationV2Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.INdiliusApiClient
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.LogEntryType
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.NotificationV2Service
@@ -57,6 +58,9 @@ class CheckinV2ServiceIntegrationTest : IntegrationTestBase() {
   @Autowired
   private lateinit var outboxItemRepository: OutboxItemRepository
 
+  @Autowired
+  private lateinit var genericNotificationV2Repository: GenericNotificationV2Repository
+
   @MockitoBean
   private lateinit var ndiliusApiClient: INdiliusApiClient
 
@@ -74,6 +78,7 @@ class CheckinV2ServiceIntegrationTest : IntegrationTestBase() {
 
   @AfterEach
   fun tearDown() {
+    genericNotificationV2Repository.deleteAll()
     offenderEventLogV2Repository.deleteAll()
     checkinV2Repository.deleteAll()
     offenderV2Repository.deleteAll()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/events/CheckinEventsListenerIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/events/CheckinEventsListenerIT.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinCreatedEvent
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinReviewedEvent
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinSubmittedEvent
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinV2Status
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.GenericNotificationV2Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.NotificationV2Service
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2Repository
@@ -46,10 +47,14 @@ class CheckinEventsListenerIT : IntegrationTestBase() {
   private lateinit var outboxItemRepository: OutboxItemRepository
 
   @Autowired
+  private lateinit var genericNotificationV2Repository: GenericNotificationV2Repository
+
+  @Autowired
   private lateinit var clock: Clock
 
   @AfterEach
   fun cleanUp() {
+    genericNotificationV2Repository.deleteAll()
     outboxItemRepository.deleteAll()
     checkinV2Repository.deleteAll()
     offenderV2Repository.deleteAll()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/V2OffenderRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/V2OffenderRepositoryTest.kt
@@ -36,6 +36,8 @@ class V2OffenderRepositoryTest : IntegrationTestBase() {
 
   @AfterEach
   fun cleanUp() {
+    genericNotificationV2Repository.deleteAll()
+    checkinV2Repository.deleteAll()
     offenderV2Repository.deleteAll()
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/CustomQuestionReminderJobIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/CustomQuestionReminderJobIT.kt
@@ -22,10 +22,13 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.utils.GeneratingStubDataProv
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.MutableTestClock
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.TestClockConfiguration
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.today
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.GenericNotificationV2Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.INdiliusApiClient
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.NotificationV2Service
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2Repository
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderEventLogV2Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2Repository
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OutboxItemRepository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.QuestionListAssignmentRepository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.jobs.CustomQuestionsReminderJob
 import java.time.Clock
@@ -66,6 +69,12 @@ class CustomQuestionReminderJobIT : IntegrationTestBase() {
 
   @Autowired lateinit var offenderCheckinV2Repository: OffenderCheckinV2Repository
 
+  @Autowired lateinit var offenderEventLogV2Repository: OffenderEventLogV2Repository
+
+  @Autowired lateinit var genericNotificationV2Repository: GenericNotificationV2Repository
+
+  @Autowired lateinit var outboxItemRepository: OutboxItemRepository
+
   @Autowired lateinit var questionListItemRepository: DebugQuestionsRepository
 
   @Autowired lateinit var questionListAssignmentRepository: QuestionListAssignmentRepository
@@ -88,6 +97,9 @@ class CustomQuestionReminderJobIT : IntegrationTestBase() {
   fun tearDown() {
     reset(notificationService)
 
+    genericNotificationV2Repository.deleteAll()
+    outboxItemRepository.deleteAll()
+    offenderEventLogV2Repository.deleteAll()
     questionListItemRepository.deleteAllNonSystem()
     questionListAssignmentRepository.deleteAll()
     questionListItemRepository.deleteCustomQuestions()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupV2ServiceTest.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
@@ -383,8 +384,9 @@ class OffenderSetupV2ServiceTest {
       startedAt = null,
     )
 
-    whenever(offenderSetupRepository.findByCrn(offender.crn)).thenReturn(Optional.of(setup))
-    whenever(offenderSetupRepository.save(any())).thenReturn(setup)
+    whenever(offenderRepository.findByCrn(offender.crn)).thenReturn(Optional.of(offender))
+    whenever(offenderRepository.save(any())).thenAnswer { it.getArgument(0) }
+    whenever(offenderSetupRepository.save(any<OffenderSetupV2>())).thenAnswer { it.getArgument(0) }
 
     val first = service.startOffenderSetup(
       OffenderInfoV2(
@@ -410,7 +412,7 @@ class OffenderSetupV2ServiceTest {
       ),
     )
 
-    assertEquals(first.uuid, second.uuid)
+    assertTrue(first.uuid != second.uuid)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupV2ServiceTest.kt
@@ -16,12 +16,13 @@ import org.mockito.kotlin.whenever
 import org.springframework.transaction.support.TransactionTemplate
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CodedDescription
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.ContactDetails
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.EligibilityChoice
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.Event
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.INdiliusApiClient
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.Name
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.NotificationV2Service
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2Repository
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderInfoInitial
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderInfoV2
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderSetupV2
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderSetupV2Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2
@@ -81,12 +82,14 @@ class OffenderSetupV2ServiceTest {
     val practitionerId = "PRACT001"
     val firstCheckin = LocalDate.now(clock).plusDays(7)
 
-    val offenderInfo = OffenderInfoInitial(
+    val offenderInfo = OffenderInfoV2(
+      setupUuid = UUID.randomUUID(),
       practitionerId = practitionerId,
       crn = crn,
       firstCheckin = firstCheckin,
       checkinInterval = CheckinInterval.WEEKLY,
       contactPreference = ContactPreference.EMAIL,
+      eligibilityChoice = EligibilityChoice.SUPPLEMENT_F2F,
     )
 
     val savedOffender = OffenderV2(
@@ -102,23 +105,24 @@ class OffenderSetupV2ServiceTest {
       contactPreference = ContactPreference.EMAIL,
     )
 
-    val savedSetup = OffenderSetupV2(
-      uuid = UUID.randomUUID(),
+    val expectedSetup = OffenderSetupV2(
+      uuid = offenderInfo.setupUuid,
       offender = savedOffender,
       practitionerId = practitionerId,
       createdAt = clock.instant(),
-      startedAt = null,
+      startedAt = offenderInfo.startedAt,
+      eligibilityChoice = offenderInfo.eligibilityChoice,
     )
 
     whenever(offenderRepository.save(any())).thenReturn(savedOffender)
-    whenever(offenderSetupRepository.save(any())).thenReturn(savedSetup)
+    whenever(offenderSetupRepository.save(any())).thenReturn(expectedSetup)
 
     // When
     val result = service.startOffenderSetup(offenderInfo)
 
     // Then
     assertNotNull(result)
-    assertEquals(savedSetup.uuid, result.uuid)
+    assertEquals(offenderInfo.setupUuid, result.uuid)
     assertEquals(practitionerId, result.practitionerId)
     assertEquals(savedOffender.uuid, result.offenderUuid)
 
@@ -380,24 +384,29 @@ class OffenderSetupV2ServiceTest {
     )
 
     whenever(offenderSetupRepository.findByCrn(offender.crn)).thenReturn(Optional.of(setup))
+    whenever(offenderSetupRepository.save(any())).thenReturn(setup)
 
     val first = service.startOffenderSetup(
-      OffenderInfoInitial(
+      OffenderInfoV2(
+        setupUuid = UUID.randomUUID(),
         crn = offender.crn,
         practitionerId = "PRACT001",
         firstCheckin = offender.firstCheckin,
         checkinInterval = CheckinInterval.WEEKLY,
         contactPreference = offender.contactPreference,
+        eligibilityChoice = EligibilityChoice.SUPPLEMENT_F2F,
       ),
     )
 
     val second = service.startOffenderSetup(
-      OffenderInfoInitial(
+      OffenderInfoV2(
+        setupUuid = UUID.randomUUID(),
         crn = offender.crn,
         practitionerId = "PRACT001",
         firstCheckin = offender.firstCheckin,
         checkinInterval = CheckinInterval.WEEKLY,
         contactPreference = offender.contactPreference,
+        eligibilityChoice = EligibilityChoice.SUPPLEMENT_F2F,
       ),
     )
 


### PR DESCRIPTION
The offender setup request now accepts an optional eligibility value.

Also, removed some code around offender setup - it was only called from tests. This was an alternative setup path that didn't require the setup UUID in the payload. Somehow this ended up unused.