### PR TITLE
ESUP-1849: add rationale field to offender setup entity+dto

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorV2Service.kt
@@ -50,7 +50,7 @@ class NotificationOrchestratorV2Service(
   fun sendSetupCompletedNotifications(
     offender: OffenderV2,
     contactDetails: ContactDetails? = null,
-    setupId: UUID? = null,
+    setup: OffenderSetupV2Dto
   ) {
     val details = contactDetails ?: ndiliusApiClient.getContactDetails(offender.crn)
 
@@ -61,11 +61,11 @@ class NotificationOrchestratorV2Service(
       description = "Practitioner completed setup for offender ${offender.crn}",
       additionalInformation = AdditionalInformation(
         eventNumber = details?.let { activeEventNumber(offender, it) },
-        setupId = setupId,
+        setupId = setup.setupId,
       ),
     )
 
-    eventAuditService.recordSetupCompleted(offender, details)
+    eventAuditService.recordSetupCompleted(offender, details, setup)
 
     if (details != null) {
       try {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorV2Service.kt
@@ -50,7 +50,7 @@ class NotificationOrchestratorV2Service(
   fun sendSetupCompletedNotifications(
     offender: OffenderV2,
     contactDetails: ContactDetails? = null,
-    setup: OffenderSetupV2Dto
+    setup: OffenderSetupV2Dto,
   ) {
     val details = contactDetails ?: ndiliusApiClient.getContactDetails(offender.crn)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationV2Service.kt
@@ -17,8 +17,8 @@ class NotificationV2Service(
   /**
    * Send notifications for setup completed event
    */
-  fun sendSetupCompletedNotifications(offender: OffenderV2, contactDetails: ContactDetails? = null, setupId: UUID? = null) {
-    orchestrator.sendSetupCompletedNotifications(offender, contactDetails, setupId)
+  fun sendSetupCompletedNotifications(offender: OffenderV2, contactDetails: ContactDetails? = null, setup: OffenderSetupV2Dto) {
+    orchestrator.sendSetupCompletedNotifications(offender, contactDetails, setup)
   }
 
   /**

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
@@ -229,7 +229,7 @@ data class OffenderInfoV2(
   @field:Schema(description = "Eligibility choice", required = false)
   val eligibilityChoice: EligibilityChoice? = null,
   @field:Schema(description = "Rationale for decision to sign up a POP for checkins", required = false)
-  val rationale: String?,
+  val rationale: String? = null,
 )
 
 /** V2 Offender setup DTO (response) */

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
@@ -244,7 +244,7 @@ data class OffenderSetupV2Dto(
   @field:Schema(description = "Eligibility choice", required = false)
   val eligibilityChoice: EligibilityChoice? = null,
   @field:Schema(description = "Rationale for decision to sign up a POP for checkins", required = false)
-  val rationale: String?,
+  val rationale: String? = null,
   @field:Schema(description = "Setup ID", required = true)
   val setupId: UUID,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
@@ -229,7 +229,7 @@ data class OffenderInfoV2(
   @field:Schema(description = "Eligibility choice", required = false)
   val eligibilityChoice: EligibilityChoice? = null,
   @field:Schema(description = "Rationale for decision to sign up a POP for checkins", required = false)
-  val rationale: String?
+  val rationale: String?,
 )
 
 /** V2 Offender setup DTO (response) */

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Dtos.kt
@@ -228,6 +228,8 @@ data class OffenderInfoV2(
   val startedAt: Instant? = null,
   @field:Schema(description = "Eligibility choice", required = false)
   val eligibilityChoice: EligibilityChoice? = null,
+  @field:Schema(description = "Rationale for decision to sign up a POP for checkins", required = false)
+  val rationale: String?
 )
 
 /** V2 Offender setup DTO (response) */
@@ -241,6 +243,10 @@ data class OffenderSetupV2Dto(
   val startedAt: Instant? = null,
   @field:Schema(description = "Eligibility choice", required = false)
   val eligibilityChoice: EligibilityChoice? = null,
+  @field:Schema(description = "Rationale for decision to sign up a POP for checkins", required = false)
+  val rationale: String?,
+  @field:Schema(description = "Setup ID", required = true)
+  val setupId: UUID,
 )
 
 // ========================================

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Entities.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/V2Entities.kt
@@ -150,6 +150,9 @@ open class OffenderSetupV2(
   @Column(name = "eligibility_choice", nullable = true)
   @Enumerated(EnumType.STRING)
   open var eligibilityChoice: EligibilityChoice? = null,
+
+  @Column(name = "rationale", nullable = true)
+  open var rationale: String? = null,
 ) : V2BaseEntity() {
   fun setupId(): UUID = UUID.nameUUIDFromBytes("$id:$setupCounter".toByteArray())
 
@@ -164,6 +167,8 @@ open class OffenderSetupV2(
     createdAt = createdAt,
     startedAt = startedAt,
     eligibilityChoice = eligibilityChoice,
+    rationale = rationale,
+    setupId = setupId(),
   )
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/audit/EventAuditV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/audit/EventAuditV2Service.kt
@@ -59,12 +59,13 @@ class EventAuditV2Service(
   /**
    * Record setup completed event
    */
-  fun recordSetupCompleted(offender: OffenderV2, contactDetails: ContactDetails?, setup: OffenderSetupV2Dto) =
-    recordOffenderEvent(OffenderAuditEventType.SETUP_COMPLETED,
-      offender = offender,
-      contactDetails = contactDetails,
-      notes = "Rationale for sign up: ${setup.rationale ?: "not provided"}\nEligibility: ${setup.eligibilityChoice?.name ?: "not provided"}\n",
-      sensitive = false)
+  fun recordSetupCompleted(offender: OffenderV2, contactDetails: ContactDetails?, setup: OffenderSetupV2Dto) = recordOffenderEvent(
+    OffenderAuditEventType.SETUP_COMPLETED,
+    offender = offender,
+    contactDetails = contactDetails,
+    notes = "Rationale for sign up: ${setup.rationale ?: "not provided"}\nEligibility: ${setup.eligibilityChoice?.name ?: "not provided"}\n",
+    sensitive = false,
+  )
 
   fun recordCheckinEvent(eventType: CheckinAuditEventType, checkin: OffenderCheckinV2, event: ICheckinEvent) {
     if (event.checkin.personalDetails?.practitioner == null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/audit/EventAuditV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/audit/EventAuditV2Service.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.EventAuditV2
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.EventAuditV2Repository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.ICheckinEvent
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinV2
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderSetupV2Dto
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ExternalUserId
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.security.PiiSanitizer
@@ -58,7 +59,12 @@ class EventAuditV2Service(
   /**
    * Record setup completed event
    */
-  fun recordSetupCompleted(offender: OffenderV2, contactDetails: ContactDetails?) = recordOffenderEvent(OffenderAuditEventType.SETUP_COMPLETED, offender, contactDetails, null, sensitive = false)
+  fun recordSetupCompleted(offender: OffenderV2, contactDetails: ContactDetails?, setup: OffenderSetupV2Dto) =
+    recordOffenderEvent(OffenderAuditEventType.SETUP_COMPLETED,
+      offender = offender,
+      contactDetails = contactDetails,
+      notes = "Rationale for sign up: ${setup.rationale ?: "not provided"}\nEligibility: ${setup.eligibilityChoice?.name ?: "not provided"}\n",
+      sensitive = false)
 
   fun recordCheckinEvent(eventType: CheckinAuditEventType, checkin: OffenderCheckinV2, event: ICheckinEvent) {
     if (event.checkin.personalDetails?.practitioner == null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/audit/EventAuditV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/audit/EventAuditV2Service.kt
@@ -133,11 +133,7 @@ class EventAuditV2Service(
   fun recordCheckinReminded(checkins: Iterable<Pair<OffenderCheckinV2, ContactDetails?>>) = recordCheckinEvents(CheckinAuditEventType.CHECKIN_REMINDER, checkins)
 
   fun recordOffenderEvent(eventType: OffenderAuditEventType, offender: OffenderV2, contactDetails: ContactDetails?, notes: String?, sensitive: Boolean = false) {
-    if (contactDetails == null) {
-      LOGGER.warn("Cannot record audit event {} for CRN {}: contact details not found", eventType.name, offender.crn)
-      return
-    }
-    if (contactDetails.practitioner == null) {
+    if (contactDetails?.practitioner == null) {
       // Still record the event (e.g. an automated deactivation of a POP in reset) - the practitioner
       // org-unit columns are nullable, so we keep the audit trail rather than dropping it entirely.
       LOGGER.warn("Recording audit event {} for CRN {} without practitioner organisation details", eventType.name, offender.crn)
@@ -155,7 +151,7 @@ class EventAuditV2Service(
     eventType: String,
     crn: CRN,
     practitionerId: ExternalUserId,
-    contactDetails: ContactDetails,
+    contactDetails: ContactDetails?,
     checkin: OffenderCheckinV2? = null,
     timeToSubmitHours: BigDecimal? = null,
     timeToReviewHours: BigDecimal? = null,
@@ -170,12 +166,12 @@ class EventAuditV2Service(
     occurredAt = clock.instant(),
     crn = crn,
     practitionerId = practitionerId,
-    localAdminUnitCode = contactDetails.practitioner?.localAdminUnit?.code,
-    localAdminUnitDescription = contactDetails.practitioner?.localAdminUnit?.description,
-    pduCode = contactDetails.practitioner?.probationDeliveryUnit?.code,
-    pduDescription = contactDetails.practitioner?.probationDeliveryUnit?.description,
-    providerCode = contactDetails.practitioner?.provider?.code,
-    providerDescription = contactDetails.practitioner?.provider?.description,
+    localAdminUnitCode = contactDetails?.practitioner?.localAdminUnit?.code,
+    localAdminUnitDescription = contactDetails?.practitioner?.localAdminUnit?.description,
+    pduCode = contactDetails?.practitioner?.probationDeliveryUnit?.code,
+    pduDescription = contactDetails?.practitioner?.probationDeliveryUnit?.description,
+    providerCode = contactDetails?.practitioner?.provider?.code,
+    providerDescription = contactDetails?.practitioner?.provider?.description,
     checkinUuid = checkin?.uuid,
     checkinStatus = checkin?.status?.name,
     checkinDueDate = checkin?.dueDate,
@@ -189,7 +185,7 @@ class EventAuditV2Service(
     sensitive = sensitive,
   )
 
-  private fun OffenderV2.toAudit(eventType: OffenderAuditEventType, contactDetails: ContactDetails, notes: String?, sensitive: Boolean = false): EventAuditV2 {
+  private fun OffenderV2.toAudit(eventType: OffenderAuditEventType, contactDetails: ContactDetails?, notes: String?, sensitive: Boolean = false): EventAuditV2 {
     val offender = this
     return when (eventType) {
       OffenderAuditEventType.SETUP_COMPLETED,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/audit/EventAuditV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/audit/EventAuditV2Service.kt
@@ -63,7 +63,7 @@ class EventAuditV2Service(
     OffenderAuditEventType.SETUP_COMPLETED,
     offender = offender,
     contactDetails = contactDetails,
-    notes = "Rationale for sign up: ${setup.rationale ?: "not provided"}\nEligibility: ${setup.eligibilityChoice?.name ?: "not provided"}\n",
+    notes = "Eligibility: ${setup.eligibilityChoice?.name ?: "not provided"}\nRationale provided: ${!setup.rationale.isNullOrBlank()}",
     sensitive = false,
   )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupV2Service.kt
@@ -183,7 +183,7 @@ class OffenderSetupV2Service(
       checkin?.uuid ?: "not due",
     )
     try {
-      notificationService.sendSetupCompletedNotifications(savedOffender, contactDetails, setup.setupId())
+      notificationService.sendSetupCompletedNotifications(savedOffender, contactDetails, setup.dto())
     } catch (e: Exception) {
       LOGGER.warn("Failed to send setup completed notifications for offender {}", savedOffender.uuid, e)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupV2Service.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupV2Service.kt
@@ -105,6 +105,7 @@ class OffenderSetupV2Service(
       createdAt = now,
       startedAt = offenderInfo.startedAt,
       eligibilityChoice = offenderInfo.eligibilityChoice,
+      rationale = offenderInfo.rationale,
     )
 
     val saved =

--- a/src/main/resources/db/changelog/changesets/70_add_rationale_column.sql
+++ b/src/main/resources/db/changelog/changesets/70_add_rationale_column.sql
@@ -2,6 +2,6 @@
 
 --changeset roland.sadowski:70_add_rationale_column.sql splitStatements:false
 
-alter table offender add rationale text;
+alter table offender_setup_v2 add rationale text;
 
---rollback alter table offender drop column rationale;
+--rollback alter table offender_setup_v2 drop column rationale;

--- a/src/main/resources/db/changelog/changesets/70_add_rationale_column.sql
+++ b/src/main/resources/db/changelog/changesets/70_add_rationale_column.sql
@@ -1,0 +1,7 @@
+--liquibase formatted sql
+
+--changeset roland.sadowski:70_add_rationale_column.sql splitStatements:false
+
+alter table offender add rationale text;
+
+--rollback alter table offender drop column rationale;

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -137,4 +137,5 @@ databaseChangeLog:
       file: db/changelog/changesets/68_update_welsh_default_questions.sql
   - include:
       file: db/changelog/changesets/69_add_eligibility_column.sql
-
+  - include:
+      file: db/changelog/changesets/70_add_rationale_column.sql

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/datagen/Data.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/datagen/Data.kt
@@ -49,5 +49,5 @@ fun OffenderV2.asSetupDto(clock: Clock) = OffenderSetupV2Dto(
   null,
   EligibilityChoice.SUPPLEMENT_F2F,
   "It's fine",
-  UUID.randomUUID()
+  UUID.randomUUID(),
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/datagen/Data.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/datagen/Data.kt
@@ -42,12 +42,12 @@ fun OffenderV2Dto.toEntity() = OffenderV2(
 )
 
 fun OffenderV2.asSetupDto(clock: Clock) = OffenderSetupV2Dto(
-  UUID.randomUUID(),
-  this.practitionerId,
-  this.uuid,
-  clock.instant(),
-  null,
-  EligibilityChoice.SUPPLEMENT_F2F,
-  "It's fine",
-  UUID.randomUUID(),
+  uuid = UUID.randomUUID(),
+  practitionerId = this.practitionerId,
+  offenderUuid = this.uuid,
+  createdAt = clock.instant(),
+  startedAt = null,
+  eligibilityChoice = EligibilityChoice.SUPPLEMENT_F2F,
+  rationale = "It's fine",
+  setupId = UUID.randomUUID(),
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/datagen/Data.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/datagen/Data.kt
@@ -4,11 +4,14 @@ package uk.gov.justice.digital.hmpps.esupervisionapi.datagen
  * Put "template" DTOs here for use in tests
  */
 
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.EligibilityChoice
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderSetupV2Dto
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderV2Dto
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.CheckinInterval
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ContactPreference
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.OffenderStatus
+import java.time.Clock
 import java.time.Instant
 import java.util.UUID
 
@@ -36,4 +39,15 @@ fun OffenderV2Dto.toEntity() = OffenderV2(
   createdBy = createdBy,
   updatedAt = updatedAt,
   contactPreference = contactPreference,
+)
+
+fun OffenderV2.asSetupDto(clock: Clock) = OffenderSetupV2Dto(
+  UUID.randomUUID(),
+  this.practitionerId,
+  this.uuid,
+  clock.instant(),
+  null,
+  EligibilityChoice.SUPPLEMENT_F2F,
+  "It's fine",
+  UUID.randomUUID()
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/jobs/MonthlyStatsRefreshJobIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/jobs/MonthlyStatsRefreshJobIT.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.esupervisionapi.integration.jobs
 
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.jdbc.core.JdbcTemplate
@@ -23,7 +23,7 @@ class MonthlyStatsRefreshJobIT : IntegrationTestBase() {
   private val fixedClock: Clock =
     Clock.fixed(Instant.parse("2026-02-22T12:00:00Z"), ZoneOffset.UTC)
 
-  @BeforeEach
+  @AfterEach
   fun cleanDb() {
     jdbcTemplate.update("TRUNCATE TABLE event_audit_log_v2 RESTART IDENTITY CASCADE")
     jdbcTemplate.update("TRUNCATE TABLE monthly_stats RESTART IDENTITY CASCADE")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorV2ServiceTest.kt
@@ -78,12 +78,13 @@ class NotificationOrchestratorV2ServiceTest {
 
     whenever(ndiliusApiClient.getContactDetails(any())).thenReturn(null)
 
-    service.sendSetupCompletedNotifications(offender, null, offender.asSetupDto(clock))
+    val setupDto = offender.asSetupDto(clock)
+    service.sendSetupCompletedNotifications(offender, null, setupDto)
 
     // Domain event ALWAYS published (even without contact details)
     verify(domainEventService).publishDomainEvent(any(), eq(offender.uuid), eq(offender.crn), any(), eq(null), any())
     // Audit event ALWAYS recorded (even with null contact details)
-    verify(eventAuditService).recordSetupCompleted(offender, null, offender.asSetupDto(clock))
+    verify(eventAuditService).recordSetupCompleted(offender, null, setupDto)
     // Notifications NOT sent (because contact details missing)
     verify(notificationPersistence, never()).saveNotifications(any())
   }
@@ -226,7 +227,8 @@ class NotificationOrchestratorV2ServiceTest {
     whenever(notificationPersistence.buildOffenderNotifications(any(), any(), any(), any(), any())).thenReturn(emptyList())
     whenever(notificationPersistence.saveNotifications(any())).thenReturn(emptyList())
 
-    service.sendSetupCompletedNotifications(offender, contactDetails, offender.asSetupDto(clock))
+    val setupDto = offender.asSetupDto(clock)
+    service.sendSetupCompletedNotifications(offender, contactDetails, setupDto)
 
     verify(domainEventService).publishDomainEvent(
       eq(DomainEventType.V2_SETUP_COMPLETED),
@@ -234,7 +236,7 @@ class NotificationOrchestratorV2ServiceTest {
       eq(offender.crn),
       any(),
       eq(null),
-      eq(AdditionalInformation(eventNumber = 12345L, setupId = null)),
+      eq(AdditionalInformation(eventNumber = 12345L, setupId = setupDto.setupId)),
     )
   }
 
@@ -246,7 +248,8 @@ class NotificationOrchestratorV2ServiceTest {
     whenever(notificationPersistence.buildOffenderNotifications(any(), any(), any(), any(), any())).thenReturn(emptyList())
     whenever(notificationPersistence.saveNotifications(any())).thenReturn(emptyList())
 
-    service.sendSetupCompletedNotifications(offender, contactDetails, offender.asSetupDto(clock))
+    val setupDto = offender.asSetupDto(clock)
+    service.sendSetupCompletedNotifications(offender, contactDetails, setupDto)
 
     verify(domainEventService).publishDomainEvent(
       eq(DomainEventType.V2_SETUP_COMPLETED),
@@ -254,7 +257,7 @@ class NotificationOrchestratorV2ServiceTest {
       eq(offender.crn),
       any(),
       eq(null),
-      eq(AdditionalInformation(eventNumber = null, setupId = null)),
+      eq(AdditionalInformation(eventNumber = null, setupId = setupDto.setupId)),
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorV2ServiceTest.kt
@@ -10,6 +10,7 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.esupervisionapi.config.AppConfig
+import uk.gov.justice.digital.hmpps.esupervisionapi.datagen.asSetupDto
 import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.NotificationType
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.audit.EventAuditV2Service
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.CheckinInterval
@@ -66,7 +67,7 @@ class NotificationOrchestratorV2ServiceTest {
     whenever(notificationPersistence.saveNotifications(any())).thenReturn(emptyList())
     whenever(ndiliusApiClient.getContactDetails(any())).thenReturn(contactDetails)
 
-    service.sendSetupCompletedNotifications(offender, contactDetails)
+    service.sendSetupCompletedNotifications(offender, contactDetails, offender.asSetupDto(clock))
 
     verify(domainEventService).publishDomainEvent(any(), eq(offender.uuid), eq(offender.crn), any(), eq(null), any())
   }
@@ -77,12 +78,12 @@ class NotificationOrchestratorV2ServiceTest {
 
     whenever(ndiliusApiClient.getContactDetails(any())).thenReturn(null)
 
-    service.sendSetupCompletedNotifications(offender, null)
+    service.sendSetupCompletedNotifications(offender, null, offender.asSetupDto(clock))
 
     // Domain event ALWAYS published (even without contact details)
     verify(domainEventService).publishDomainEvent(any(), eq(offender.uuid), eq(offender.crn), any(), eq(null), any())
     // Audit event ALWAYS recorded (even with null contact details)
-    verify(eventAuditService).recordSetupCompleted(offender, null)
+    verify(eventAuditService).recordSetupCompleted(offender, null, offender.asSetupDto(clock))
     // Notifications NOT sent (because contact details missing)
     verify(notificationPersistence, never()).saveNotifications(any())
   }
@@ -212,7 +213,7 @@ class NotificationOrchestratorV2ServiceTest {
       .thenThrow(RuntimeException("GOV.UK Notify error"))
     whenever(ndiliusApiClient.getContactDetails(any())).thenReturn(contactDetails)
 
-    service.sendSetupCompletedNotifications(offender, contactDetails)
+    service.sendSetupCompletedNotifications(offender, contactDetails, offender.asSetupDto(clock))
 
     verify(domainEventService).publishDomainEvent(any(), eq(offender.uuid), eq(offender.crn), any(), eq(null), any())
   }
@@ -225,7 +226,7 @@ class NotificationOrchestratorV2ServiceTest {
     whenever(notificationPersistence.buildOffenderNotifications(any(), any(), any(), any(), any())).thenReturn(emptyList())
     whenever(notificationPersistence.saveNotifications(any())).thenReturn(emptyList())
 
-    service.sendSetupCompletedNotifications(offender, contactDetails)
+    service.sendSetupCompletedNotifications(offender, contactDetails, offender.asSetupDto(clock))
 
     verify(domainEventService).publishDomainEvent(
       eq(DomainEventType.V2_SETUP_COMPLETED),
@@ -245,7 +246,7 @@ class NotificationOrchestratorV2ServiceTest {
     whenever(notificationPersistence.buildOffenderNotifications(any(), any(), any(), any(), any())).thenReturn(emptyList())
     whenever(notificationPersistence.saveNotifications(any())).thenReturn(emptyList())
 
-    service.sendSetupCompletedNotifications(offender, contactDetails)
+    service.sendSetupCompletedNotifications(offender, contactDetails, offender.asSetupDto(clock))
 
     verify(domainEventService).publishDomainEvent(
       eq(DomainEventType.V2_SETUP_COMPLETED),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/audit/EventAuditV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/audit/EventAuditV2ServiceTest.kt
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.springframework.transaction.support.TransactionCallback
 import org.springframework.transaction.support.TransactionTemplate
@@ -70,9 +69,9 @@ class EventAuditV2ServiceTest {
   }
 
   @Test
-  fun `skips recording when contact details are entirely absent`() {
+  fun `records when contact details are entirely absent`() {
     service.recordOffenderEvent(OffenderAuditEventType.OFFENDER_DEACTIVATED, offender, null, "reason")
 
-    verify(auditRepository, never()).save(any())
+    verify(auditRepository).save(any())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/events/CheckinEventsListenerIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/events/CheckinEventsListenerIT.kt
@@ -55,9 +55,11 @@ class CheckinEventsListenerIT : IntegrationTestBase() {
   @AfterEach
   fun cleanUp() {
     genericNotificationV2Repository.deleteAll()
+    genericNotificationV2Repository.flush()
     outboxItemRepository.deleteAll()
     checkinV2Repository.deleteAll()
     offenderV2Repository.deleteAll()
+    offenderV2Repository.flush()
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/CustomQuestionReminderJobIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/CustomQuestionReminderJobIT.kt
@@ -98,6 +98,7 @@ class CustomQuestionReminderJobIT : IntegrationTestBase() {
     reset(notificationService)
 
     genericNotificationV2Repository.deleteAll()
+    genericNotificationV2Repository.flush()
     outboxItemRepository.deleteAll()
     offenderEventLogV2Repository.deleteAll()
     questionListItemRepository.deleteAllNonSystem()
@@ -105,6 +106,7 @@ class CustomQuestionReminderJobIT : IntegrationTestBase() {
     questionListItemRepository.deleteCustomQuestions()
     offenderCheckinV2Repository.deleteAll()
     offenderV2Repository.deleteAll()
+    offenderV2Repository.flush()
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/QuestionsIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/question/QuestionsIT.kt
@@ -118,6 +118,7 @@ class QuestionsIT(
   fun tearDown() {
     outboxItemRepository.deleteAll()
     genericNotificationV2Repository.deleteAll()
+    genericNotificationV2Repository.flush()
     offenderEventLogV2Repository.deleteAll()
     questionListItemRepository.deleteAllNonSystem()
     questionListAssignmentRepository.deleteAll()
@@ -125,6 +126,7 @@ class QuestionsIT(
     offenderSetupV2Repository.deleteAll()
     offenderCheckinV2Repository.deleteAll()
     offenderV2Repository.deleteAll()
+    offenderV2Repository.flush()
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupV2ServiceTest.kt
@@ -130,7 +130,11 @@ class OffenderSetupV2ServiceTest {
     assertEquals(savedOffender.uuid, result.offenderUuid)
 
     verify(offenderRepository).save(argThat { this.status != OffenderStatus.VERIFIED })
-    verify(offenderSetupRepository).save(argThat { this == expectedSetup })
+    verify(offenderSetupRepository).save(
+      argThat {
+        this.uuid == expectedSetup.uuid && rationale == expectedSetup.rationale && eligibilityChoice == expectedSetup.eligibilityChoice
+      },
+    )
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupV2ServiceTest.kt
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argThat
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -92,7 +91,7 @@ class OffenderSetupV2ServiceTest {
       checkinInterval = CheckinInterval.WEEKLY,
       contactPreference = ContactPreference.EMAIL,
       eligibilityChoice = EligibilityChoice.SUPPLEMENT_F2F,
-      rationale = "it's fine"
+      rationale = "it's fine",
     )
 
     val savedOffender = OffenderV2(
@@ -399,7 +398,7 @@ class OffenderSetupV2ServiceTest {
         checkinInterval = CheckinInterval.WEEKLY,
         contactPreference = offender.contactPreference,
         eligibilityChoice = EligibilityChoice.SUPPLEMENT_F2F,
-        rationale = "it's fine"
+        rationale = "it's fine",
       ),
     )
 
@@ -412,7 +411,7 @@ class OffenderSetupV2ServiceTest {
         checkinInterval = CheckinInterval.WEEKLY,
         contactPreference = offender.contactPreference,
         eligibilityChoice = EligibilityChoice.SUPPLEMENT_F2F,
-        rationale = "it's fine"
+        rationale = "it's fine",
       ),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupV2ServiceTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
@@ -91,6 +92,7 @@ class OffenderSetupV2ServiceTest {
       checkinInterval = CheckinInterval.WEEKLY,
       contactPreference = ContactPreference.EMAIL,
       eligibilityChoice = EligibilityChoice.SUPPLEMENT_F2F,
+      rationale = "it's fine"
     )
 
     val savedOffender = OffenderV2(
@@ -173,7 +175,7 @@ class OffenderSetupV2ServiceTest {
     assertEquals(1, setup.setupCounter)
     verify(s3UploadService).isSetupPhotoUploaded(setup)
     verify(offenderRepository).save(any())
-    verify(notificationService).sendSetupCompletedNotifications(any(), isNull(), eq(setup.setupId()))
+    verify(notificationService).sendSetupCompletedNotifications(any(), isNull(), argThat { setupId == setup.setupId() })
   }
 
   @Test
@@ -397,6 +399,7 @@ class OffenderSetupV2ServiceTest {
         checkinInterval = CheckinInterval.WEEKLY,
         contactPreference = offender.contactPreference,
         eligibilityChoice = EligibilityChoice.SUPPLEMENT_F2F,
+        rationale = "it's fine"
       ),
     )
 
@@ -409,6 +412,7 @@ class OffenderSetupV2ServiceTest {
         checkinInterval = CheckinInterval.WEEKLY,
         contactPreference = offender.contactPreference,
         eligibilityChoice = EligibilityChoice.SUPPLEMENT_F2F,
+        rationale = "it's fine"
       ),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupV2ServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupV2ServiceTest.kt
@@ -114,6 +114,7 @@ class OffenderSetupV2ServiceTest {
       createdAt = clock.instant(),
       startedAt = offenderInfo.startedAt,
       eligibilityChoice = offenderInfo.eligibilityChoice,
+      rationale = offenderInfo.rationale,
     )
 
     whenever(offenderRepository.save(any())).thenReturn(savedOffender)
@@ -128,8 +129,8 @@ class OffenderSetupV2ServiceTest {
     assertEquals(practitionerId, result.practitionerId)
     assertEquals(savedOffender.uuid, result.offenderUuid)
 
-    verify(offenderRepository).save(any())
-    verify(offenderSetupRepository).save(any())
+    verify(offenderRepository).save(argThat { this.status != OffenderStatus.VERIFIED })
+    verify(offenderSetupRepository).save(argThat { this == expectedSetup })
   }
 
   @Test


### PR DESCRIPTION
Adds `rationale` text column to the `offender_setup_v2` table. I left the refactoring of offender operations to use events (as most checkin operations) due to time constraints. I've not put `@NotBlank` annotation on the `OffenderInfoV2` to not break the clients.