### PR TITLE
ESUP-1930: adds metrics endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/MetricsConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/MetricsConfig.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.config
+
+import io.micrometer.core.aop.TimedAspect
+import io.micrometer.core.instrument.MeterRegistry
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class MetricsConfig {
+  @Bean
+  fun timedAspect(registry: MeterRegistry): TimedAspect = TimedAspect(registry)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/StubServicesConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/StubServicesConfiguration.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.esupervisionapi.config
 
+import io.micrometer.core.annotation.Timed
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.DisposableBean
 import org.springframework.context.annotation.Bean
@@ -34,7 +35,7 @@ class StubServicesConfiguration {
  *
  * The file can be edited at runtime and will be automatically reloaded.
  */
-class StubNdiliusApiClient(
+open class StubNdiliusApiClient(
   val watcher: StubDataWatcher = StubDataWatcher(Path.of("src/test/resources/ndelius-responses/default.json")),
   val dataProvider: StubDataProvider = GeneratingStubDataProvider(),
 ) : INdiliusApiClient,
@@ -53,6 +54,7 @@ class StubNdiliusApiClient(
     return watcher.allowedCrns.contains(personalDetails.crn)
   }
 
+  @Timed("ndelius.get-contact-details", extraTags = ["method=GET", "endpoint=/case/{crn}"], description = "Time taken to get contact details (STUB)")
   override fun getContactDetails(crn: String): ContactDetails? {
     LOG.debug("Fetching contact details for CRN: {}", crn)
     if (watcher.allowedCrns.contains(crn)) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/StubServicesConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/config/StubServicesConfiguration.kt
@@ -54,7 +54,7 @@ open class StubNdiliusApiClient(
     return watcher.allowedCrns.contains(personalDetails.crn)
   }
 
-  @Timed("ndelius.get-contact-details", extraTags = ["method=GET", "endpoint=/case/{crn}"], description = "Time taken to get contact details (STUB)")
+  @Timed("ndelius.get-contact-details", extraTags = ["method", "GET", "endpoint", "/case/{crn}"], description = "Time taken to get contact details (STUB)")
   override fun getContactDetails(crn: String): ContactDetails? {
     LOG.debug("Fetching contact details for CRN: {}", crn)
     if (watcher.allowedCrns.contains(crn)) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NdiliusApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NdiliusApiClient.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.esupervisionapi.v2
 
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker
 import io.github.resilience4j.retry.annotation.Retry
+import io.micrometer.core.annotation.Timed
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Profile
 import org.springframework.http.HttpStatus
@@ -42,6 +43,7 @@ class NdiliusApiClient(
    */
   @CircuitBreaker(name = "ndiliusApi", fallbackMethod = "getContactDetailsFallback")
   @Retry(name = "ndiliusApi")
+  @Timed("ndelius.get-contact-details", extraTags = ["method=GET", "endpoint=/case/{crn}"], description = "Time taken to get contact details")
   override fun getContactDetails(crn: String): ContactDetails? {
     LOGGER.info("Fetching contact details for CRN: {}", crn)
 
@@ -72,6 +74,7 @@ class NdiliusApiClient(
    */
   @CircuitBreaker(name = "ndiliusApi", fallbackMethod = "getContactDetailsForMultipleFallback")
   @Retry(name = "ndiliusApi")
+  @Timed("ndelius.get-contact-details-for-multiple", extraTags = ["method=POST", "endpoint=/cases"], description = "Time taken to get contact details")
   override fun getContactDetailsForMultiple(crns: List<String>): List<ContactDetails> {
     if (crns.isEmpty()) {
       return emptyList()
@@ -104,27 +107,13 @@ class NdiliusApiClient(
   }
 
   /**
-   * Get contact details in batches (handles automatic chunking)
-   */
-  fun getContactDetailsInBatches(crns: List<String>): List<ContactDetails> {
-    if (crns.isEmpty()) {
-      return emptyList()
-    }
-
-    LOGGER.info("Fetching contact details for {} CRNs in batches of {}", crns.size, INdiliusApiClient.MAX_BATCH_SIZE)
-
-    return crns.chunked(INdiliusApiClient.MAX_BATCH_SIZE).flatMap { batch ->
-      getContactDetailsForMultiple(batch)
-    }
-  }
-
-  /**
    * Validate personal details for a person on probation
    * POST /case/{crn}/validate-details
    * Returns true if valid (200 OK), false if invalid (400 Bad Request)
    */
   @CircuitBreaker(name = "ndiliusApi", fallbackMethod = "validatePersonalDetailsFallback")
   @Retry(name = "ndiliusApi")
+  @Timed("ndelius.validate-details", extraTags = ["method=POST", "endpoint=/case/{crn}/validate-details"], description = "Time taken to validate personal details")
   override fun validatePersonalDetails(personalDetails: PersonalDetails): Boolean {
     LOGGER.info("Validating personal details for CRN: {}", personalDetails.crn)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NdiliusApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NdiliusApiClient.kt
@@ -43,7 +43,7 @@ class NdiliusApiClient(
    */
   @CircuitBreaker(name = "ndiliusApi", fallbackMethod = "getContactDetailsFallback")
   @Retry(name = "ndiliusApi")
-  @Timed("ndelius.get-contact-details", extraTags = ["method=GET", "endpoint=/case/{crn}"], description = "Time taken to get contact details")
+  @Timed("ndelius.get-contact-details", extraTags = ["method", "GET", "endpoint", "/case/{crn}"], description = "Time taken to get contact details")
   override fun getContactDetails(crn: String): ContactDetails? {
     LOGGER.info("Fetching contact details for CRN: {}", crn)
 
@@ -74,7 +74,7 @@ class NdiliusApiClient(
    */
   @CircuitBreaker(name = "ndiliusApi", fallbackMethod = "getContactDetailsForMultipleFallback")
   @Retry(name = "ndiliusApi")
-  @Timed("ndelius.get-contact-details-for-multiple", extraTags = ["method=POST", "endpoint=/cases"], description = "Time taken to get contact details")
+  @Timed("ndelius.get-contact-details-for-multiple", extraTags = ["method", "POST", "endpoint", "/cases"], description = "Time taken to get contact details")
   override fun getContactDetailsForMultiple(crns: List<String>): List<ContactDetails> {
     if (crns.isEmpty()) {
       return emptyList()
@@ -113,7 +113,7 @@ class NdiliusApiClient(
    */
   @CircuitBreaker(name = "ndiliusApi", fallbackMethod = "validatePersonalDetailsFallback")
   @Retry(name = "ndiliusApi")
-  @Timed("ndelius.validate-details", extraTags = ["method=POST", "endpoint=/case/{crn}/validate-details"], description = "Time taken to validate personal details")
+  @Timed("ndelius.validate-details", extraTags = ["method", "POST", "endpoint", "/case/{crn}/validate-details"], description = "Time taken to validate personal details")
   override fun validatePersonalDetails(personalDetails: PersonalDetails): Boolean {
     LOGGER.info("Validating personal details for CRN: {}", personalDetails.crn)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/rekognition/RekognitionCompareFacesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/rekognition/RekognitionCompareFacesService.kt
@@ -47,7 +47,7 @@ open class RekognitionCompareFacesService(
 
   @CircuitBreaker(name = "awsRekognition")
   @Retry(name = "awsRekognition")
-  @Timed("rekog.compare-faces.verify-chckin-images", extraTags = [], description = "Time taken to compare checkin images")
+  @Timed("rekog.compare-faces.verify-checkin-images", extraTags = [], description = "Time taken to compare checkin images")
   override fun verifyCheckinImages(
     snapshots: CheckinVerificationImages,
     requiredConfidence: Float,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/rekognition/RekognitionCompareFacesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/rekognition/RekognitionCompareFacesService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.rekogniti
 
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker
 import io.github.resilience4j.retry.annotation.Retry
+import io.micrometer.core.annotation.Timed
 import org.slf4j.LoggerFactory
 import software.amazon.awssdk.services.rekognition.RekognitionAsyncClient
 import software.amazon.awssdk.services.rekognition.model.CompareFacesResponse
@@ -46,6 +47,7 @@ open class RekognitionCompareFacesService(
 
   @CircuitBreaker(name = "awsRekognition")
   @Retry(name = "awsRekognition")
+  @Timed("rekog.compare-faces.verify-chckin-images", extraTags = [], description = "Time taken to compare checkin images")
   override fun verifyCheckinImages(
     snapshots: CheckinVerificationImages,
     requiredConfidence: Float,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/rekognition/RekognitionLivenessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/rekognition/RekognitionLivenessService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.rekogniti
 
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker
 import io.github.resilience4j.retry.annotation.Retry
+import io.micrometer.core.annotation.Timed
 import org.slf4j.LoggerFactory
 import software.amazon.awssdk.services.rekognition.RekognitionAsyncClient
 import software.amazon.awssdk.services.rekognition.model.ChallengePreference
@@ -28,6 +29,7 @@ open class RekognitionLivenessService(
 
   @CircuitBreaker(name = "awsRekognition")
   @Retry(name = "awsRekognition")
+  @Timed("rekog.liveness.create-session", extraTags = [], description = "Time taken to create Rekognition liveness session")
   override fun createSession(): CompletableFuture<String> {
     LOGGER.info("Creating Rekognition Face Liveness session")
 
@@ -49,6 +51,7 @@ open class RekognitionLivenessService(
 
   @CircuitBreaker(name = "awsRekognition")
   @Retry(name = "awsRekognition")
+  @Timed("rekog.liveness.results", extraTags = [], description = "Time taken to get Rekognition liveness results")
   override fun getSessionResults(sessionId: String): CompletableFuture<GetFaceLivenessSessionResultsResponse> {
     LOGGER.info("Getting liveness session results for session: {}", sessionId)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/stats/MetricsDebugResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/stats/MetricsDebugResource.kt
@@ -15,7 +15,7 @@ class MetricsDebugResource(private val meterRegistry: MeterRegistry) {
     NDELIUS_VALIDATE_DETAILS("ndelius.validate-details"),
     REKOG_LIVENESS_CREATE_SESSION("rekog.liveness.create-session"),
     REKOG_LIVENESS_RESULTS("rekog.liveness.results"),
-    REKOG_COMPARE_FACES_VERIFY_CHECKIN_IMAGES("rekog.compare-faces.verify-chckin-images"),
+    REKOG_COMPARE_FACES_VERIFY_CHECKIN_IMAGES("rekog.compare-faces.verify-checkin-images"),
   }
 
   @PreAuthorize("hasRole('ROLE_ESUPERVISION__ESUPERVISION_UI')")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/stats/MetricsDebugResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/stats/MetricsDebugResource.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.esupervisionapi.v2.stats
 
 import io.micrometer.core.instrument.MeterRegistry
 import jakarta.servlet.http.HttpServletRequest
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -17,6 +18,7 @@ class MetricsDebugResource(private val meterRegistry: MeterRegistry) {
     REKOG_COMPARE_FACES_VERIFY_CHECKIN_IMAGES("rekog.compare-faces.verify-chckin-images"),
   }
 
+  @PreAuthorize("hasRole('ROLE_ESUPERVISION__ESUPERVISION_UI')")
   @GetMapping("/metrics")
   fun getMetrics(request: HttpServletRequest): Map<String, Any> = mapOf(
     "host" to request.serverName,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/stats/MetricsDebugResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/stats/MetricsDebugResource.kt
@@ -1,0 +1,42 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.v2.stats
+
+import io.micrometer.core.instrument.MeterRegistry
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class MetricsDebugResource(private val meterRegistry: MeterRegistry) {
+
+  enum class Metrics(val label: String) {
+    NDELIUS_GET_CONTACT_DETAILS("ndelius.get-contact-details"),
+    NDELIUS_GET_CONTACT_FOR_MULTIPLE("ndelius.get-contact-details-for-multiple"),
+    NDELIUS_VALIDATE_DETAILS("ndelius.validate-details"),
+    REKOG_LIVENESS_CREATE_SESSION("rekog.liveness.create-session"),
+    REKOG_LIVENESS_RESULTS("rekog.liveness.results"),
+    REKOG_COMPARE_FACES_VERIFY_CHECKIN_IMAGES("rekog.compare-faces.verify-chckin-images"),
+  }
+
+  @GetMapping("/metrics")
+  fun getMetrics(request: HttpServletRequest): Map<String, Any> = mapOf(
+    "host" to request.serverName,
+    "metrics" to Metrics.entries.map { meterRegistry.metricFor(it) },
+  )
+}
+
+private fun MeterRegistry.metricFor(metric: MetricsDebugResource.Metrics): Map<String, Any> {
+  val meter = this.find(metric.label).timer()
+  val snapshot = meter?.takeSnapshot()
+  fun format(value: Double): String = String.format("%.4f", value)
+
+  return if (snapshot != null) {
+    mapOf(
+      "metric_name" to metric.label,
+      "count" to snapshot.count(),
+      "max_time_ms" to format(snapshot.max(java.util.concurrent.TimeUnit.MILLISECONDS)),
+      "mean_time_ms" to format(snapshot.mean(java.util.concurrent.TimeUnit.MILLISECONDS)),
+    )
+  } else {
+    mapOf("metric_name" to metric.label, "message" to "not recorded yet.")
+  }
+}


### PR DESCRIPTION
The endpoint exposes /metrics with timings for some of the external services (rekognition, NDelius). The endpoint needs auth, so won't be easy to access in prod, but at least will give us an idea of how things look like in dev.