### PR TITLE
ESUP-1956 Date the resend note as the submitted date

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/CheckinNoteResendService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/CheckinNoteResendService.kt
@@ -92,7 +92,10 @@ class CheckinNoteResendService(
         OffenderEventLog(
           comment = buildNotes(checkin),
           sensitive = checkin.sensitive,
-          createdAt = clock.instant(),
+          // Date the corrective note to the original submission, not "now", so NDelius (via
+          // EventDetailResponse.timestamp = annotation.createdAt) sorts it into the past instead of
+          // surfacing it as the "latest update" in MPoP. The resend time is recorded on row.sentAt.
+          createdAt = checkin.submittedAt ?: checkin.createdAt,
           logEntryType = LogEntryType.OFFENDER_CHECKIN_ANNOTATED,
           practitioner = "SYSTEM",
           uuid = UUID.randomUUID(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/jobs/CheckinNoteResendJobIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/integration/jobs/CheckinNoteResendJobIT.kt
@@ -103,6 +103,9 @@ class CheckinNoteResendJobIT : IntegrationTestBase() {
     assertThat(detail.notes).contains("Check in answers:")
     assertThat(detail.notes).contains("How they have been feeling: Feeling Great")
     assertThat(detail.crn).isEqualTo(checkin.offender.crn)
+    // the note is dated to the original submission, not the resend time, so NDelius does not
+    // surface it as the "latest update" for the check-in
+    assertThat(detail.timestamp).isEqualTo(checkin.submittedAt)
 
     // other tests in this class also write CHECKIN_NOTE_RESEND job logs, so assert on the latest
     val jobLog = jobLogRepository.findAll().filter { it.jobType == "CHECKIN_NOTE_RESEND" }.maxBy { it.id }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/CheckinNoteResendServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/CheckinNoteResendServiceTest.kt
@@ -101,6 +101,9 @@ class CheckinNoteResendServiceTest {
     assertThat(logEntry.practitioner).isEqualTo("SYSTEM")
     assertThat(logEntry.sensitive).isTrue()
     assertThat(logEntry.checkin).isEqualTo(checkin.id)
+    // Dated to the original submission (not the resend/clock time) so NDelius sorts it into the past
+    assertThat(logEntry.createdAt).isEqualTo(checkin.submittedAt)
+    assertThat(logEntry.createdAt).isNotEqualTo(clock.instant())
     assertThat(logEntry.comment).contains("This comment was added due to a system issue.")
     assertThat(logEntry.comment).contains("answers for the check in submitted on 12 May 2026 at 3:30pm")
     assertThat(logEntry.comment).contains("Check in answers:")


### PR DESCRIPTION
Set the date for the resent questions and answers note to be the submitted date so it doesn't appear as the latest update