### PR TITLE
ESUP-1994 Send outcome code in additionalInformation -> reason

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/DomainEventService.kt
@@ -48,7 +48,7 @@ class DomainEventService(
       )
 
       eventPublisher.publish(event)
-      LOGGER.info("Published domain event: eventType={}, crn={}, detailUrl={}, eventNumber={}, setupId={}", eventType.type, crn, detailUrl, additionalInformation?.eventNumber, additionalInformation?.setupId)
+      LOGGER.info("Published domain event: eventType={}, crn={}, detailUrl={}, eventNumber={}, setupId={}, outcomeCode={}", eventType.type, crn, detailUrl, additionalInformation?.eventNumber, additionalInformation?.setupId, additionalInformation?.outcomeCode)
     } catch (e: Exception) {
       LOGGER.error(
         "Failed to publish domain event: {}",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorService.kt
@@ -159,7 +159,7 @@ class NotificationOrchestratorService(
     offender: Offender,
     contactDetails: ContactDetails? = null,
     setupId: UUID? = null,
-    reason: String? = null,
+    outcomeCode: String? = null,
   ) {
     val details = contactDetails ?: ndiliusApiClient.getContactDetails(offender.crn)
 
@@ -171,7 +171,7 @@ class NotificationOrchestratorService(
       additionalInformation = AdditionalInformation(
         eventNumber = details?.let { activeEventNumber(offender, it) },
         setupId = setupId,
-        reason = reason,
+        outcomeCode = outcomeCode,
       ),
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorService.kt
@@ -159,6 +159,7 @@ class NotificationOrchestratorService(
     offender: Offender,
     contactDetails: ContactDetails? = null,
     setupId: UUID? = null,
+    reason: String? = null,
   ) {
     val details = contactDetails ?: ndiliusApiClient.getContactDetails(offender.crn)
 
@@ -170,6 +171,7 @@ class NotificationOrchestratorService(
       additionalInformation = AdditionalInformation(
         eventNumber = details?.let { activeEventNumber(offender, it) },
         setupId = setupId,
+        reason = reason,
       ),
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationService.kt
@@ -24,8 +24,8 @@ class NotificationService(
   /**
    * Send notifications for deactivation completed event
    */
-  fun sendDeactivationCompletedNotifications(offender: Offender, contactDetails: ContactDetails? = null, setupId: UUID? = null) {
-    orchestrator.sendDeactivationCompletedNotifications(offender, contactDetails, setupId)
+  fun sendDeactivationCompletedNotifications(offender: Offender, contactDetails: ContactDetails? = null, setupId: UUID? = null, reason: String? = null) {
+    orchestrator.sendDeactivationCompletedNotifications(offender, contactDetails, setupId, reason)
   }
 
   /**

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationService.kt
@@ -24,8 +24,8 @@ class NotificationService(
   /**
    * Send notifications for deactivation completed event
    */
-  fun sendDeactivationCompletedNotifications(offender: Offender, contactDetails: ContactDetails? = null, setupId: UUID? = null, reason: String? = null) {
-    orchestrator.sendDeactivationCompletedNotifications(offender, contactDetails, setupId, reason)
+  fun sendDeactivationCompletedNotifications(offender: Offender, contactDetails: ContactDetails? = null, setupId: UUID? = null, outcomeCode: String? = null) {
+    orchestrator.sendDeactivationCompletedNotifications(offender, contactDetails, setupId, outcomeCode)
   }
 
   /**

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/audit/EventAuditService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/audit/EventAuditService.kt
@@ -21,18 +21,22 @@ import java.time.Clock
 import java.time.Duration
 import java.util.UUID
 
-enum class OffenderAuditEventType {
+/**
+ * @param deliusOutcomeCode the code sent to NDelius on the V2_SETUP_REMOVED domain event to convey
+ *   why online check-ins were stopped. Null for event types that do not stop check-ins.
+ */
+enum class OffenderAuditEventType(val deliusOutcomeCode: String? = null) {
   SETUP_COMPLETED,
 
   /** Practitioner-initiated deactivation via the deactivate endpoint. */
-  OFFENDER_DEACTIVATED,
+  OFFENDER_DEACTIVATED("ESPMP"),
   OFFENDER_REACTIVATED,
 
   /** Automated deactivation by a scheduled job because the POP's NDelius contact is suspended (in reset). */
-  OFFENDER_AUTO_DEACTIVATED_CONTACT_SUSPENDED,
+  OFFENDER_AUTO_DEACTIVATED_CONTACT_SUSPENDED("ESPRS"),
 
   /** Automated deactivation by a scheduled job because the POP has no active probation events in NDelius. */
-  OFFENDER_AUTO_DEACTIVATED_NO_ACTIVE_EVENTS,
+  OFFENDER_AUTO_DEACTIVATED_NO_ACTIVE_EVENTS("ESPNA"),
 }
 
 enum class CheckinAuditEventType {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/events/Model.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/events/Model.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.events
 import java.time.ZonedDateTime
 import java.util.UUID
 
-data class AdditionalInformation(val eventNumber: Long? = null, val setupId: UUID? = null)
+data class AdditionalInformation(val eventNumber: Long? = null, val setupId: UUID? = null, val reason: String? = null)
 
 data class DomainEvent(
   val eventType: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/events/Model.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/events/Model.kt
@@ -3,7 +3,12 @@ package uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.events
 import java.time.ZonedDateTime
 import java.util.UUID
 
-data class AdditionalInformation(val eventNumber: Long? = null, val setupId: UUID? = null, val reason: String? = null)
+data class AdditionalInformation(
+  val eventNumber: Long? = null,
+  val setupId: UUID? = null,
+  /** Delius outcome code explaining why online check-ins were stopped (V2_SETUP_REMOVED only). */
+  val outcomeCode: String? = null,
+)
 
 data class DomainEvent(
   val eventType: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderDeactivationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderDeactivationService.kt
@@ -88,7 +88,7 @@ class OffenderDeactivationService(
 
     val setup = offenderSetupRepository.findByOffender(saved).orElse(null)
     try {
-      notificationService.sendDeactivationCompletedNotifications(saved, contactDetails, setup?.setupId())
+      notificationService.sendDeactivationCompletedNotifications(saved, contactDetails, setup?.setupId(), auditEventType.deliusOutcomeCode)
     } catch (e: Exception) {
       LOGGER.warn("Failed to send deactivation completed notifications for offender {}", saved.uuid, e)
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorServiceTest.kt
@@ -322,14 +322,14 @@ class NotificationOrchestratorServiceTest {
   }
 
   @Test
-  fun `sendDeactivationCompletedNotifications - includes reason code in domain event`() {
+  fun `sendDeactivationCompletedNotifications - includes outcome code in domain event`() {
     val offender = createOffender()
     val contactDetails = createContactDetailsWithEvents()
 
     whenever(notificationPersistence.buildOffenderNotifications(any(), any(), any(), any(), any())).thenReturn(emptyList())
     whenever(notificationPersistence.saveNotifications(any())).thenReturn(emptyList())
 
-    service.sendDeactivationCompletedNotifications(offender, contactDetails, reason = "ESPRS")
+    service.sendDeactivationCompletedNotifications(offender, contactDetails, outcomeCode = "ESPRS")
 
     verify(domainEventService).publishDomainEvent(
       eq(DomainEventType.V2_SETUP_REMOVED),
@@ -337,7 +337,7 @@ class NotificationOrchestratorServiceTest {
       eq(offender.crn),
       any(),
       eq(null),
-      eq(AdditionalInformation(eventNumber = 12345L, setupId = null, reason = "ESPRS")),
+      eq(AdditionalInformation(eventNumber = 12345L, setupId = null, outcomeCode = "ESPRS")),
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorServiceTest.kt
@@ -322,6 +322,26 @@ class NotificationOrchestratorServiceTest {
   }
 
   @Test
+  fun `sendDeactivationCompletedNotifications - includes reason code in domain event`() {
+    val offender = createOffender()
+    val contactDetails = createContactDetailsWithEvents()
+
+    whenever(notificationPersistence.buildOffenderNotifications(any(), any(), any(), any(), any())).thenReturn(emptyList())
+    whenever(notificationPersistence.saveNotifications(any())).thenReturn(emptyList())
+
+    service.sendDeactivationCompletedNotifications(offender, contactDetails, reason = "ESPRS")
+
+    verify(domainEventService).publishDomainEvent(
+      eq(DomainEventType.V2_SETUP_REMOVED),
+      eq(offender.uuid),
+      eq(offender.crn),
+      any(),
+      eq(null),
+      eq(AdditionalInformation(eventNumber = 12345L, setupId = null, reason = "ESPRS")),
+    )
+  }
+
+  @Test
   fun `sendDeactivationCompletedNotifications - publishes event without eventNumber when no events`() {
     val offender = createOffender()
     val contactDetails = createContactDetails().copy(events = emptyList())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderDeactivationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderDeactivationServiceTest.kt
@@ -70,7 +70,7 @@ class OffenderDeactivationServiceTest {
       eq("no active events"),
       eq(true),
     )
-    verify(notificationService).sendDeactivationCompletedNotifications(eq(offender), eq(contactDetails), isNull())
+    verify(notificationService).sendDeactivationCompletedNotifications(eq(offender), eq(contactDetails), isNull(), eq("ESPMP"))
   }
 
   @Test
@@ -93,6 +93,7 @@ class OffenderDeactivationServiceTest {
       eq("no active events"),
       eq(false),
     )
+    verify(notificationService).sendDeactivationCompletedNotifications(eq(offender), eq(contactDetails), isNull(), eq("ESPNA"))
   }
 
   @Test
@@ -115,7 +116,7 @@ class OffenderDeactivationServiceTest {
     assertEquals(OffenderStatus.INACTIVE, result.status)
     verify(offenderRepository, never()).save(any())
     verify(questionService, never()).deleteUpcomingAssignment(any())
-    verify(notificationService, never()).sendDeactivationCompletedNotifications(any(), any(), any())
+    verify(notificationService, never()).sendDeactivationCompletedNotifications(any(), any(), any(), any())
   }
 
   @Test
@@ -126,7 +127,7 @@ class OffenderDeactivationServiceTest {
 
     service.deactivateOffender(offender, "no active events")
 
-    verify(notificationService).sendDeactivationCompletedNotifications(eq(offender), isNull(), isNull())
+    verify(notificationService).sendDeactivationCompletedNotifications(eq(offender), isNull(), isNull(), eq("ESPMP"))
   }
 
   private fun offender(status: OffenderStatus) = Offender(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderDeactivationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderDeactivationServiceTest.kt
@@ -97,6 +97,29 @@ class OffenderDeactivationServiceTest {
   }
 
   @Test
+  fun `propagates the contact-suspended outcome code (automated deactivation)`() {
+    val offender = offender(OffenderStatus.VERIFIED)
+    whenever(offenderRepository.save(any<Offender>())).thenAnswer { it.getArgument<Offender>(0) }
+    whenever(offenderSetupRepository.findByOffender(any())).thenReturn(Optional.empty())
+
+    service.deactivateOffender(
+      offender,
+      "contact suspended",
+      contactDetails,
+      auditEventType = OffenderAuditEventType.OFFENDER_AUTO_DEACTIVATED_CONTACT_SUSPENDED,
+    )
+
+    verify(eventAuditService).recordOffenderEvent(
+      eq(OffenderAuditEventType.OFFENDER_AUTO_DEACTIVATED_CONTACT_SUSPENDED),
+      eq(offender),
+      eq(contactDetails),
+      eq("contact suspended"),
+      eq(false),
+    )
+    verify(notificationService).sendDeactivationCompletedNotifications(eq(offender), eq(contactDetails), isNull(), eq("ESPRS"))
+  }
+
+  @Test
   fun `cancels pending CREATED check-ins on deactivation`() {
     val offender = offender(OffenderStatus.VERIFIED)
     whenever(offenderRepository.save(any<Offender>())).thenAnswer { it.getArgument<Offender>(0) }


### PR DESCRIPTION
PI team is ready for us to start sending the new outcome codes for stopping check ins

This sends the following codes in `additionalInformation -> outcomeCode`:
- ESPMP - manual stop by practitioner
- ESPNA - auto stop due to no active events
- ESPRS - auto stop due to being in reset

Once they're being received, PI will make their update to record the outcome