### PR TITLE
ESUP-2012: add offender name to data class OffenderSummaryDto

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/Dtos.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/Dtos.kt
@@ -40,6 +40,10 @@ data class Event(
   )
 }
 
+interface INamedPerson {
+  val name: Name
+}
+
 /** Contact details from Delius API
  *
  * See https://github.com/ministryofjustice/hmpps-probation-integration-services/blob/main/projects/esupervision-and-delius/src/main/kotlin/uk/gov/justice/digital/hmpps/model/ContactDetails.kt
@@ -49,7 +53,7 @@ data class ContactDetails(
   val crn: String,
 
   @field:Schema(description = "Person's name", required = true)
-  val name: Name,
+  override val name: Name,
 
   @field:Schema(
     description = "Mobile phone number (optional)",
@@ -86,35 +90,40 @@ data class ContactDetails(
     required = false,
   )
   val contactSuspended: Boolean = false,
-)
+) : INamedPerson
 
 /** Person's name from Ndilius */
 data class Name(
-  @Schema(description = "Forename", required = true, example = "John") val forename: String,
-  @Schema(description = "Surname", required = true, example = "Smith") val surname: String,
+  @field:Schema(description = "Forename", required = true, example = "John") val forename: String,
+  @field:Schema(description = "Surname", required = true, example = "Smith") val surname: String,
 )
 
 /** Practitioner details from Ndilius API */
 data class PractitionerDetails(
-  @Schema(description = "Practitioner's name", required = true) val name: Name,
-  @Schema(
+  @field:Schema(description = "Practitioner's name", required = true)
+  override val name: Name,
+
+  @field:Schema(
     description = "Practitioner's email address (optional - may not be available)",
     required = false,
     example = "practitioner@example.com",
   )
   val email: String? = null,
-  @Schema(description = "Local Admin Unit", required = false)
+
+  @field:Schema(description = "Local Admin Unit", required = false)
   val localAdminUnit: OrganizationalUnit? = null,
-  @Schema(description = "Probation Delivery Unit", required = false)
+
+  @field:Schema(description = "Probation Delivery Unit", required = false)
   val probationDeliveryUnit: OrganizationalUnit? = null,
-  @Schema(description = "Provider", required = false)
+
+  @field:Schema(description = "Provider", required = false)
   val provider: OrganizationalUnit? = null,
-)
+) : INamedPerson
 
 /** Organizational unit (LAU, PDU, Provider) */
 data class OrganizationalUnit(
-  @Schema(description = "Unit code", required = true, example = "N01ABC") val code: String,
-  @Schema(description = "Unit description", required = false, example = "London North LAU")
+  @field:Schema(description = "Unit code", required = true, example = "N01ABC") val code: String,
+  @field:Schema(description = "Unit description", required = false, example = "London North LAU")
   val description: String? = null,
 )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderResource.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.utils.logger
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.today
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinStatus
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.ContactDetails
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.INamedPerson
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.INdiliusApiClient
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.Name
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.NotificationService
@@ -70,22 +71,24 @@ class OffenderResource(
   @PreAuthorize("hasRole('ROLE_ESUPERVISION__ESUPERVISION_UI')")
   @Operation(
     summary = "Get offender by CRN",
-    description = "Returns offender registration details (no PII). Returns 404 if not found.",
+    description = "Returns offender registration details.",
   )
   @ApiResponse(responseCode = "200", description = "Offender found")
   @ApiResponse(responseCode = "404", description = "Offender not found")
   @GetMapping("/crn/{crn}")
   fun getOffenderByCrn(
     @Parameter(description = "Case Reference Number", required = true) @PathVariable crn: String,
+    @RequestParam(name = "include-personal-details", required = false, defaultValue = "false") includePersonalDetails: Boolean,
   ): ResponseEntity<OffenderSummaryDto> {
     val offender = offenderRepository.findByCrn(crn.trim().uppercase()).orElse(null)
     if (offender == null) {
       LOGGER.info("Offender not found for crn={}", crn)
       return ResponseEntity.notFound().build()
     }
+    val contactDetails = if (includePersonalDetails) ndiliusApiClient.getContactDetails(crn) else null
 
-    LOGGER.info("Found offender by CRN: crn={}, status={}", offender.crn, offender.status)
-    return ResponseEntity.ok(offender.toSummaryDto(getOffenderPhotoUrl(offender)))
+    LOGGER.info("Found offender by CRN: crn={}, status={}, contactDetails={}", offender.crn, offender.status, if (!includePersonalDetails) "skipped" else contactDetails != null)
+    return ResponseEntity.ok(offender.toSummaryDto(getOffenderPhotoUrl(offender), contactDetails))
   }
 
   @PreAuthorize("hasRole('ROLE_ESUPERVISION__ESUPERVISION_UI')")
@@ -439,7 +442,14 @@ class OffenderResource(
   }
 }
 
-/** Simple DTO for offender lookup - no PII */
+/**
+ * Subset of [ContactDetails] that is returned in the summary DTO.
+ */
+data class OffenderSummaryDetails(
+  override val name: Name,
+) : INamedPerson
+
+/** Simple DTO for offender lookup - no PII by default */
 data class OffenderSummaryDto(
   val uuid: UUID,
   val crn: String,
@@ -448,9 +458,10 @@ data class OffenderSummaryDto(
   val checkinInterval: CheckinInterval,
   val contactPreference: ContactPreference,
   val photoUrl: String? = null,
+  val details: INamedPerson? = null,
 )
 
-private fun Offender.toSummaryDto(photoUrl: String? = null) = OffenderSummaryDto(
+private fun Offender.toSummaryDto(photoUrl: String? = null, contactDetails: ContactDetails? = null) = OffenderSummaryDto(
   uuid = uuid,
   crn = crn,
   status = status,
@@ -458,6 +469,7 @@ private fun Offender.toSummaryDto(photoUrl: String? = null) = OffenderSummaryDto
   checkinInterval = CheckinInterval.fromDuration(checkinInterval),
   contactPreference = contactPreference,
   photoUrl = photoUrl,
+  details = contactDetails?.let { OffenderSummaryDetails(it.name) },
 )
 
 /** Request to deactivate an offender */

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderResource.kt
@@ -86,7 +86,14 @@ class OffenderResource(
     }
     val contactDetails = if (includePersonalDetails) ndiliusApiClient.getContactDetails(normalisedCrn) else null
 
-    LOGGER.info("Found offender by CRN: crn={}, status={}, contactDetails={}", normalisedCrn, offender.status, if (!includePersonalDetails) "skipped" else contactDetails != null)
+    val detailsMesage = if (!includePersonalDetails) {
+      "skipped"
+    } else if (contactDetails != null) {
+      "fetched"
+    } else {
+      "not found"
+    }
+    LOGGER.info("Found offender by CRN: crn={}, status={}, contactDetails={}", normalisedCrn, offender.status, detailsMesage)
     return ResponseEntity.ok(offender.toSummaryDto(getOffenderPhotoUrl(offender), contactDetails))
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderResource.kt
@@ -71,13 +71,14 @@ class OffenderResource(
   @PreAuthorize("hasRole('ROLE_ESUPERVISION__ESUPERVISION_UI')")
   @Operation(
     summary = "Get offender by CRN",
-    description = "Returns offender registration details.",
+    description = "Returns offender registration details. Does not include PII by default.",
   )
   @ApiResponse(responseCode = "200", description = "Offender found")
   @ApiResponse(responseCode = "404", description = "Offender not found")
   @GetMapping("/crn/{crn}")
   fun getOffenderByCrn(
     @Parameter(description = "Case Reference Number", required = true) @PathVariable crn: String,
+    @Parameter(description = "Include PII from NDdelius", required = false)
     @RequestParam(name = "include-personal-details", required = false, defaultValue = "false") includePersonalDetails: Boolean,
   ): ResponseEntity<OffenderSummaryDto> {
     val normalisedCrn = crn.trim().uppercase()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderResource.kt
@@ -86,7 +86,7 @@ class OffenderResource(
     }
     val contactDetails = if (includePersonalDetails) ndiliusApiClient.getContactDetails(normalisedCrn) else null
 
-    LOGGER.info("Found offender by CRN: crn={}, status={}, contactDetails={}", offender.crn, offender.status, if (!includePersonalDetails) "skipped" else contactDetails != null)
+    LOGGER.info("Found offender by CRN: crn={}, status={}, contactDetails={}", normalisedCrn, offender.status, if (!includePersonalDetails) "skipped" else contactDetails != null)
     return ResponseEntity.ok(offender.toSummaryDto(getOffenderPhotoUrl(offender), contactDetails))
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderResource.kt
@@ -80,12 +80,13 @@ class OffenderResource(
     @Parameter(description = "Case Reference Number", required = true) @PathVariable crn: String,
     @RequestParam(name = "include-personal-details", required = false, defaultValue = "false") includePersonalDetails: Boolean,
   ): ResponseEntity<OffenderSummaryDto> {
-    val offender = offenderRepository.findByCrn(crn.trim().uppercase()).orElse(null)
+    val normalisedCrn = crn.trim().uppercase()
+    val offender = offenderRepository.findByCrn(normalisedCrn).orElse(null)
     if (offender == null) {
       LOGGER.info("Offender not found for crn={}", crn)
       return ResponseEntity.notFound().build()
     }
-    val contactDetails = if (includePersonalDetails) ndiliusApiClient.getContactDetails(crn) else null
+    val contactDetails = if (includePersonalDetails) ndiliusApiClient.getContactDetails(normalisedCrn) else null
 
     LOGGER.info("Found offender by CRN: crn={}, status={}, contactDetails={}", offender.crn, offender.status, if (!includePersonalDetails) "skipped" else contactDetails != null)
     return ResponseEntity.ok(offender.toSummaryDto(getOffenderPhotoUrl(offender), contactDetails))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderResource.kt
@@ -460,7 +460,7 @@ data class OffenderSummaryDto(
   val checkinInterval: CheckinInterval,
   val contactPreference: ContactPreference,
   val photoUrl: String? = null,
-  val details: INamedPerson? = null,
+  val details: OffenderSummaryDetails? = null,
 )
 
 private fun Offender.toSummaryDto(photoUrl: String? = null, contactDetails: ContactDetails? = null) = OffenderSummaryDto(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderResourceTest.kt
@@ -11,7 +11,6 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.reset
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -65,10 +64,6 @@ class OffenderResourceTest {
 
   @BeforeEach
   fun setUp() {
-    reset(
-      offenderRepository, s3UploadService, checkinCreationService, eventAuditService, ndiliusApiClient,
-      notificationService, checkinRepository, offenderSetupService, offenderDeactivationService,
-    )
     resource = OffenderResource(
       offenderRepository,
       s3UploadService,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderResourceTest.kt
@@ -779,9 +779,11 @@ class OffenderResourceTest {
     val resultWithoutDetails = resource.getOffenderByCrn(offender.crn, includePersonalDetails = false)
     assertNotNull(resultWithoutDetails.body)
     assertNull(resultWithoutDetails.body?.details)
+    verify(ndiliusApiClient, times(0)).getContactDetails(offender.crn)
 
     val resultWithDetails = resource.getOffenderByCrn(offender.crn, includePersonalDetails = true)
     assertNotNull(resultWithDetails.body?.details)
+    verify(ndiliusApiClient, times(1)).getContactDetails(offender.crn)
   }
 
   // ========================================

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderResourceTest.kt
@@ -761,10 +761,11 @@ class OffenderResourceTest {
   @Test
   fun `getOffenderByCrn - success`() {
     val offender = createOffender(UUID.randomUUID(), OffenderStatus.VERIFIED)
-    whenever(offenderRepository.findByUuid(offender.uuid)).thenReturn(Optional.of(offender))
+    whenever(offenderRepository.findByCrn(offender.crn)).thenReturn(Optional.of(offender))
     whenever(ndiliusApiClient.getContactDetails(offender.crn)).thenAnswer { GeneratingStubDataProvider().provideCase(crn = offender.crn) }
 
     val resultWithoutDetails = resource.getOffenderByCrn(offender.crn, includePersonalDetails = false)
+    assertNotNull(resultWithoutDetails.body)
     assertNull(resultWithoutDetails.body?.details)
 
     val resultWithDetails = resource.getOffenderByCrn(offender.crn, includePersonalDetails = true)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderResourceTest.kt
@@ -752,6 +752,17 @@ class OffenderResourceTest {
     assertEquals(ContactPreference.EMAIL, offender.contactPreference)
   }
 
+  @Test
+  fun `getOffenderByCrn - success`() {
+    val offender = createOffender(UUID.randomUUID(), OffenderStatus.VERIFIED)
+
+    val resultWithoutDetails = resource.getOffenderByCrn(offender.crn, includePersonalDetails = false)
+    assertNull(resultWithoutDetails.body?.details)
+
+    val resultWithDetails = resource.getOffenderByCrn(offender.crn, includePersonalDetails = true)
+    assertNotNull(resultWithDetails.body?.details)
+  }
+
   // ========================================
   // Helper Methods
   // ========================================

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderResourceTest.kt
@@ -11,12 +11,14 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.reset
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.http.HttpStatus
 import org.springframework.web.server.ResponseStatusException
 import uk.gov.justice.digital.hmpps.esupervisionapi.config.AppConfig
+import uk.gov.justice.digital.hmpps.esupervisionapi.utils.GeneratingStubDataProvider
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.today
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinStatus
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CodedDescription
@@ -64,6 +66,10 @@ class OffenderResourceTest {
 
   @BeforeEach
   fun setUp() {
+    reset(
+      offenderRepository, s3UploadService, checkinCreationService, eventAuditService, ndiliusApiClient,
+      notificationService, checkinRepository, offenderSetupService, offenderDeactivationService, appConfig,
+    )
     resource = OffenderResource(
       offenderRepository,
       s3UploadService,
@@ -755,6 +761,8 @@ class OffenderResourceTest {
   @Test
   fun `getOffenderByCrn - success`() {
     val offender = createOffender(UUID.randomUUID(), OffenderStatus.VERIFIED)
+    whenever(offenderRepository.findByUuid(offender.uuid)).thenReturn(Optional.of(offender))
+    whenever(ndiliusApiClient.getContactDetails(offender.crn)).thenAnswer { GeneratingStubDataProvider().provideCase(crn = offender.crn) }
 
     val resultWithoutDetails = resource.getOffenderByCrn(offender.crn, includePersonalDetails = false)
     assertNull(resultWithoutDetails.body?.details)


### PR DESCRIPTION
Adds a query param to the `/v2/offenders/crn/:crn` endpoint: `include-personal-details` to optionally return more details about the offender (as of now, only their name). 