### PR TITLE
use check-in creation service in offender setup

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorService.kt
@@ -42,7 +42,7 @@ class NotificationOrchestratorService(
   private val ndiliusApiClient: INdiliusApiClient,
   private val appConfig: AppConfig,
   private val clock: Clock,
-  @Value("\${app.scheduling.checkin-notification.window:72h}") private val checkinWindow: Duration,
+  @param:Value("\${app.scheduling.checkin-notification.window:72h}") private val checkinWindow: Duration,
 ) {
   private val checkinWindowPeriod = Period.ofDays(checkinWindow.toDays().toInt())
 
@@ -52,26 +52,24 @@ class NotificationOrchestratorService(
     contactDetails: ContactDetails? = null,
     setup: OffenderSetupDto,
   ) {
-    val details = contactDetails ?: ndiliusApiClient.getContactDetails(offender.crn)
-
     domainEventService.publishDomainEvent(
       eventType = DomainEventType.V2_SETUP_COMPLETED,
       uuid = offender.uuid,
       crn = offender.crn,
       description = "Practitioner completed setup for offender ${offender.crn}",
       additionalInformation = AdditionalInformation(
-        eventNumber = details?.let { activeEventNumber(offender, it) },
+        eventNumber = contactDetails?.let { activeEventNumber(offender, it) },
         setupId = setup.setupId,
       ),
     )
 
-    eventAuditService.recordSetupCompleted(offender, details, setup)
+    eventAuditService.recordSetupCompleted(offender, contactDetails, setup)
 
-    if (details != null) {
+    if (contactDetails != null) {
       try {
         val personalisation =
           mapOf(
-            "name" to "${details.name.forename} ${details.name.surname}",
+            "name" to "${contactDetails.name.forename} ${contactDetails.name.surname}",
             "date" to offender.firstCheckin.format(DATE_FORMATTER),
             "frequency" to formatCheckinFrequency(CheckinInterval.fromDuration(offender.checkinInterval)),
           )
@@ -81,7 +79,7 @@ class NotificationOrchestratorService(
             offenderId = offender.id,
             crn = offender.crn,
             contactPreference = offender.contactPreference,
-            contactDetails = details,
+            contactDetails = contactDetails,
             notificationType = NotificationType.RegistrationConfirmation,
           )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/Repositories.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/Repositories.kt
@@ -132,6 +132,7 @@ interface OffenderRepository : JpaRepository<Offender, Long> {
  */
 @Repository
 interface OffenderSetupRepository : JpaRepository<OffenderSetup, Long> {
+  @EntityGraph(attributePaths = ["offender"])
   fun findByUuid(uuid: UUID): Optional<OffenderSetup>
 
   @Query(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/CheckinCreationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/CheckinCreationService.kt
@@ -9,6 +9,7 @@ import org.springframework.transaction.support.TransactionTemplate
 import org.springframework.web.server.ResponseStatusException
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinPersistenceService
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinStatus
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.ContactDetails
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.INdiliusApiClient
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.NotificationService
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.Offender
@@ -67,7 +68,8 @@ class CheckinCreationService(
   }
 
   /**
-   * Create a checkin for an offender
+   * Create a checkin for an offender. Attempts to fetch contact details from NDelius.
+   *
    * @param offender Offender entity
    * @param dueDate Due date for checkin
    * @param createdBy Who created the checkin
@@ -80,7 +82,23 @@ class CheckinCreationService(
   ): OffenderCheckin {
     val contactDetails = ndiliusApiClient.getContactDetails(offender.crn)
       ?: throw ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Failed to fetch contact details for CRN=${offender.crn}")
+    return createCheckinForOffender(offender, dueDate, createdBy, contactDetails)
+  }
 
+  /**
+   * Create a checkin for an offender
+   * @param offender Offender entity
+   * @param dueDate Due date for checkin
+   * @param createdBy Who created the checkin
+   * @param contactDetails Contact details for offender
+   * @return Created checkin
+   */
+  fun createCheckinForOffender(
+    offender: Offender,
+    dueDate: LocalDate,
+    createdBy: ExternalUserId,
+    contactDetails: ContactDetails,
+  ): OffenderCheckin {
     val checkin =
       OffenderCheckin(
         uuid = UUID.randomUUID(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupService.kt
@@ -186,7 +186,7 @@ class OffenderSetupService(
       offender.uuid,
       offender.crn,
       uuid,
-      result.checkin ?: "not due",
+      result.checkin ?: if (offender.firstCheckin == LocalDate.now(clock)) "skipped (no contact details)" else "not due",
     )
     try {
       notificationService.sendSetupCompletedNotifications(offender, contactDetails, setup.dto())

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupService.kt
@@ -7,21 +7,17 @@ import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.support.TransactionTemplate
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinCreatedEvent
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinStatus
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.ContactDetails
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.INdiliusApiClient
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.NotificationFailureException
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.NotificationService
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.Offender
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckin
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinRepository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderDto
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderInfo
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderRepository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderSetup
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderSetupDto
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderSetupRepository
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.audit.EventAuditService
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.checkin.CheckinCreationService
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.checkin.checkinIneligibilityReason
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.OffenderStatus
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.exceptions.BadArgumentException
@@ -33,6 +29,30 @@ import java.time.Period
 import java.util.Optional
 import java.util.UUID
 import kotlin.jvm.optionals.getOrElse
+
+@Service
+class OffenderSetupPersistenceService(
+  private val offenderRepository: OffenderRepository,
+  private val checkinCreationService: CheckinCreationService,
+  private val clock: Clock,
+) {
+  data class Result(val checkin: UUID?)
+
+  /**
+   *
+   */
+  @Transactional
+  fun completeOffenderSetupAndMaybeCreateCheckin(offender: Offender, contactDetails: ContactDetails?, createCheckin: Boolean): Result {
+    require(offender.status == OffenderStatus.VERIFIED) { "Offender must be in VERIFIED status" }
+    offenderRepository.save(offender)
+    val checkin = if (createCheckin && contactDetails != null) {
+      checkinCreationService.createCheckinForOffender(offender, offender.firstCheckin, offender.createdBy, contactDetails)
+    } else {
+      null
+    }
+    return Result(checkin = checkin?.uuid)
+  }
+}
 
 /**
  * V2 Offender Setup Service Handles registration/setup workflow for V2 offenders
@@ -47,13 +67,12 @@ class OffenderSetupService(
   private val clock: Clock,
   private val offenderRepository: OffenderRepository,
   private val offenderSetupRepository: OffenderSetupRepository,
-  private val checkinRepository: OffenderCheckinRepository,
   private val s3UploadService: S3UploadService,
   private val notificationService: NotificationService,
-  private val eventAuditService: EventAuditService,
   private val ndiliusApiClient: INdiliusApiClient,
   private val transactionTemplate: TransactionTemplate,
   @param:Value("\${app.scheduling.checkin-notification.window:72h}") private val checkinWindow: Duration,
+  private val offenderSetupPersistenceService: OffenderSetupPersistenceService,
 ) {
 
   private val checkinWindowPeriod = Period.ofDays(checkinWindow.toDays().toInt())
@@ -127,12 +146,10 @@ class OffenderSetupService(
    * Complete offender setup Verifies photo, changes status to VERIFIED, sends notifications, and
    * creates first checkin if due
    */
-  @Transactional
   fun completeOffenderSetup(uuid: UUID): OffenderDto {
-    val setup =
-      offenderSetupRepository.findByUuid(uuid).getOrElse {
-        throw BadArgumentException("No setup for given uuid=$uuid")
-      }
+    val setup = offenderSetupRepository.findByUuid(uuid).getOrElse {
+      throw BadArgumentException("No setup for given uuid=$uuid")
+    }
     val photoUploaded = s3UploadService.isSetupPhotoUploaded(setup)
     if (!photoUploaded) {
       throw InvalidOffenderSetupState("No uploaded photo for setup uuid=$uuid", setup)
@@ -159,55 +176,23 @@ class OffenderSetupService(
     val now = clock.instant()
     offender.status = OffenderStatus.VERIFIED
     offender.updatedAt = now
-    val savedOffender = offenderRepository.save(offender)
-
-    var checkin: OffenderCheckin? = null
-    val checkinDueToday = savedOffender.firstCheckin == LocalDate.now(clock)
-    if (checkinDueToday) {
-      checkin = checkinRepository.save(
-        OffenderCheckin(
-          uuid = UUID.randomUUID(),
-          offender = savedOffender,
-          status = CheckinStatus.CREATED,
-          dueDate = savedOffender.firstCheckin,
-          createdAt = now,
-          createdBy = "SYSTEM",
-        ),
-      )
-    }
+    val createCheckin = offender.firstCheckin == LocalDate.now(clock) && contactDetails != null
+    val result = offenderSetupPersistenceService.completeOffenderSetupAndMaybeCreateCheckin(offender, contactDetails, createCheckin)
 
     LOGGER.info(
       "Completed V2 offender setup: offender={}, crn={}, setup={}, checkin={}",
-      savedOffender.uuid,
-      savedOffender.crn,
+      offender.uuid,
+      offender.crn,
       uuid,
-      checkin?.uuid ?: "not due",
+      result.checkin ?: "not due",
     )
     try {
-      notificationService.sendSetupCompletedNotifications(savedOffender, contactDetails, setup.dto())
+      notificationService.sendSetupCompletedNotifications(offender, contactDetails, setup.dto())
     } catch (e: Exception) {
-      LOGGER.warn("Failed to send setup completed notifications for offender {}", savedOffender.uuid, e)
+      LOGGER.warn("Failed to send setup completed notifications for offender {}", offender.crn, e)
     }
 
-    checkin?.let {
-      try {
-        val event = CheckinCreatedEvent(
-          checkinId = it.id,
-          offenderId = offender.id,
-          practitionerId = it.createdBy,
-          checkin = it.dto(contactDetails, clock = clock, checkinWindow = checkinWindowPeriod),
-          offenderContactPreference = it.offender.contactPreference,
-          currentEvent = it.offender.currentEvent,
-        )
-        contactDetails?.let { notificationService.sendCheckinCreatedNotifications(event) }
-      } catch (e: NotificationFailureException) {
-        LOGGER.info("Notification failure {}", e.message, e)
-      } catch (e: Exception) {
-        LOGGER.warn("Unknown notification failure {}", checkin.uuid, e)
-      }
-    }
-
-    return savedOffender.dto(contactDetails)
+    return offender.dto(contactDetails)
   }
 
   /**

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupService.kt
@@ -44,7 +44,7 @@ class OffenderSetupPersistenceService(
   @Transactional
   fun completeOffenderSetupAndMaybeCreateCheckin(offender: Offender, contactDetails: ContactDetails?, createCheckin: Boolean): Result {
     require(offender.status == OffenderStatus.VERIFIED) { "Offender must be in VERIFIED status" }
-    require(!createCheckin || offender.firstCheckin == LocalDate.now(clock))
+    require(!createCheckin || offender.firstCheckin == LocalDate.now(clock)) { "createCheckin=true requires offender.firstCheckin to be today" }
 
     offenderRepository.save(offender)
     val checkin = if (createCheckin && contactDetails != null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupService.kt
@@ -39,11 +39,13 @@ class OffenderSetupPersistenceService(
   data class Result(val checkin: UUID?)
 
   /**
-   *
+   * Saves the updated offender record and optionally creates a checkin.
    */
   @Transactional
   fun completeOffenderSetupAndMaybeCreateCheckin(offender: Offender, contactDetails: ContactDetails?, createCheckin: Boolean): Result {
     require(offender.status == OffenderStatus.VERIFIED) { "Offender must be in VERIFIED status" }
+    require(!createCheckin || offender.firstCheckin == LocalDate.now(clock))
+
     offenderRepository.save(offender)
     val checkin = if (createCheckin && contactDetails != null) {
       checkinCreationService.createCheckinForOffender(offender, offender.firstCheckin, offender.createdBy, contactDetails)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupServiceTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
@@ -15,9 +16,11 @@ import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.reset
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.transaction.support.TransactionTemplate
+import uk.gov.justice.digital.hmpps.esupervisionapi.utils.GeneratingStubDataProvider
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CodedDescription
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.ContactDetails
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.EligibilityChoice
@@ -30,6 +33,7 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderInfo
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderRepository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderSetup
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderSetupRepository
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.checkin.CheckinCreationService
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.CheckinInterval
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ContactPreference
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.OffenderStatus
@@ -518,6 +522,52 @@ class OffenderSetupServiceTest {
     val (_, secondSetupId) = service.activateOffenderAndIncrementSetupCounter(offender)
     assertEquals(2, setup.setupCounter)
     assertEquals(firstSetupId, secondSetupId)
+  }
+
+  @Nested
+  inner class OffenderSetupPersistenceServiceTest {
+
+    fun makeData(): Pair<Offender, ContactDetails> {
+      val offender = makeOffender(clock, LocalDate.now(clock))
+      offender.status = OffenderStatus.VERIFIED
+      return Pair(offender, GeneratingStubDataProvider().provideCase(offender.crn))
+    }
+
+    @Test
+    fun `do not create checkin when contact info is missing`() {
+      val (offender, _) = makeData()
+
+      val checkinCreationService = mock<CheckinCreationService>()
+      val service = OffenderSetupPersistenceService(offenderRepository, checkinCreationService, clock)
+
+      service.completeOffenderSetupAndMaybeCreateCheckin(offender, null, true)
+
+      verify(offenderRepository).save(offender)
+      verify(checkinCreationService, never()).createCheckinForOffender(any(), any(), any(), anyOrNull())
+    }
+
+    @Test
+    fun `create checkin when contact info is passed in`() {
+      val (offender, contactDetails) = makeData()
+      val checkinCreationService = mock<CheckinCreationService>()
+      val service = OffenderSetupPersistenceService(offenderRepository, checkinCreationService, clock)
+
+      service.completeOffenderSetupAndMaybeCreateCheckin(offender, contactDetails, true)
+
+      verify(offenderRepository).save(offender)
+      verify(checkinCreationService, times(1)).createCheckinForOffender(any(), any(), any(), anyOrNull())
+    }
+
+    @Test
+    fun `do not create checkin when contact info passed, but flag is false`() {
+      val (offender, contactDetails) = makeData()
+      val checkinCreationService = mock<CheckinCreationService>()
+      val service = OffenderSetupPersistenceService(offenderRepository, checkinCreationService, clock)
+
+      service.completeOffenderSetupAndMaybeCreateCheckin(offender, contactDetails, false)
+      verify(offenderRepository, times(1)).save(offender)
+      verify(checkinCreationService, never()).createCheckinForOffender(any(), any(), any(), anyOrNull())
+    }
   }
 }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupServiceTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.esupervisionapi.v2.setup
 
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
@@ -8,10 +9,12 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.reset
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.transaction.support.TransactionTemplate
@@ -23,12 +26,10 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.INdiliusApiClient
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.Name
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.NotificationService
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.Offender
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinRepository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderInfo
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderRepository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderSetup
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderSetupRepository
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.audit.EventAuditService
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.CheckinInterval
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ContactPreference
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.OffenderStatus
@@ -51,12 +52,11 @@ class OffenderSetupServiceTest {
   private val clock = Clock.fixed(Instant.parse("2025-12-03T10:00:00Z"), ZoneId.of("UTC"))
   private val offenderRepository: OffenderRepository = mock()
   private val offenderSetupRepository: OffenderSetupRepository = mock()
-  private val checkinRepository: OffenderCheckinRepository = mock()
   private val s3UploadService: S3UploadService = mock()
   private val notificationService: NotificationService = mock()
-  private val eventAuditService: EventAuditService = mock()
   private val ndiliusApiClient: INdiliusApiClient = mock()
   private val transactionTemplate: TransactionTemplate = mock()
+  private val offenderSetupPersistenceService: OffenderSetupPersistenceService = mock()
 
   private lateinit var service: OffenderSetupService
 
@@ -66,14 +66,18 @@ class OffenderSetupServiceTest {
       clock,
       offenderRepository,
       offenderSetupRepository,
-      checkinRepository,
       s3UploadService,
       notificationService,
-      eventAuditService,
       ndiliusApiClient,
       transactionTemplate,
       Duration.ofDays(3),
+      offenderSetupPersistenceService,
     )
+  }
+
+  @AfterEach
+  fun tearDown() {
+    reset(offenderRepository, offenderSetupRepository, s3UploadService, notificationService, ndiliusApiClient, transactionTemplate, offenderSetupPersistenceService)
   }
 
   @Test
@@ -117,7 +121,6 @@ class OffenderSetupServiceTest {
       rationale = offenderInfo.rationale,
     )
 
-    whenever(offenderRepository.save(any())).thenReturn(savedOffender)
     whenever(offenderSetupRepository.save(any())).thenReturn(expectedSetup)
 
     // When
@@ -168,7 +171,8 @@ class OffenderSetupServiceTest {
       val callback = it.getArgument<org.springframework.transaction.support.TransactionCallback<Pair<Offender, Any?>>>(0)
       callback.doInTransaction(null)
     }
-    whenever(offenderRepository.save(any())).thenAnswer { it.getArgument(0) }
+    whenever(offenderSetupPersistenceService.completeOffenderSetupAndMaybeCreateCheckin(any(), anyOrNull(), any()))
+      .thenReturn(OffenderSetupPersistenceService.Result(checkin = null)) // because no contact info
 
     // When
     val result = service.completeOffenderSetup(setup.uuid)
@@ -178,7 +182,7 @@ class OffenderSetupServiceTest {
     assertEquals(offender.uuid, result.uuid)
     assertEquals(1, setup.setupCounter)
     verify(s3UploadService).isSetupPhotoUploaded(setup)
-    verify(offenderRepository).save(any())
+    verify(offenderSetupPersistenceService).completeOffenderSetupAndMaybeCreateCheckin(argThat { status == OffenderStatus.VERIFIED }, anyOrNull(), any())
     verify(notificationService).sendSetupCompletedNotifications(any(), isNull(), argThat { setupId == setup.setupId() })
   }
 
@@ -294,12 +298,13 @@ class OffenderSetupServiceTest {
     whenever(offenderSetupRepository.findByUuid(setup.uuid)).thenReturn(Optional.of(setup))
     whenever(s3UploadService.isSetupPhotoUploaded(setup)).thenReturn(true)
     whenever(ndiliusApiClient.getContactDetails(offender.crn)).thenReturn(null)
-    whenever(offenderRepository.save(any())).thenAnswer { it.getArgument(0) }
+    whenever(offenderSetupPersistenceService.completeOffenderSetupAndMaybeCreateCheckin(any(), anyOrNull(), any()))
+      .thenReturn(OffenderSetupPersistenceService.Result(checkin = UUID.randomUUID()))
 
     val result = service.completeOffenderSetup(setup.uuid)
 
     assertEquals(OffenderStatus.VERIFIED, result.status)
-    verify(offenderRepository).save(any())
+    verify(offenderSetupPersistenceService).completeOffenderSetupAndMaybeCreateCheckin(argThat { status == OffenderStatus.VERIFIED }, anyOrNull(), any())
   }
 
   @Test
@@ -318,12 +323,13 @@ class OffenderSetupServiceTest {
     whenever(ndiliusApiClient.getContactDetails(offender.crn)).thenReturn(
       ContactDetails(crn = offender.crn, name = Name("John", "Doe"), events = listOf(activeEvent)),
     )
-    whenever(offenderRepository.save(any())).thenAnswer { it.getArgument(0) }
+    whenever(offenderSetupPersistenceService.completeOffenderSetupAndMaybeCreateCheckin(any(), any(), any()))
+      .thenReturn(OffenderSetupPersistenceService.Result(checkin = UUID.randomUUID()))
 
     val result = service.completeOffenderSetup(setup.uuid)
 
     assertEquals(OffenderStatus.VERIFIED, result.status)
-    verify(offenderRepository).save(any())
+    verify(offenderSetupPersistenceService).completeOffenderSetupAndMaybeCreateCheckin(argThat { status == OffenderStatus.VERIFIED }, any(), any())
   }
 
   @Test


### PR DESCRIPTION
This removes the direct repository .save() call and goes through the service (which in turn triggers an event that will be handled after the transaction completes). I also removed the call to fetch contact details from the `NotifcationOrchestratorService.sendSetupCompletedNotifications` method because it's used only once and we fetch the details right before calling it.

This fixes the issue where outbox items related to check-ins created on offender setup (if "today" is check-in day) would never be marked as "SENT".