### PR TITLE
QA - [ESUP-2041] - Proxy Delius PI data through ESUP API to for setting up online checkins

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderResource.kt
@@ -113,14 +113,67 @@ class OffenderResource(
 
   @PreAuthorize("hasRole('ROLE_ESUPERVISION__ESUPERVISION_UI')")
   @Operation(
+    summary = "Get personal details by CRN",
+    description = """Returns personal details straight from NDelius, without requiring the person to
+      already be registered for e-supervision. Used to look up details before starting setup.""",
+  )
+  @ApiResponse(responseCode = "200", description = "Personal details found")
+  @ApiResponse(responseCode = "404", description = "CRN not found in NDelius")
+  @GetMapping("/crn/{crn}/personal-details")
+  fun getPersonalDetailsByCrn(
+    @Parameter(description = "Case Reference Number", required = true) @PathVariable crn: String,
+  ): ResponseEntity<PersonalDetailsSummary> {
+    val normalisedCrn = crn.trim().uppercase()
+    val contactDetails = ndiliusApiClient.getContactDetails(normalisedCrn)
+    if (contactDetails == null) {
+      LOGGER.info("Personal details not found for crn={}", normalisedCrn)
+      return ResponseEntity.notFound().build()
+    }
+
+    return ResponseEntity.ok(
+      PersonalDetailsSummary(
+        crn = contactDetails.crn,
+        name = contactDetails.name,
+        dateOfBirth = contactDetails.dateOfBirth,
+        mobile = contactDetails.mobile,
+        email = contactDetails.email,
+      ),
+    )
+  }
+
+  @PreAuthorize("hasRole('ROLE_ESUPERVISION__ESUPERVISION_UI')")
+  @Operation(
+    summary = "Get probation practitioner by CRN",
+    description = """Returns the allocated probation practitioner straight from NDelius, without requiring
+      the person to already be registered for e-supervision. Used to look up details before starting setup.""",
+  )
+  @ApiResponse(responseCode = "200", description = "Practitioner found")
+  @ApiResponse(responseCode = "404", description = "CRN not found in NDelius, or no practitioner allocated")
+  @GetMapping("/crn/{crn}/practitioner-details")
+  fun getPractitionerDetailsByCrn(
+    @Parameter(description = "Case Reference Number", required = true) @PathVariable crn: String,
+  ): ResponseEntity<PractitionerSummary> {
+    val normalisedCrn = crn.trim().uppercase()
+    val practitioner = ndiliusApiClient.getContactDetails(normalisedCrn)?.practitioner
+    if (practitioner == null) {
+      LOGGER.info("Practitioner not found for crn={}", normalisedCrn)
+      return ResponseEntity.notFound().build()
+    }
+
+    return ResponseEntity.ok(practitioner.toSummary())
+  }
+
+  @PreAuthorize("hasRole('ROLE_ESUPERVISION__ESUPERVISION_UI')")
+  @Operation(
     summary = "Update contact details by CRN",
     description = """Updates a person's mobile number and/or email address.
-      Forwards the request to esupervision-and-delius's PUT /case/{crn}/contact-details endpoint (PI-4356).""",
+      Forwards the request to esupervision-and-delius's PUT /case/{crn}/contact-details endpoint (PI-4356).
+      Does not require the person to already be registered for e-supervision.""",
   )
   @ApiResponse(responseCode = "200", description = "Contact details updated")
   @ApiResponse(responseCode = "204", description = "No update required")
   @ApiResponse(responseCode = "400", description = "Invalid input")
-  @ApiResponse(responseCode = "404", description = "Offender not found")
+  @ApiResponse(responseCode = "404", description = "CRN not found in NDelius")
   @PutMapping("/crn/{crn}/contact-details")
   fun updateContactDetails(
     @Parameter(description = "Case Reference Number", required = true) @PathVariable crn: String,
@@ -132,11 +185,6 @@ class OffenderResource(
     }
 
     val normalisedCrn = crn.trim().uppercase()
-    val offender = offenderRepository.findByCrn(normalisedCrn).orElse(null)
-    if (offender == null) {
-      LOGGER.info("Offender not found for crn={}", crn)
-      return ResponseEntity.notFound().build()
-    }
 
     if (request.mobile == null && request.email == null) {
       return ResponseEntity.noContent().build()
@@ -529,6 +577,17 @@ class OffenderResource(
     private val LOGGER = logger<OffenderResource>()
   }
 }
+
+/**
+ * Personal details looked up directly from NDelius by CRN, ahead of setup - before an [Offender] exists locally.
+ */
+data class PersonalDetailsSummary(
+  val crn: String,
+  override val name: Name,
+  val dateOfBirth: LocalDate,
+  val mobile: String? = null,
+  val email: String? = null,
+) : INamedPerson
 
 /**
  * Subset of [ContactDetails] that is returned in the summary DTO.

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderResourceTest.kt
@@ -977,7 +977,7 @@ class OffenderResourceTest {
   }
 
   @Test
-  fun `getPractitionerDetailsByCrn - unallocated with no practitioner - returns 404`() {
+  fun `getPractitionerDetailsByCrn - no practitioner allocated - returns 404`() {
     val contactDetails = uk.gov.justice.digital.hmpps.esupervisionapi.v2.ContactDetails(
       crn = "X123456",
       name = uk.gov.justice.digital.hmpps.esupervisionapi.v2.Name("John", "Doe"),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderResourceTest.kt
@@ -900,13 +900,104 @@ class OffenderResourceTest {
   }
 
   // ========================================
+  // Personal Details Lookup Tests
+  // ========================================
+
+  @Test
+  fun `getPersonalDetailsByCrn - happy path - returns details without requiring local offender`() {
+    val crn = "x123456"
+    val contactDetails = uk.gov.justice.digital.hmpps.esupervisionapi.v2.ContactDetails(
+      crn = "X123456",
+      name = uk.gov.justice.digital.hmpps.esupervisionapi.v2.Name("John", "Doe"),
+      dateOfBirth = LocalDate.of(1980, 1, 1),
+      mobile = "07700900123",
+      email = "john.doe@example.com",
+    )
+    whenever(ndiliusApiClient.getContactDetails("X123456")).thenReturn(contactDetails)
+
+    val result = resource.getPersonalDetailsByCrn(crn)
+
+    assertEquals(HttpStatus.OK, result.statusCode)
+    assertEquals("X123456", result.body?.crn)
+    assertEquals("John", result.body?.name?.forename)
+    assertEquals("07700900123", result.body?.mobile)
+    assertEquals("john.doe@example.com", result.body?.email)
+    verify(offenderRepository, times(0)).findByCrn(any())
+  }
+
+  @Test
+  fun `getPersonalDetailsByCrn - not found in nDelius - returns 404`() {
+    whenever(ndiliusApiClient.getContactDetails("X999999")).thenReturn(null)
+
+    val result = resource.getPersonalDetailsByCrn("X999999")
+
+    assertEquals(HttpStatus.NOT_FOUND, result.statusCode)
+  }
+
+  // ========================================
+  // Practitioner Details Lookup Tests
+  // ========================================
+
+
+  @Test
+  fun `getPractitionerDetailsByCrn - happy path - returns practitioner without requiring local offender`() {
+    val crn = "x123456"
+    val practitioner = uk.gov.justice.digital.hmpps.esupervisionapi.v2.PractitionerDetails(
+      code = "N01A001",
+      name = uk.gov.justice.digital.hmpps.esupervisionapi.v2.Name("Jane", "Smith"),
+      email = "jane.smith@example.com",
+      unallocated = false,
+      username = "AUTH_USER",
+    )
+    val contactDetails = uk.gov.justice.digital.hmpps.esupervisionapi.v2.ContactDetails(
+      crn = "X123456",
+      name = uk.gov.justice.digital.hmpps.esupervisionapi.v2.Name("John", "Doe"),
+      dateOfBirth = LocalDate.of(1980, 1, 1),
+      practitioner = practitioner,
+    )
+    whenever(ndiliusApiClient.getContactDetails("X123456")).thenReturn(contactDetails)
+
+    val result = resource.getPractitionerDetailsByCrn(crn)
+
+    assertEquals(HttpStatus.OK, result.statusCode)
+    assertEquals("N01A001", result.body?.code)
+    assertEquals("Jane", result.body?.name?.forename)
+    assertEquals("jane.smith@example.com", result.body?.email)
+    assertEquals(false, result.body?.unallocated)
+    assertEquals("AUTH_USER", result.body?.username)
+    verify(offenderRepository, times(0)).findByCrn(any())
+  }
+
+  @Test
+  fun `getPractitionerDetailsByCrn - crn not found in nDelius - returns 404`() {
+    whenever(ndiliusApiClient.getContactDetails("X999999")).thenReturn(null)
+
+    val result = resource.getPractitionerDetailsByCrn("X999999")
+
+    assertEquals(HttpStatus.NOT_FOUND, result.statusCode)
+  }
+
+  @Test
+  fun `getPractitionerDetailsByCrn - unallocated with no practitioner - returns 404`() {
+    val contactDetails = uk.gov.justice.digital.hmpps.esupervisionapi.v2.ContactDetails(
+      crn = "X123456",
+      name = uk.gov.justice.digital.hmpps.esupervisionapi.v2.Name("John", "Doe"),
+      dateOfBirth = LocalDate.of(1980, 1, 1),
+      practitioner = null,
+    )
+    whenever(ndiliusApiClient.getContactDetails("X123456")).thenReturn(contactDetails)
+
+    val result = resource.getPractitionerDetailsByCrn("X123456")
+
+    assertEquals(HttpStatus.NOT_FOUND, result.statusCode)
+  }
+
+  // ========================================
   // Update Contact Details Tests
   // ========================================
 
   @Test
   fun `updateContactDetails - happy path - forwards request and returns updated record`() {
-    val offender = createOffender(UUID.randomUUID(), OffenderStatus.VERIFIED)
-    whenever(offenderRepository.findByCrn(offender.crn)).thenReturn(Optional.of(offender))
     val crn = "x123456"
     val request = ContactDetailsUpdateRequest(practitionerId = "AUTH_USER", mobile = "07700900123", email = "john.smith@example.com")
     val response = ContactDetailsUpdateResponse(crn = "X123456", mobile = request.mobile, email = request.email)
@@ -922,34 +1013,32 @@ class OffenderResourceTest {
 
   @Test
   fun `updateContactDetails - no fields provided - no-op and does not call ndilius`() {
-    val offender = createOffender(UUID.randomUUID(), OffenderStatus.VERIFIED)
-    whenever(offenderRepository.findByCrn(offender.crn)).thenReturn(Optional.of(offender))
     val request = ContactDetailsUpdateRequest(practitionerId = "AUTH_USER", mobile = null, email = null)
     val binding = BeanPropertyBindingResult(request, "request")
 
-    val result = resource.updateContactDetails(offender.crn, request, binding)
+    val result = resource.updateContactDetails("X123456", request, binding)
 
     assertEquals(HttpStatus.NO_CONTENT, result.statusCode)
     verify(ndiliusApiClient, times(0)).updateContactDetails(any(), any())
   }
 
   @Test
-  fun `updateContactDetails - offender not found - returns 404 and does not call ndilius`() {
+  fun `updateContactDetails - offender not registered locally - still forwards to ndilius`() {
     val crn = "X999999"
-    whenever(offenderRepository.findByCrn(crn)).thenReturn(Optional.empty())
     val request = ContactDetailsUpdateRequest(practitionerId = "AUTH_USER", mobile = "07700900123", email = null)
+    val response = ContactDetailsUpdateResponse(crn = "X999999", mobile = request.mobile, email = request.email)
+    whenever(ndiliusApiClient.updateContactDetails("X999999", request)).thenReturn(response)
 
     val binding = BeanPropertyBindingResult(request, "request")
     val result = resource.updateContactDetails(crn, request, binding)
 
-    assertEquals(HttpStatus.NOT_FOUND, result.statusCode)
-    verify(ndiliusApiClient, times(0)).updateContactDetails(any(), any())
+    assertEquals(HttpStatus.OK, result.statusCode)
+    assertEquals(response, result.body)
+    verify(ndiliusApiClient).updateContactDetails(eq("X999999"), eq(request))
   }
 
   @Test
   fun `updateContactDetails - CRN not found in ndilius - propagates 404`() {
-    val offender = createOffender(UUID.randomUUID(), OffenderStatus.VERIFIED)
-    whenever(offenderRepository.findByCrn(offender.crn)).thenReturn(Optional.of(offender))
     val crn = "x123456"
     val request = ContactDetailsUpdateRequest(practitionerId = "AUTH_USER", mobile = "07700900123", email = null)
     whenever(ndiliusApiClient.updateContactDetails("X123456", request)).thenThrow(
@@ -967,14 +1056,13 @@ class OffenderResourceTest {
 
   @Test
   fun `updateContactDetails - validation error - returns 400`() {
-    val offender = createOffender(UUID.randomUUID(), OffenderStatus.VERIFIED)
     val request = ContactDetailsUpdateRequest(practitionerId = "AUTH_USER", mobile = "07700900123", email = "not-an-email")
     val binding = BeanPropertyBindingResult(request, "request").apply {
       rejectValue("email", "Email", "must be a well-formed email address")
     }
 
     val exception = assertThrows(ResponseStatusException::class.java) {
-      resource.updateContactDetails(offender.crn, request, binding)
+      resource.updateContactDetails("X123456", request, binding)
     }
 
     assertEquals(HttpStatus.BAD_REQUEST, exception.statusCode)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderResourceTest.kt
@@ -938,7 +938,6 @@ class OffenderResourceTest {
   // Practitioner Details Lookup Tests
   // ========================================
 
-
   @Test
   fun `getPractitionerDetailsByCrn - happy path - returns practitioner without requiring local offender`() {
     val crn = "x123456"


### PR DESCRIPTION
During testing I noticed that I had inadvertently scoped the endpoints to only include PoPs who were already signed up to online check ins. During the sign up process we need to access and update this data before they are signed up. 

Before this PR, the POP and practitioner details were made available via the /case/{crn} endpoint however that endpoint is wholly scoped to users who are signed up for check ins. Extracting both the personal details and practitioner details into their own endpoints now makes more sense.

- GET Personal details by CRN 
  A new GET /v2/offenders/crn/{crn}/personal-details endpoint, which retrieves the details from NDelius, but doesn't require the PoP to be set up for online check ins yet. 

- Probation practitioner by CRN 
  A new GET /v2/offenders/crn/{crn}/practitioner-details, which retrieves the details from NDelius, but doesn't require the PoP to be set up for online check ins yet like the one above.

- Update contact details by CRN
  Updates to the PUT /v2/offenders/crn/{crn}/contact-details endpoint. Previously this was only scoped to POPs who were already signed up. We now access this data straight from NDelius without restriction on who is set up for check ins.
