### PR TITLE
ESUP-2016 Make content hast mandatory. Add test coverage

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/AppConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/AppConfig.kt
@@ -13,11 +13,9 @@ class AppConfig(
   @Value("\${app.hostedAt}") private val hostedAt: String,
   @Value("\${app.features.esup-1239}") val esup1239ProxyLinks: Boolean,
   @Value("\${app.features.esup-1763}") val esup1763RemoveSnapshots: Boolean,
-  @Value("\${app.features.upload-content-hash.require:false}") val uploadContentHashRequire: Boolean,
   val enabledFeatures: Set<Feature> = listOfNotNull(
     if (esup1239ProxyLinks) Feature.ESUP_1239 else null,
     if (esup1763RemoveSnapshots) Feature.ESUP_1763 else null,
-    if (uploadContentHashRequire) Feature.ESUP_1672_REQUIRE_UPLOAD_CONTENT_HASH else null,
   ).toSet(),
 ) {
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/Feature.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/Feature.kt
@@ -7,11 +7,6 @@ enum class Feature {
   ESUP_1239,
 
   /**
-   * ESUP-1672: Require a SHA-256 content hash when requesting presigned upload URLs
-   */
-  ESUP_1672_REQUIRE_UPLOAD_CONTENT_HASH,
-
-  /**
    * ESUP-1763: Remove snapshots from checkins if the manual check confirms it is a match
    */
   ESUP_1763,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/CheckinService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/CheckinService.kt
@@ -178,8 +178,6 @@ class CheckinService(
       throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Checkin is past submission date")
     }
 
-    val requireHash = appConfig.enabledFeatures.contains(Feature.ESUP_1672_REQUIRE_UPLOAD_CONTENT_HASH)
-
     val ttl = Duration.ofMinutes(uploadTtlMinutes)
     val ttlString = "PT${uploadTtlMinutes}M"
     // Video URL is left unbound to a content hash — no client uploads videos via this endpoint.
@@ -188,13 +186,7 @@ class CheckinService(
       snapshotContentTypes.mapIndexed { index, contentType ->
         val snapHash = resolveUploadHash(
           hashes?.snapshots?.getOrNull(index)?.sha256,
-          requireHash,
           "snapshot[$index]",
-        )
-        LOGGER.info(
-          "upload_hash.received endpoint=/v2/offender_checkins/upload_location slot=snapshot[{}] received={}",
-          index,
-          snapHash != null,
         )
         val presigned = s3UploadService.generatePresignedUpload(checkin, contentType, index, ttl, snapHash)
         UploadLocation(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/storage/S3UploadService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/storage/S3UploadService.kt
@@ -37,8 +37,7 @@ data class PresignedUpload(
 /**
  * Resolve a client-supplied base64 SHA-256 to forward to S3.
  *
- * - `require=true` rejects with HTTP 400 when the hash is missing (post-rollout state).
- * - Otherwise: returns the trimmed value if present, null if absent (dual-mode rollout).
+ * Rejects with HTTP 400 when the hash is missing — a content hash is mandatory for all uploads.
  *
  * The value is passed verbatim to the AWS SDK's `.checksumSHA256(...)`. The SDK / S3 will
  * reject malformed values at PUT time, so we don't validate format here beyond non-empty.
@@ -46,18 +45,14 @@ data class PresignedUpload(
  */
 fun resolveUploadHash(
   sha256Base64: String?,
-  require: Boolean,
   slot: String = "file",
-): String? {
+): String {
   val trimmed = sha256Base64?.trim()
   if (trimmed.isNullOrEmpty()) {
-    if (require) {
-      throw org.springframework.web.server.ResponseStatusException(
-        org.springframework.http.HttpStatus.BAD_REQUEST,
-        "Missing content hash for $slot",
-      )
-    }
-    return null
+    throw org.springframework.web.server.ResponseStatusException(
+      org.springframework.http.HttpStatus.BAD_REQUEST,
+      "Missing content hash for $slot",
+    )
   }
   return trimmed
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderResource.kt
@@ -19,8 +19,6 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.server.ResponseStatusException
-import uk.gov.justice.digital.hmpps.esupervisionapi.config.AppConfig
-import uk.gov.justice.digital.hmpps.esupervisionapi.config.Feature
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.logger
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.today
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinStatus
@@ -64,7 +62,6 @@ class OffenderResource(
   private val checkinRepository: OffenderCheckinRepository,
   private val offenderSetupService: OffenderSetupService,
   private val offenderDeactivationService: OffenderDeactivationService,
-  private val appConfig: AppConfig,
 ) {
 
   @PreAuthorize("hasRole('ROLE_ESUPERVISION__ESUPERVISION_UI')")
@@ -161,10 +158,8 @@ class OffenderResource(
 
     val hash = resolveUploadHash(
       sha256Base64 = hashRequest?.sha256,
-      require = appConfig.enabledFeatures.contains(Feature.ESUP_1672_REQUIRE_UPLOAD_CONTENT_HASH),
       slot = "offender-photo",
     )
-    LOGGER.info("upload_hash.received endpoint=/v2/offenders/upload_location received={}", hash != null)
 
     val duration = Duration.ofMinutes(5)
     val presigned = s3UploadService.generatePresignedUpload(offender, contentType, duration, hash)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/setup/OffenderSetupResource.kt
@@ -15,8 +15,6 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.server.ResponseStatusException
-import uk.gov.justice.digital.hmpps.esupervisionapi.config.AppConfig
-import uk.gov.justice.digital.hmpps.esupervisionapi.config.Feature
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderDto
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderInfo
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderSetupDto
@@ -37,7 +35,6 @@ import java.util.UUID
 class OffenderSetupResource(
   private val offenderSetupService: OffenderSetupService,
   private val s3UploadService: S3UploadService,
-  private val appConfig: AppConfig,
 ) {
 
   @PreAuthorize("hasRole('ROLE_ESUPERVISION__ESUPERVISION_UI')")
@@ -103,10 +100,8 @@ class OffenderSetupResource(
 
     val hash = resolveUploadHash(
       sha256Base64 = hashRequest?.sha256,
-      require = appConfig.enabledFeatures.contains(Feature.ESUP_1672_REQUIRE_UPLOAD_CONTENT_HASH),
       slot = "setup-photo",
     )
-    LOGGER.info("upload_hash.received endpoint=/v2/offender_setup/upload_location received={}", hash != null)
 
     val duration = Duration.ofMinutes(5)
     val presigned = s3UploadService.generatePresignedUpload(setup.get(), contentType, duration, hash)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,12 +49,6 @@ app:
   features:
     # publish media proxy links to NDelius
     esup-1239: true
-    # bind presigned upload URLs to the SHA-256 of the file content.
-    # When a client supplies a hash the API always signs it into the URL and echoes
-    # x-amz-checksum-sha256 in requiredHeaders. The flag below controls whether a hash is mandatory.
-    upload-content-hash:
-      # if true, reject upload_location requests that don't carry a hash
-      require: ${UPLOAD_CONTENT_HASH_REQUIRE:false}
     # remove the checkin snapshot if the manual id check confirms it is a match without concern
     esup-1763: ${APP_FEATURES_ESUP_1763:false}
   offender-survey:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/CheckinServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/CheckinServiceTest.kt
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.assertNull
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.reset
@@ -33,6 +34,7 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinPersistenceService
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinReviewInfo
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinService
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinStatus
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinUploadHashesRequest
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.GenericNotificationRepository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.INdiliusApiClient
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.LogEntryType
@@ -51,14 +53,17 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ContactPreference
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.LivenessResult
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ManualIdVerificationResult
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.OffenderStatus
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.dto.UploadHashRequest
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.rekognition.FacialRecognitionOutcome
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.rekognition.LivenessCredentialsProvider
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.rekognition.LivenessSessionService
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.rekognition.OffenderIdVerifier
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.rekognition.S3ObjectCoordinate
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.storage.PresignedUpload
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.storage.S3UploadService
 import java.net.URI
 import java.time.Clock
+import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
@@ -1085,6 +1090,90 @@ class CheckinServiceTest {
           notes["action"] == "create liveness session"
       },
     )
+  }
+
+  // ----- getUploadLocations: content-hash enforcement -----
+
+  @Test
+  fun `getUploadLocations - happy path - binds each snapshot to its hash and leaves video unbound`() {
+    val uuid = UUID.randomUUID()
+    val checkin = createCreatedCheckin(uuid)
+    whenever(checkinRepository.findByUuid(uuid)).thenReturn(Optional.of(checkin))
+
+    val videoUrl = URI.create("https://upload/video").toURL()
+    val snapshotUrl = URI.create("https://upload/snapshot/0").toURL()
+    whenever(s3UploadService.generatePresignedUpload(eq(checkin), eq("video/webm"), any<Duration>(), isNull()))
+      .thenReturn(PresignedUpload(videoUrl, emptyMap()))
+    whenever(s3UploadService.generatePresignedUpload(eq(checkin), eq("image/jpeg"), eq(0), any<Duration>(), eq("hash0")))
+      .thenReturn(PresignedUpload(snapshotUrl, mapOf("x-amz-checksum-sha256" to "hash0")))
+
+    val result = service.getUploadLocations(
+      uuid,
+      "video/webm",
+      listOf("image/jpeg"),
+      CheckinUploadHashesRequest(snapshots = listOf(UploadHashRequest(sha256 = "hash0"))),
+    )
+
+    assertEquals(videoUrl, result.video.url)
+    assertNull(result.video.requiredHeaders, "Video URL is deliberately left unbound to a content hash")
+    assertEquals(1, result.snapshots.size)
+    assertEquals(snapshotUrl, result.snapshots[0].url)
+    assertEquals(mapOf("x-amz-checksum-sha256" to "hash0"), result.snapshots[0].requiredHeaders)
+  }
+
+  @Test
+  fun `getUploadLocations - missing request body - returns 400`() {
+    val uuid = UUID.randomUUID()
+    val checkin = createCreatedCheckin(uuid)
+    whenever(checkinRepository.findByUuid(uuid)).thenReturn(Optional.of(checkin))
+
+    val exception = assertThrows(ResponseStatusException::class.java) {
+      service.getUploadLocations(uuid, "video/webm", listOf("image/jpeg"), null)
+    }
+
+    assertEquals(HttpStatus.BAD_REQUEST, exception.statusCode)
+    verify(s3UploadService, never()).generatePresignedUpload(any(), any<String>(), any<Int>(), any<Duration>(), any())
+  }
+
+  @Test
+  fun `getUploadLocations - blank snapshot hash - returns 400`() {
+    val uuid = UUID.randomUUID()
+    val checkin = createCreatedCheckin(uuid)
+    whenever(checkinRepository.findByUuid(uuid)).thenReturn(Optional.of(checkin))
+
+    val exception = assertThrows(ResponseStatusException::class.java) {
+      service.getUploadLocations(
+        uuid,
+        "video/webm",
+        listOf("image/jpeg"),
+        CheckinUploadHashesRequest(snapshots = listOf(UploadHashRequest(sha256 = "   "))),
+      )
+    }
+
+    assertEquals(HttpStatus.BAD_REQUEST, exception.statusCode)
+    verify(s3UploadService, never()).generatePresignedUpload(any(), any<String>(), any<Int>(), any<Duration>(), any())
+  }
+
+  @Test
+  fun `getUploadLocations - fewer hashes than snapshots - returns 400`() {
+    val uuid = UUID.randomUUID()
+    val checkin = createCreatedCheckin(uuid)
+    whenever(checkinRepository.findByUuid(uuid)).thenReturn(Optional.of(checkin))
+    // The first snapshot resolves fine; the second has no hash and must trigger the 400.
+    whenever(s3UploadService.generatePresignedUpload(eq(checkin), eq("image/jpeg"), eq(0), any<Duration>(), eq("hash0")))
+      .thenReturn(PresignedUpload(URI.create("https://upload/snapshot/0").toURL(), emptyMap()))
+
+    val exception = assertThrows(ResponseStatusException::class.java) {
+      service.getUploadLocations(
+        uuid,
+        "video/webm",
+        listOf("image/jpeg", "image/jpeg"),
+        CheckinUploadHashesRequest(snapshots = listOf(UploadHashRequest(sha256 = "hash0"))),
+      )
+    }
+
+    assertEquals(HttpStatus.BAD_REQUEST, exception.statusCode)
+    verify(s3UploadService, never()).generatePresignedUpload(eq(checkin), eq("image/jpeg"), eq(1), any<Duration>(), any())
   }
 
   // ----- Failure-logging test helpers -----

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderResourceTest.kt
@@ -16,7 +16,6 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.http.HttpStatus
 import org.springframework.web.server.ResponseStatusException
-import uk.gov.justice.digital.hmpps.esupervisionapi.config.AppConfig
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.today
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinStatus
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CodedDescription
@@ -32,6 +31,7 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.checkin.CheckinCreationSe
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.CheckinInterval
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ContactPreference
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.OffenderStatus
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.dto.UploadHashRequest
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.storage.PresignedUpload
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.storage.S3UploadService
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.setup.OffenderSetupService
@@ -56,7 +56,6 @@ class OffenderResourceTest {
   private val checkinRepository: OffenderCheckinRepository = mock()
   private val offenderSetupService: OffenderSetupService = mock()
   private val offenderDeactivationService: OffenderDeactivationService = mock()
-  private val appConfig: AppConfig = mock()
 
   private lateinit var resource: OffenderResource
 
@@ -75,7 +74,6 @@ class OffenderResourceTest {
       checkinRepository,
       offenderSetupService,
       offenderDeactivationService,
-      appConfig,
     )
   }
 
@@ -620,15 +618,29 @@ class OffenderResourceTest {
     val presignedUrl = URI("https://s3.amazonaws.com/bucket/photo.jpg?presigned=true").toURL()
 
     whenever(offenderRepository.findByUuid(uuid)).thenReturn(Optional.of(offender))
-    whenever(s3UploadService.generatePresignedUpload(eq(offender), eq("image/jpeg"), any<Duration>(), isNull()))
-      .thenReturn(PresignedUpload(presignedUrl, emptyMap()))
+    whenever(s3UploadService.generatePresignedUpload(eq(offender), eq("image/jpeg"), any<Duration>(), eq("hash123")))
+      .thenReturn(PresignedUpload(presignedUrl, mapOf("x-amz-checksum-sha256" to "hash123")))
 
-    val result = resource.getPhotoUploadLocation(uuid, "image/jpeg", null)
+    val result = resource.getPhotoUploadLocation(uuid, "image/jpeg", UploadHashRequest(sha256 = "hash123"))
 
     assertEquals(HttpStatus.OK, result.statusCode)
     assertNotNull(result.body?.locationInfo)
     assertEquals(presignedUrl.toString(), result.body?.locationInfo?.url.toString())
     assertEquals("image/jpeg", result.body?.locationInfo?.contentType)
+  }
+
+  @Test
+  fun `getPhotoUploadLocation - missing content hash - returns 400`() {
+    val uuid = UUID.randomUUID()
+    val offender = createOffender(uuid, OffenderStatus.VERIFIED)
+
+    whenever(offenderRepository.findByUuid(uuid)).thenReturn(Optional.of(offender))
+
+    val exception = assertThrows(ResponseStatusException::class.java) {
+      resource.getPhotoUploadLocation(uuid, "image/jpeg", null)
+    }
+
+    assertEquals(HttpStatus.BAD_REQUEST, exception.statusCode)
   }
 
   @Test
@@ -688,10 +700,10 @@ class OffenderResourceTest {
     val presignedUrl = URI("https://s3.amazonaws.com/bucket/photo.png?presigned=true").toURL()
 
     whenever(offenderRepository.findByUuid(uuid)).thenReturn(Optional.of(offender))
-    whenever(s3UploadService.generatePresignedUpload(eq(offender), eq("image/png"), any<Duration>(), isNull()))
-      .thenReturn(PresignedUpload(presignedUrl, emptyMap()))
+    whenever(s3UploadService.generatePresignedUpload(eq(offender), eq("image/png"), any<Duration>(), eq("hash123")))
+      .thenReturn(PresignedUpload(presignedUrl, mapOf("x-amz-checksum-sha256" to "hash123")))
 
-    val result = resource.getPhotoUploadLocation(uuid, "image/png", null)
+    val result = resource.getPhotoUploadLocation(uuid, "image/png", UploadHashRequest(sha256 = "hash123"))
 
     assertEquals(HttpStatus.OK, result.statusCode)
     assertNotNull(result.body?.locationInfo)


### PR DESCRIPTION
MPoP and the check ins front end have both been sending content hashes to include in the s3 upload signature for some time. This change enforces that the content hash must be sent as currently it's optional