### PR TITLE
Header endpoint fixes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderResource.kt
@@ -199,7 +199,7 @@ class OffenderResource(
   @PreAuthorize("hasRole('ROLE_ESUPERVISION__ESUPERVISION_UI')")
   @Operation(
     summary = "Get offender header by CRN",
-    description = "Returns offender header details. Returns 404 if not found.",
+    description = "Returns offender header details straight from NDelius. Returns 404 if not found.",
   )
   @ApiResponse(responseCode = "200", description = "Offender found")
   @ApiResponse(responseCode = "404", description = "Offender not found")
@@ -207,15 +207,9 @@ class OffenderResource(
   fun getOffenderHeaderByCrn(
     @Parameter(description = "Case Reference Number", required = true) @PathVariable crn: String,
   ): ResponseEntity<OffenderHeaderDetails> {
-    val offender = offenderRepository.findByCrn(crn.trim().uppercase()).orElse(null)
-    if (offender == null) {
-      LOGGER.info("Offender not found for crn={}", crn)
-      return ResponseEntity.notFound().build()
-    }
-
     val headerDetails = offenderService.getHeaderDetails(crn.trim().uppercase())
 
-    LOGGER.info("Retrieved header details for offender by CRN: crn={}, status={}", offender.crn, offender.status)
+    LOGGER.info("Retrieved header details for offender by CRN: crn={}", crn)
     return ResponseEntity.ok(headerDetails)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderService.kt
@@ -6,14 +6,14 @@ import org.springframework.stereotype.Service
 import org.springframework.web.server.ResponseStatusException
 import uk.gov.justice.digital.hmpps.esupervisionapi.utils.logger
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.INdiliusApiClient
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.arns.ArnsApiClient
-import uk.gov.justice.digital.hmpps.esupervisionapi.v2.tier.TierApiClient
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.arns.IArnsApiClient
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.tier.ITierApiClient
 
 @Service
 class OffenderService(
   private val ndiliusApiClient: INdiliusApiClient,
-  private val tierApiClient: TierApiClient,
-  private val arnsApiClient: ArnsApiClient,
+  private val tierApiClient: ITierApiClient,
+  private val arnsApiClient: IArnsApiClient,
   @Value("\${api.base.url.tier-api}") val tierApiBaseUri: String,
 ) {
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderResourceTest.kt
@@ -847,21 +847,21 @@ class OffenderResourceTest {
   }
 
   @Test
-  fun `getOffenderHeaderByCrn - success`() {
-    val offender = createOffender(UUID.randomUUID(), OffenderStatus.VERIFIED)
-    whenever(offenderRepository.findByCrn(offender.crn)).thenReturn(Optional.of(offender))
+  fun `getOffenderHeaderByCrn - success - does not require local offender`() {
+    val crn = "X123456"
 
     val headerDetails = OffenderHeaderDetails(
-      crn = offender.crn,
+      crn = crn,
       dateOfBirth = LocalDate.of(1980, 1, 1),
       tierScore = "D2",
-      tierDetailsLink = "https://tier.link/$offender.crn",
+      tierDetailsLink = "https://tier.link/$crn",
       overallRisk = "VERY_HIGH",
     )
-    whenever(offenderService.getHeaderDetails(offender.crn)).thenAnswer { headerDetails }
+    whenever(offenderService.getHeaderDetails(crn)).thenAnswer { headerDetails }
 
-    val result = resource.getOffenderHeaderByCrn(offender.crn)
-    verify(offenderService, times(1)).getHeaderDetails(offender.crn)
+    val result = resource.getOffenderHeaderByCrn(crn)
+    verify(offenderService, times(1)).getHeaderDetails(crn)
+    verify(offenderRepository, times(0)).findByCrn(any())
     assertNotNull(result.body)
     assertEquals(headerDetails.crn, result.body?.crn)
     assertEquals(headerDetails.dateOfBirth, result.body?.dateOfBirth)
@@ -871,32 +871,21 @@ class OffenderResourceTest {
   }
 
   @Test
-  fun `getOffenderHeaderByCrn - offender not found - returns 404`() {
+  fun `getOffenderHeaderByCrn - crn not found in ndelius - propagates 404`() {
     val crn = "Y124365"
-    whenever(offenderRepository.findByCrn(crn)).thenReturn(Optional.empty())
-
-    val result = resource.getOffenderHeaderByCrn(crn)
-    assertEquals(HttpStatus.NOT_FOUND, result.statusCode)
-  }
-
-  @Test
-  fun `getOffenderHeaderByCrn - offenderService failure`() {
-    val offender = createOffender(UUID.randomUUID(), OffenderStatus.VERIFIED)
-    whenever(offenderRepository.findByCrn(offender.crn)).thenReturn(Optional.of(offender))
-
-    whenever(offenderService.getHeaderDetails(offender.crn)).thenAnswer {
+    whenever(offenderService.getHeaderDetails(crn)).thenAnswer {
       throw ResponseStatusException(
         HttpStatus.NOT_FOUND,
-        "Could not verify contact details in NDelius for ${offender.crn}.",
+        "Could not verify contact details in NDelius for $crn.",
       )
     }
 
     val exception = assertThrows(ResponseStatusException::class.java) {
-      val result = resource.getOffenderHeaderByCrn(offender.crn)
+      resource.getOffenderHeaderByCrn(crn)
     }
 
     assertEquals(HttpStatus.NOT_FOUND, exception.statusCode)
-    assertEquals("Could not verify contact details in NDelius for ${offender.crn}.", exception.reason)
+    assertEquals("Could not verify contact details in NDelius for $crn.", exception.reason)
   }
 
   // ========================================


### PR DESCRIPTION
- Remove header endpoint's restriction to only show POPs who have been signed up to online check ins and update tests.
- Use the ITierApiClient/IArnsApiClient interfaces (instead of the concrete TierApiClient/ArnsApiClient classes) in OffenderService, so the stubtier/stubarns profiles are wired in for local testing.
