### PR TITLE
ESUP-1891: use events for app offender deactivation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/CheckinPersistenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/CheckinPersistenceService.kt
@@ -15,7 +15,8 @@ import java.util.UUID
  * (apart from calls to .finalise() on certain events).
  */
 @Service
-class CheckinPersistenceService(
+class
+CheckinPersistenceService(
   private val checkinRepository: OffenderCheckinRepository,
   private val eventAuditService: EventAuditService,
   private val appEventPublisher: ApplicationEventPublisher,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/EventDtos.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/EventDtos.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.esupervisionapi.v2
 
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.audit.OffenderAuditEventType
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ContactPreference
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ExternalUserId
 import java.util.UUID
@@ -9,7 +10,34 @@ import java.util.UUID
  */
 interface IPartialEvent
 
-interface IEventBase {
+interface IOffenderEventBase {
+  val offenderId: Long
+  val offender: OffenderDto
+}
+
+/**
+ * Our listeners should be able to process any subclass of this.
+ */
+sealed interface IOffenderEvent : IOffenderEventBase {
+  val outboxItemCoords: Pair<OutboxItemType, Long>? get() = null
+}
+
+data class OffenderDeactivatedEvent(
+  override val offenderId: Long,
+  override val offender: OffenderDto,
+  val auditEventType: OffenderAuditEventType,
+  val setup: UUID?,
+  /**
+   * See [uk.gov.justice.digital.hmpps.esupervisionapi.v2.checkin.activeEventNumber]
+   */
+  val activeEventNumber: Long?,
+  val reason: String? = null,
+  val sensitive: Boolean = false,
+) : IOffenderEvent {
+  override val outboxItemCoords = OutboxItemType.OFFENDER_DEACTIVATED to offenderId
+}
+
+interface ICheckinEventBase {
   val checkinId: Long
   val offenderId: Long
   val practitionerId: ExternalUserId
@@ -20,7 +48,7 @@ interface IEventBase {
 /**
  * Our listeners should be able to process any subclass of this.
  */
-sealed interface ICheckinEvent : IEventBase {
+sealed interface ICheckinEvent : ICheckinEventBase {
   val outboxItemCoords: Pair<OutboxItemType, Long>? get() = null
 }
 
@@ -77,7 +105,7 @@ data class PartialCheckinCreatedEvent(
   override val checkin: CheckinDto,
   override val offenderContactPreference: ContactPreference,
   override val currentEvent: Long?,
-) : IEventBase,
+) : ICheckinEventBase,
   IPartialEvent,
   ActiveEvent {
   fun finalise(checkin: OffenderCheckin): CheckinCreatedEvent {
@@ -102,7 +130,7 @@ data class PartialCheckinAnnotatedEvent(
   override val practitionerId: ExternalUserId,
   override val checkin: CheckinDto,
   override val offenderContactPreference: ContactPreference,
-) : IEventBase,
+) : ICheckinEventBase,
   IPartialEvent {
   fun finalise(logEntry: OffenderEventLog): CheckinAnnotatedEvent = CheckinAnnotatedEvent(
     checkinId = checkinId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorService.kt
@@ -156,12 +156,10 @@ class NotificationOrchestratorService(
 
   /** Send notifications for deactivation completed event */
   fun sendDeactivationCompletedNotifications(
-    offender: Offender,
-    contactDetails: ContactDetails? = null,
-    setupId: UUID? = null,
-    outcomeCode: String? = null,
+    event: OffenderDeactivatedEvent,
   ) {
-    val details = contactDetails ?: ndiliusApiClient.getContactDetails(offender.crn)
+    val offender = event.offender
+    val details = event.offender.personalDetails
 
     domainEventService.publishDomainEvent(
       eventType = DomainEventType.V2_SETUP_REMOVED,
@@ -169,9 +167,9 @@ class NotificationOrchestratorService(
       crn = offender.crn,
       description = "Online check-ins stopped for offender ${offender.crn}",
       additionalInformation = AdditionalInformation(
-        eventNumber = details?.let { activeEventNumber(offender, it) },
-        setupId = setupId,
-        outcomeCode = outcomeCode,
+        eventNumber = event.activeEventNumber,
+        setupId = event.setup,
+        outcomeCode = event.auditEventType.deliusOutcomeCode,
       ),
     )
 
@@ -184,7 +182,7 @@ class NotificationOrchestratorService(
 
         val notificationsWithRecipients =
           notificationPersistence.buildOffenderNotifications(
-            offenderId = offender.id,
+            offenderId = event.offenderId,
             crn = offender.crn,
             contactPreference = offender.contactPreference,
             contactDetails = details,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationService.kt
@@ -24,8 +24,8 @@ class NotificationService(
   /**
    * Send notifications for deactivation completed event
    */
-  fun sendDeactivationCompletedNotifications(offender: Offender, contactDetails: ContactDetails? = null, setupId: UUID? = null, outcomeCode: String? = null) {
-    orchestrator.sendDeactivationCompletedNotifications(offender, contactDetails, setupId, outcomeCode)
+  fun sendDeactivationCompletedNotifications(event: OffenderDeactivatedEvent) {
+    orchestrator.sendDeactivationCompletedNotifications(event)
   }
 
   /**

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/OffenderPersistenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/OffenderPersistenceService.kt
@@ -1,0 +1,35 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.v2
+
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.esupervisionapi.utils.logger
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.audit.EventAuditService
+
+@Service
+class OffenderPersistenceService(
+  private val offenderRepository: OffenderRepository,
+  private val checkinRepository: OffenderCheckinRepository,
+  private val questionListAssignmentRepository: QuestionListAssignmentRepository,
+  private val eventAuditService: EventAuditService,
+  private val appEventPublisher: ApplicationEventPublisher,
+) {
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  fun offenderDeactivation(offender: Offender, event: OffenderDeactivatedEvent) {
+    offenderRepository.save(offender)
+    val deletedAssignments = questionListAssignmentRepository.deleteUpcomingAssignment(offender.id)
+    val cancelledCheckins = checkinRepository.updateStatusForOffender(offender, CheckinStatus.CREATED, CheckinStatus.CANCELLED)
+    if (cancelledCheckins > 0 || deletedAssignments > 0) {
+      LOGGER.info("Cancelled {} created/pending check ins, deleted {} question assignments for CRN {} due to offender deactivation", cancelledCheckins, deletedAssignments, offender.crn)
+    }
+    eventAuditService.recordOffenderEvent(event.auditEventType, event.offender, event.offender.personalDetails, event.reason, event.sensitive)
+
+    appEventPublisher.publishEvent(event)
+  }
+
+  companion object {
+    val LOGGER = logger<OffenderPersistenceService>()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/audit/EventAuditService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/audit/EventAuditService.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.EventAuditRepository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.ICheckinEvent
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.Offender
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckin
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderDto
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderSetupDto
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ExternalUserId
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.security.PiiSanitizer
@@ -65,7 +66,7 @@ class EventAuditService(
    */
   fun recordSetupCompleted(offender: Offender, contactDetails: ContactDetails?, setup: OffenderSetupDto) = recordOffenderEvent(
     OffenderAuditEventType.SETUP_COMPLETED,
-    offender = offender,
+    offender = offender.dto(contactDetails),
     contactDetails = contactDetails,
     notes = "Eligibility: ${setup.eligibilityChoice?.name ?: "not provided"}\nRationale provided: ${!setup.rationale.isNullOrBlank()}",
     sensitive = false,
@@ -136,7 +137,7 @@ class EventAuditService(
    */
   fun recordCheckinReminded(checkins: Iterable<Pair<OffenderCheckin, ContactDetails?>>) = recordCheckinEvents(CheckinAuditEventType.CHECKIN_REMINDER, checkins)
 
-  fun recordOffenderEvent(eventType: OffenderAuditEventType, offender: Offender, contactDetails: ContactDetails?, notes: String?, sensitive: Boolean = false) {
+  fun recordOffenderEvent(eventType: OffenderAuditEventType, offender: OffenderDto, contactDetails: ContactDetails?, notes: String?, sensitive: Boolean = false) {
     if (contactDetails?.practitioner == null) {
       // Still record the event (e.g. an automated deactivation of a POP in reset) - the practitioner
       // org-unit columns are nullable, so we keep the audit trail rather than dropping it entirely.
@@ -189,7 +190,7 @@ class EventAuditService(
     sensitive = sensitive,
   )
 
-  private fun Offender.toAudit(eventType: OffenderAuditEventType, contactDetails: ContactDetails?, notes: String?, sensitive: Boolean = false): EventAudit {
+  private fun OffenderDto.toAudit(eventType: OffenderAuditEventType, contactDetails: ContactDetails?, notes: String?, sensitive: Boolean = false): EventAudit {
     val offender = this
     return when (eventType) {
       OffenderAuditEventType.SETUP_COMPLETED,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/Utils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/checkin/Utils.kt
@@ -23,7 +23,7 @@ fun activeEventNumber(offender: ActiveEvent, details: ContactDetails): Long? {
     return offender.currentEvent
   }
 
-  return details.events?.firstOrNull()?.number
+  return details.events.firstOrNull()?.number
 }
 
 /**

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/events/OffenderEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/events/OffenderEventListener.kt
@@ -1,0 +1,38 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.events
+
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Service
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+import uk.gov.justice.digital.hmpps.esupervisionapi.utils.logger
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.IOffenderEvent
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.NotificationService
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderDeactivatedEvent
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OutboxItemRepository
+import java.util.concurrent.CompletableFuture
+
+@Service
+class OffenderEventListener(
+  private val notificationService: NotificationService,
+  private val outboxItemRepository: OutboxItemRepository,
+) {
+
+  @Async
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  fun processEvent(event: IOffenderEvent): CompletableFuture<Void> {
+    LOGGER.debug("processing offender event for offender CRN={} with status={}", event.offender.crn, event.offender.status.name)
+    when (event) {
+      is OffenderDeactivatedEvent -> notificationService.sendDeactivationCompletedNotifications(event)
+    }
+    event.outboxItemCoords?.let { (type, id) ->
+      val result = outboxItemRepository.markAsSent(type.name, id)
+      LOGGER.info("offender CRN={}, marked outbox item {} as sent, updated records: {}", event.offender.crn, type to id, result)
+    }
+
+    return CompletableFuture.completedFuture(null)
+  }
+
+  companion object {
+    private val LOGGER = logger<OffenderEventListener>()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderDeactivationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderDeactivationService.kt
@@ -2,19 +2,14 @@ package uk.gov.justice.digital.hmpps.esupervisionapi.v2.offender
 
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Propagation
-import org.springframework.transaction.annotation.Transactional
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinStatus
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.ContactDetails
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.NotificationService
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.Offender
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinRepository
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderRepository
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderDeactivatedEvent
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderPersistenceService
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderSetupRepository
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.audit.EventAuditService
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.audit.OffenderAuditEventType
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.checkin.activeEventNumber
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.OffenderStatus
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.question.QuestionService
 import java.time.Clock
 
 /**
@@ -33,12 +28,8 @@ import java.time.Clock
 @Service
 class OffenderDeactivationService(
   private val clock: Clock,
-  private val offenderRepository: OffenderRepository,
-  private val checkinRepository: OffenderCheckinRepository,
   private val offenderSetupRepository: OffenderSetupRepository,
-  private val questionService: QuestionService,
-  private val eventAuditService: EventAuditService,
-  private val notificationService: NotificationService,
+  private val offenderPersistenceService: OffenderPersistenceService,
 ) {
 
   /**
@@ -52,14 +43,13 @@ class OffenderDeactivationService(
    *   was stopped (in reset vs no active events) is queryable via the audit event_type.
    * @return the (possibly unchanged) offender
    *
-   * Runs in its own transaction (REQUIRES_NEW) so that a deactivation commits independently of any
+   * Spins its own transaction (REQUIRES_NEW) so that a deactivation commits independently of any
    * surrounding work. In particular, when called from [V2CheckinCreationJob]'s long-lived job
    * transaction this prevents a failure in one offender's audit/persistence (which would otherwise
    * mark the shared transaction rollback-only) from rolling back every other offender's check-in
    * creation and deactivation in the same run. It also makes each deactivation atomic for the
    * non-transactional callers (the reminder job and the deactivate endpoint).
    */
-  @Transactional(propagation = Propagation.REQUIRES_NEW)
   fun deactivateOffender(
     offender: Offender,
     reason: String,
@@ -74,26 +64,21 @@ class OffenderDeactivationService(
 
     offender.status = OffenderStatus.INACTIVE
     offender.updatedAt = clock.instant()
-    val saved = offenderRepository.save(offender)
 
-    questionService.deleteUpcomingAssignment(saved.crn)
+    val setup = offenderSetupRepository.findByOffender(offender).orElse(null)
+    val event = OffenderDeactivatedEvent(
+      offenderId = offender.id,
+      offender = offender.dto(contactDetails),
+      auditEventType = auditEventType,
+      setup = setup?.uuid,
+      activeEventNumber = contactDetails?.let { activeEventNumber(offender, it) },
+      reason = reason,
+      sensitive = sensitive,
+    )
 
-    // set any pending check ins to cancelled
-    val cancelled = checkinRepository.updateStatusForOffender(saved, CheckinStatus.CREATED, CheckinStatus.CANCELLED)
-    if (cancelled > 0) {
-      LOGGER.info("Cancelled {} created/pending check ins for CRN {} due to offender deactivation", cancelled, saved.crn)
-    }
+    offenderPersistenceService.offenderDeactivation(offender, event)
 
-    eventAuditService.recordOffenderEvent(auditEventType, saved, contactDetails, reason, sensitive)
-
-    val setup = offenderSetupRepository.findByOffender(saved).orElse(null)
-    try {
-      notificationService.sendDeactivationCompletedNotifications(saved, contactDetails, setup?.setupId(), auditEventType.deliusOutcomeCode)
-    } catch (e: Exception) {
-      LOGGER.warn("Failed to send deactivation completed notifications for offender {}", saved.uuid, e)
-    }
-
-    return saved
+    return offender
   }
 
   companion object {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderResource.kt
@@ -421,7 +421,8 @@ class OffenderResource(
       // exception already logged and sanitised elswhere
       LOGGER.info("Failed to get contact details for offender ${offender.crn} from NDelius. Using missing details instead.")
     }
-    eventAuditService.recordOffenderEvent(eventType, offender, contactDetails ?: missingDetails(offender.crn), reason, sensitive)
+    val details = contactDetails ?: missingDetails(offender.crn)
+    eventAuditService.recordOffenderEvent(eventType, offender.dto(details), details, reason, sensitive)
   }
 
   private fun validate(scheduleUpdate: CheckinScheduleUpdateRequest) {

--- a/src/main/resources/db/changelog/changesets/72_offender_events_outbox.sql
+++ b/src/main/resources/db/changelog/changesets/72_offender_events_outbox.sql
@@ -1,0 +1,29 @@
+-- liquibase formatted sql
+
+-- changeset roland.sadowski:72_offender_events_outbox-1 splitStatements:false
+
+CREATE OR REPLACE FUNCTION fn_add_outbox_record_on_offender_status_update()
+    RETURNS TRIGGER AS $$
+BEGIN
+    INSERT INTO outbox_items(type, entity_id)
+    VALUES (
+               CASE
+                   WHEN NEW.STATUS = 'INACTIVE'::offender_status_v2 THEN 'OFFENDER_DEACTIVATED'::OutboxItemType
+                   END,
+               NEW.id
+           );
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+--rollback drop function fn_add_outbox_record_on_offender_status_update();
+
+-- changeset roland.sadowski:72_offender_events_outbox-2 splitStatements:false
+
+CREATE TRIGGER trg_offender_status_update__outbox
+    AFTER UPDATE on offender_V2
+    FOR EACH ROW
+    WHEN (NEW.status in ('INACTIVE'::offender_status_v2))
+EXECUTE FUNCTION fn_add_outbox_record_on_offender_status_update();
+
+--rollback drop trigger trg_offender_status_update__outbox on offender_V2;

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -141,3 +141,5 @@ databaseChangeLog:
       file: db/changelog/changesets/70_add_rationale_column.sql
   - include:
       file: db/changelog/changesets/71_checkin_note_resend.sql
+  - include:
+      file: db/changelog/changesets/72_offender_events_outbox.sql

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/NotificationOrchestratorServiceTest.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.config.AppConfig
 import uk.gov.justice.digital.hmpps.esupervisionapi.datagen.asSetupDto
 import uk.gov.justice.digital.hmpps.esupervisionapi.notifications.NotificationType
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.audit.EventAuditService
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.audit.OffenderAuditEventType
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.CheckinInterval
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ContactPreference
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.OffenderStatus
@@ -309,7 +310,17 @@ class NotificationOrchestratorServiceTest {
     whenever(notificationPersistence.buildOffenderNotifications(any(), any(), any(), any(), any())).thenReturn(emptyList())
     whenever(notificationPersistence.saveNotifications(any())).thenReturn(emptyList())
 
-    service.sendDeactivationCompletedNotifications(offender, contactDetails)
+    val eventNumber = 12345L
+    val event = OffenderDeactivatedEvent(
+      offenderId = offender.id,
+      offender = offender.dto(contactDetails),
+      auditEventType = OffenderAuditEventType.OFFENDER_AUTO_DEACTIVATED_CONTACT_SUSPENDED,
+      null,
+      eventNumber,
+      null,
+      false,
+    )
+    service.sendDeactivationCompletedNotifications(event)
 
     verify(domainEventService).publishDomainEvent(
       eq(DomainEventType.V2_SETUP_REMOVED),
@@ -317,7 +328,7 @@ class NotificationOrchestratorServiceTest {
       eq(offender.crn),
       any(),
       eq(null),
-      eq(AdditionalInformation(eventNumber = 12345L, setupId = null)),
+      eq(AdditionalInformation(eventNumber = eventNumber, setupId = null)),
     )
   }
 
@@ -329,7 +340,17 @@ class NotificationOrchestratorServiceTest {
     whenever(notificationPersistence.buildOffenderNotifications(any(), any(), any(), any(), any())).thenReturn(emptyList())
     whenever(notificationPersistence.saveNotifications(any())).thenReturn(emptyList())
 
-    service.sendDeactivationCompletedNotifications(offender, contactDetails, outcomeCode = "ESPRS")
+    val eventNumber = 12345L
+    val event = OffenderDeactivatedEvent(
+      offenderId = offender.id,
+      offender = offender.dto(contactDetails),
+      auditEventType = OffenderAuditEventType.OFFENDER_AUTO_DEACTIVATED_CONTACT_SUSPENDED,
+      null,
+      eventNumber,
+      null,
+      false,
+    )
+    service.sendDeactivationCompletedNotifications(event)
 
     verify(domainEventService).publishDomainEvent(
       eq(DomainEventType.V2_SETUP_REMOVED),
@@ -337,7 +358,7 @@ class NotificationOrchestratorServiceTest {
       eq(offender.crn),
       any(),
       eq(null),
-      eq(AdditionalInformation(eventNumber = 12345L, setupId = null, outcomeCode = "ESPRS")),
+      eq(AdditionalInformation(eventNumber = eventNumber, setupId = null, outcomeCode = "ESPRS")),
     )
   }
 
@@ -349,7 +370,16 @@ class NotificationOrchestratorServiceTest {
     whenever(notificationPersistence.buildOffenderNotifications(any(), any(), any(), any(), any())).thenReturn(emptyList())
     whenever(notificationPersistence.saveNotifications(any())).thenReturn(emptyList())
 
-    service.sendDeactivationCompletedNotifications(offender, contactDetails)
+    val event = OffenderDeactivatedEvent(
+      offenderId = offender.id,
+      offender = offender.dto(contactDetails),
+      auditEventType = OffenderAuditEventType.OFFENDER_AUTO_DEACTIVATED_CONTACT_SUSPENDED,
+      null,
+      null,
+      null,
+      false,
+    )
+    service.sendDeactivationCompletedNotifications(event)
 
     verify(domainEventService).publishDomainEvent(
       eq(DomainEventType.V2_SETUP_REMOVED),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/audit/EventAuditServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/audit/EventAuditServiceTest.kt
@@ -53,7 +53,7 @@ class EventAuditServiceTest {
   fun `records the offender event when practitioner details are present`() {
     val details = ContactDetails(crn = offender.crn, name = Name("John", "Doe"), practitioner = PractitionerDetails(Name("P", "Q")))
 
-    service.recordOffenderEvent(OffenderAuditEventType.OFFENDER_DEACTIVATED, offender, details, "reason")
+    service.recordOffenderEvent(OffenderAuditEventType.OFFENDER_DEACTIVATED, offender.dto(details), details, "reason")
 
     verify(auditRepository).save(any())
   }
@@ -63,14 +63,14 @@ class EventAuditServiceTest {
     // e.g. an automated deactivation of a POP in reset whose NDelius record has no practitioner
     val details = ContactDetails(crn = offender.crn, name = Name("John", "Doe"), practitioner = null)
 
-    service.recordOffenderEvent(OffenderAuditEventType.OFFENDER_DEACTIVATED, offender, details, "no active events")
+    service.recordOffenderEvent(OffenderAuditEventType.OFFENDER_DEACTIVATED, offender.dto(details), details, "no active events")
 
     verify(auditRepository).save(any())
   }
 
   @Test
   fun `records when contact details are entirely absent`() {
-    service.recordOffenderEvent(OffenderAuditEventType.OFFENDER_DEACTIVATED, offender, null, "reason")
+    service.recordOffenderEvent(OffenderAuditEventType.OFFENDER_DEACTIVATED, offender.dto(null), null, "reason")
 
     verify(auditRepository).save(any())
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/events/OffenderEventListenerIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/infrastructure/events/OffenderEventListenerIT.kt
@@ -1,0 +1,71 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.events
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
+import uk.gov.justice.digital.hmpps.esupervisionapi.datagen.offenderTemplate
+import uk.gov.justice.digital.hmpps.esupervisionapi.datagen.toEntity
+import uk.gov.justice.digital.hmpps.esupervisionapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.NotificationService
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderDeactivatedEvent
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderRepository
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OutboxItemRepository
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OutboxItemStatus
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OutboxItemType
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.audit.OffenderAuditEventType
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.OffenderStatus
+import java.time.LocalDate
+import java.util.concurrent.TimeUnit
+
+class OffenderEventListenerIT : IntegrationTestBase() {
+
+  @Autowired
+  private lateinit var offenderEventListener: OffenderEventListener
+
+  @Autowired
+  private lateinit var offenderRepository: OffenderRepository
+
+  @Autowired
+  private lateinit var outboxItemRepository: OutboxItemRepository
+
+  @AfterEach
+  fun cleanUp() {
+    outboxItemRepository.deleteAll()
+    offenderRepository.deleteAll()
+    offenderRepository.flush()
+  }
+
+  @Test
+  fun `processEvent - offender deactivated - mark outbox item as sent - success`() {
+    var offender = offenderTemplate.copy(firstCheckin = LocalDate.now(), status = OffenderStatus.VERIFIED).toEntity()
+    offender = offenderRepository.save(offender)
+
+    offender.status = OffenderStatus.INACTIVE
+    offenderRepository.save(offender) // this will trigger the creation of outbox item
+
+    val event = OffenderDeactivatedEvent(
+      offenderId = offender.id,
+      offender = offender.dto(),
+      auditEventType = OffenderAuditEventType.OFFENDER_DEACTIVATED,
+      setup = null,
+      activeEventNumber = null,
+    )
+
+    offenderEventListener.processEvent(event).get(2, TimeUnit.SECONDS)
+
+    val outboxItem = outboxItemRepository.findByTypeAndEntityId(OutboxItemType.OFFENDER_DEACTIVATED, offender.id).orElseThrow()
+    assertEquals(OutboxItemStatus.SENT, outboxItem.status)
+  }
+
+  @TestConfiguration
+  class TestConfig {
+    @Bean
+    @Primary
+    fun notificationV2Service(): NotificationService = mock()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderDeactivationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderDeactivationServiceTest.kt
@@ -2,27 +2,24 @@ package uk.gov.justice.digital.hmpps.esupervisionapi.v2.offender
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatcher
 import org.mockito.kotlin.any
-import org.mockito.kotlin.eq
-import org.mockito.kotlin.isNull
+import org.mockito.kotlin.argThat
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinStatus
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.ContactDetails
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.Name
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.NotificationService
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.Offender
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinRepository
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderDeactivatedEvent
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderPersistenceService
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderRepository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderSetupRepository
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.audit.EventAuditService
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.audit.OffenderAuditEventType
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.CheckinInterval
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ContactPreference
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.OffenderStatus
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.question.QuestionService
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
@@ -34,23 +31,31 @@ class OffenderDeactivationServiceTest {
 
   private val clock = Clock.fixed(Instant.parse("2025-12-10T10:00:00Z"), ZoneId.of("UTC"))
   private val offenderRepository: OffenderRepository = mock()
-  private val checkinRepository: OffenderCheckinRepository = mock()
   private val offenderSetupRepository: OffenderSetupRepository = mock()
-  private val questionService: QuestionService = mock()
-  private val eventAuditService: EventAuditService = mock()
-  private val notificationService: NotificationService = mock()
+  private val offenderPersistenceService: OffenderPersistenceService = mock()
 
   private val service = OffenderDeactivationService(
     clock,
-    offenderRepository,
-    checkinRepository,
     offenderSetupRepository,
-    questionService,
-    eventAuditService,
-    notificationService,
+    offenderPersistenceService,
   )
 
   private val contactDetails = ContactDetails(crn = "X123456", name = Name("John", "Doe"), mobile = "07700900123")
+
+  class OffenderDeactivatedEventMatcher(
+    private val offender: Offender,
+    private val auditEventType: OffenderAuditEventType,
+    private val reason: String?,
+  ) : ArgumentMatcher<OffenderDeactivatedEvent> {
+    override fun matches(arg: OffenderDeactivatedEvent): Boolean {
+      var matches = arg.offenderId == offender.id
+      matches = matches && arg.offender.crn == offender.crn
+      matches = matches && arg.offender.status == OffenderStatus.INACTIVE
+      matches = matches && arg.reason == reason
+      matches = matches && arg.auditEventType == auditEventType
+      return matches
+    }
+  }
 
   @Test
   fun `deactivates a VERIFIED offender - status, audit and notification`() {
@@ -61,16 +66,8 @@ class OffenderDeactivationServiceTest {
     val result = service.deactivateOffender(offender, "no active events", contactDetails, sensitive = true)
 
     assertEquals(OffenderStatus.INACTIVE, result.status)
-    verify(offenderRepository).save(offender)
-    verify(questionService).deleteUpcomingAssignment(offender.crn)
-    verify(eventAuditService).recordOffenderEvent(
-      eq(OffenderAuditEventType.OFFENDER_DEACTIVATED),
-      eq(offender),
-      eq(contactDetails),
-      eq("no active events"),
-      eq(true),
-    )
-    verify(notificationService).sendDeactivationCompletedNotifications(eq(offender), eq(contactDetails), isNull(), eq("ESPMP"))
+    val matcher = OffenderDeactivatedEventMatcher(offender, OffenderAuditEventType.OFFENDER_DEACTIVATED, "no active events")
+    verify(offenderPersistenceService).offenderDeactivation(any(), argThat(matcher))
   }
 
   @Test
@@ -86,14 +83,8 @@ class OffenderDeactivationServiceTest {
       auditEventType = OffenderAuditEventType.OFFENDER_AUTO_DEACTIVATED_NO_ACTIVE_EVENTS,
     )
 
-    verify(eventAuditService).recordOffenderEvent(
-      eq(OffenderAuditEventType.OFFENDER_AUTO_DEACTIVATED_NO_ACTIVE_EVENTS),
-      eq(offender),
-      eq(contactDetails),
-      eq("no active events"),
-      eq(false),
-    )
-    verify(notificationService).sendDeactivationCompletedNotifications(eq(offender), eq(contactDetails), isNull(), eq("ESPNA"))
+    val matcher = OffenderDeactivatedEventMatcher(offender, OffenderAuditEventType.OFFENDER_AUTO_DEACTIVATED_NO_ACTIVE_EVENTS, "no active events")
+    verify(offenderPersistenceService).offenderDeactivation(any(), argThat(matcher))
   }
 
   @Test
@@ -109,25 +100,8 @@ class OffenderDeactivationServiceTest {
       auditEventType = OffenderAuditEventType.OFFENDER_AUTO_DEACTIVATED_CONTACT_SUSPENDED,
     )
 
-    verify(eventAuditService).recordOffenderEvent(
-      eq(OffenderAuditEventType.OFFENDER_AUTO_DEACTIVATED_CONTACT_SUSPENDED),
-      eq(offender),
-      eq(contactDetails),
-      eq("contact suspended"),
-      eq(false),
-    )
-    verify(notificationService).sendDeactivationCompletedNotifications(eq(offender), eq(contactDetails), isNull(), eq("ESPRS"))
-  }
-
-  @Test
-  fun `cancels pending CREATED check-ins on deactivation`() {
-    val offender = offender(OffenderStatus.VERIFIED)
-    whenever(offenderRepository.save(any<Offender>())).thenAnswer { it.getArgument<Offender>(0) }
-    whenever(offenderSetupRepository.findByOffender(any())).thenReturn(Optional.empty())
-
-    service.deactivateOffender(offender, "in reset", contactDetails)
-
-    verify(checkinRepository).updateStatusForOffender(offender, CheckinStatus.CREATED, CheckinStatus.CANCELLED)
+    val matcher = OffenderDeactivatedEventMatcher(offender, OffenderAuditEventType.OFFENDER_AUTO_DEACTIVATED_CONTACT_SUSPENDED, "contact suspended")
+    verify(offenderPersistenceService).offenderDeactivation(any(), argThat(matcher))
   }
 
   @Test
@@ -138,8 +112,6 @@ class OffenderDeactivationServiceTest {
 
     assertEquals(OffenderStatus.INACTIVE, result.status)
     verify(offenderRepository, never()).save(any())
-    verify(questionService, never()).deleteUpcomingAssignment(any())
-    verify(notificationService, never()).sendDeactivationCompletedNotifications(any(), any(), any(), any())
   }
 
   @Test
@@ -150,7 +122,11 @@ class OffenderDeactivationServiceTest {
 
     service.deactivateOffender(offender, "no active events")
 
-    verify(notificationService).sendDeactivationCompletedNotifications(eq(offender), isNull(), isNull(), eq("ESPMP"))
+//    verify(notificationService).sendDeactivationCompletedNotifications(eq(offender), isNull(), isNull(), eq("ESPMP"))
+
+    val matcher = OffenderDeactivatedEventMatcher(offender, OffenderAuditEventType.OFFENDER_DEACTIVATED, "no active events")
+    verify(offenderPersistenceService).offenderDeactivation(any(), argThat(matcher))
+    verify(offenderPersistenceService).offenderDeactivation(any(), argThat { this.offender.personalDetails == null })
   }
 
   private fun offender(status: OffenderStatus) = Offender(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderPersistenceServiceIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderPersistenceServiceIT.kt
@@ -1,0 +1,92 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.v2.offender
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.esupervisionapi.datagen.offenderTemplate
+import uk.gov.justice.digital.hmpps.esupervisionapi.datagen.toEntity
+import uk.gov.justice.digital.hmpps.esupervisionapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.CheckinStatus
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckin
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinRepository
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderDeactivatedEvent
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderPersistenceService
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderRepository
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OutboxItemRepository
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.QuestionListAssignment
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.QuestionListAssignmentRepository
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.audit.OffenderAuditEventType
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.OffenderStatus
+import java.time.Instant
+import java.time.LocalDate
+import java.util.UUID
+
+class OffenderPersistenceServiceIT : IntegrationTestBase() {
+
+  @Autowired
+  private lateinit var offenderPersistenceService: OffenderPersistenceService
+
+  @Autowired
+  private lateinit var offenderRepository: OffenderRepository
+
+  @Autowired
+  private lateinit var checkinRepository: OffenderCheckinRepository
+
+  @Autowired
+  private lateinit var questionListAssignmentRepository: QuestionListAssignmentRepository
+
+  @Autowired
+  private lateinit var outboxItemRepository: OutboxItemRepository
+
+  @AfterEach
+  fun cleanUp() {
+    questionListAssignmentRepository.deleteAll()
+    checkinRepository.deleteAll()
+    offenderRepository.deleteAll()
+    offenderRepository.flush()
+    outboxItemRepository.deleteAll()
+  }
+
+  @Test
+  fun `offenderDeactivation cancels checkins and deletes upcoming question assignments`() {
+    var offender = offenderTemplate.copy(firstCheckin = LocalDate.now(), status = OffenderStatus.VERIFIED).toEntity()
+    offender = offenderRepository.save(offender)
+
+    var checkin = OffenderCheckin(
+      uuid = UUID.randomUUID(),
+      offender = offender,
+      status = CheckinStatus.CREATED,
+      dueDate = LocalDate.now(),
+      createdAt = Instant.now(),
+      createdBy = "test_user",
+    )
+    checkin = checkinRepository.save(checkin)
+
+    var assignment = QuestionListAssignment(
+      questionListId = 1L,
+      offenderId = offender.id,
+      checkinId = null,
+      created_at = Instant.now(),
+      updatedAt = Instant.now(),
+    )
+    assignment = questionListAssignmentRepository.save(assignment)
+
+    offender.status = OffenderStatus.INACTIVE
+    val event = OffenderDeactivatedEvent(
+      offenderId = offender.id,
+      offender = offender.dto(),
+      auditEventType = OffenderAuditEventType.OFFENDER_DEACTIVATED,
+      setup = null,
+      activeEventNumber = null,
+    )
+
+    offenderPersistenceService.offenderDeactivation(offender, event)
+
+    val updatedCheckin = checkinRepository.findById(checkin.id).orElseThrow()
+    assertEquals(CheckinStatus.CANCELLED, updatedCheckin.status)
+
+    val assignments = questionListAssignmentRepository.findAll()
+    assertEquals(0, assignments.size)
+  }
+}


### PR DESCRIPTION
Start applying the pattern already used for check-ins to offender entities (e.g. limit the use of `@Transactional` and
- adds a trigger to offender_v2 table to populate the outbox table
- add OffenderPersistenceService and OffenderEventListener
- integration tests