### PR TITLE
remove prism container from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,19 +55,6 @@ services:
       - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"
 
-  ndilius-mock:
-    image: stoplight/prism:5
-    container_name: ndilius-mock
-    networks:
-      - hmpps
-    ports:
-      - "4010:4010"
-    command: mock -h 0.0.0.0 /api/ndilius-api.yaml
-    volumes:
-      - ./mock:/api
-    environment:
-      - PRISM_LOG_LEVEL=info
-
 networks:
   hmpps:
 


### PR DESCRIPTION
Looks like leftovers from the V1->V2 transition. We mock the nDelius service inside the app.