### PR TITLE
fix: check-in review timing logic

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/CheckinService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/CheckinService.kt
@@ -324,6 +324,7 @@ class CheckinService(
 
   /** Mark checkin review as started */
   fun startReview(uuid: UUID, practitionerId: ExternalUserId): CheckinDto {
+    // This function should be removed once we ensure MPOP stopped using it,
     val checkin =
       checkinRepository.findByUuid(uuid).orElseThrow {
         ResponseStatusException(HttpStatus.NOT_FOUND, "Checkin not found: $uuid")
@@ -338,9 +339,6 @@ class CheckinService(
 
     checkin.reviewStartedAt = clock.instant()
     checkin.reviewStartedBy = practitionerId
-    transactionTemplate.execute { checkinRepository.save(checkin) }
-
-    LOGGER.info("Review started for checkin {} by {}", uuid, practitionerId)
 
     val personalDetails = ndiliusApiClient.getContactDetails(checkin.offender.crn)
     val videoUrl = s3UploadService.getCheckinVideo(checkin)
@@ -1130,12 +1128,20 @@ object CheckinRequestApplicator {
   fun OffenderCheckin.applyRequest(request: ReviewCheckinRequest, reviewInfo: CheckinReviewInfo, clock: Clock) {
     assert(this.status == CheckinStatus.SUBMITTED || this.status == CheckinStatus.EXPIRED)
     this.status = reviewInfo.newStatus
-    this.reviewedAt = clock.instant()
+    this.reviewStartedBy = request.reviewedBy
     this.reviewedBy = request.reviewedBy
     this.manualIdCheck = request.manualIdCheck
     this.riskFeedback = request.riskManagementFeedback
     this.sensitive = this.sensitive || request.sensitive
+    this.reviewedAt = clock.instant()
+    if (request.reviewStartedAt != null && request.reviewStartedAt < this.reviewedAt) {
+      this.reviewStartedAt = request.reviewStartedAt
+    } else {
+      LOGGER.debug("Invalid review timings for checkin={}, reviewStartedAt={}, reviewedAt={}", this.uuid, request.reviewStartedAt, this.reviewedAt)
+    }
   }
+
+  val LOGGER = logger<CheckinRequestApplicator>()
 }
 
 private fun OffenderCheckin.toCheckinSubmittedEvent(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/CheckinService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/CheckinService.kt
@@ -1134,10 +1134,12 @@ object CheckinRequestApplicator {
     this.riskFeedback = request.riskManagementFeedback
     this.sensitive = this.sensitive || request.sensitive
     this.reviewedAt = clock.instant()
-    if (request.reviewStartedAt != null && request.reviewStartedAt < this.reviewedAt) {
-      this.reviewStartedAt = request.reviewStartedAt
-    } else {
-      LOGGER.debug("Invalid review timings for checkin={}, reviewStartedAt={}, reviewedAt={}", this.uuid, request.reviewStartedAt, this.reviewedAt)
+    if (request.reviewStartedAt != null) {
+      if (request.reviewStartedAt < this.reviewedAt) {
+        this.reviewStartedAt = request.reviewStartedAt
+      } else {
+        LOGGER.debug("Invalid review timings for checkin={}, reviewStartedAt={}, reviewedAt={}", this.uuid, request.reviewStartedAt, this.reviewedAt)
+      }
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/Dtos.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/Dtos.kt
@@ -418,7 +418,7 @@ data class ReviewCheckinRequest(
   @field:JsonDeserialize(using = StrictBooleanDeserializer::class)
   val sensitive: Boolean = false,
 
-  @field:Schema(description = "", required = false)
+  @field:Schema(description = "When the practitioner started reviewing this check-in (UTC Instant).", required = false)
   val reviewStartedAt: Instant? = null,
 )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/Dtos.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/Dtos.kt
@@ -398,20 +398,28 @@ data class SubmitCheckinRequest(
 
 /** Review checkin request */
 data class ReviewCheckinRequest(
-  @Schema(description = "Reviewed by practitioner ID", required = true)
+  @field:Schema(description = "Reviewed by practitioner ID", required = true)
   @field:NotBlank
   val reviewedBy: ExternalUserId,
-  @Schema(description = "Manual ID check result", required = false)
+
+  @field:Schema(description = "Manual ID check result", required = false)
   val manualIdCheck: ManualIdVerificationResult? = null,
-  @Schema(description = "Review notes", required = false)
+
+  @field:Schema(description = "Review notes", required = false)
   val notes: String? = null,
-  @Schema(description = "Missed checkin comments", required = false)
+
+  @field:Schema(description = "Missed checkin comments", required = false)
   val missedCheckinComment: String? = null,
-  @Schema(description = "Risk management feedback", required = false)
+
+  @field:Schema(description = "Risk management feedback", required = false)
   val riskManagementFeedback: Boolean? = null,
-  @Schema(description = "Whether the review contains sensitive information", required = false)
-  @JsonDeserialize(using = StrictBooleanDeserializer::class)
+
+  @field:Schema(description = "Whether the review contains sensitive information", required = false)
+  @field:JsonDeserialize(using = StrictBooleanDeserializer::class)
   val sensitive: Boolean = false,
+
+  @field:Schema(description = "", required = false)
+  val reviewStartedAt: Instant? = null,
 )
 
 /** Review started request */

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/CheckinServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/CheckinServiceTest.kt
@@ -19,7 +19,6 @@ import org.mockito.kotlin.reset
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.http.HttpStatus
-import org.springframework.transaction.support.TransactionCallback
 import org.springframework.transaction.support.TransactionTemplate
 import org.springframework.web.server.ResponseStatusException
 import software.amazon.awssdk.core.SdkBytes
@@ -291,34 +290,6 @@ class CheckinServiceTest {
   }
 
   @Test
-  fun `startReview - happy path - marks review as started`() {
-    val uuid = UUID.randomUUID()
-    val offender = createOffender()
-    val checkin = OffenderCheckin(
-      uuid = uuid,
-      offender = offender,
-      status = CheckinStatus.SUBMITTED,
-      dueDate = LocalDate.now(clock),
-      createdAt = clock.instant(),
-      createdBy = "SYSTEM",
-      submittedAt = clock.instant(),
-    )
-
-    whenever(checkinRepository.findByUuid(uuid)).thenReturn(Optional.of(checkin))
-    whenever(checkinRepository.save(any())).thenAnswer { it.getArgument(0) }
-    whenever(ndiliusApiClient.getContactDetails(any())).thenReturn(null)
-    whenever(transactionTemplate.execute(any<TransactionCallback<Any>>())).thenAnswer { invocation ->
-      val callback = invocation.arguments[0] as TransactionCallback<*>
-      callback.doInTransaction(mock())
-    }
-
-    val result = service.startReview(uuid, "PRACT001")
-
-    assertNotNull(result.snapshotUrl)
-    verify(checkinRepository).save(any())
-  }
-
-  @Test
   fun `reviewCheckin - happy path & Feature ESUP_1763 TRUE - completes review and updates status`() {
     val uuid = UUID.randomUUID()
     val offender = createOffender()
@@ -330,7 +301,6 @@ class CheckinServiceTest {
       createdAt = clock.instant(),
       createdBy = "SYSTEM",
       submittedAt = clock.instant(),
-      reviewStartedAt = clock.instant(),
       reviewStartedBy = "PRACT001",
     )
 
@@ -338,6 +308,7 @@ class CheckinServiceTest {
       reviewedBy = "PRACT001",
       manualIdCheck = ManualIdVerificationResult.MATCH,
       notes = "Approved",
+      reviewStartedAt = clock.instant().minusSeconds(20),
     )
 
     whenever(checkinPersistenceService.findCheckin(any())).thenReturn(checkin)
@@ -352,7 +323,7 @@ class CheckinServiceTest {
     assertNull(result.snapshotUrl)
     assertEquals("PRACT001", result.reviewedBy)
     assertEquals(ManualIdVerificationResult.MATCH, result.manualIdCheck)
-    verify(checkinPersistenceService).checkinReview(any(), any(), any())
+    verify(checkinPersistenceService).checkinReview(argThat { reviewStartedAt != null }, any(), any())
     verify(s3UploadService).deleteCheckinSnapshot(uuid, 0)
     verify(s3UploadService).deleteCheckinVideo(uuid)
   }


### PR DESCRIPTION
Add reviewStartedAt field to ReviewCheckinRequest.

Make the `startReview()` a noop (e.g., no actual writes) to not break clients. We will remove it once MPOP changes are deployed.