### PR TITLE
ESUP-2057: add telemetry service and emit events with job results

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/TelemetryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/TelemetryService.kt
@@ -42,8 +42,8 @@ class TelemetryServiceImpl(
     )
     telemetryClient.trackEvent(
       event.name,
-      event.properties.filterValues { it != null },
-      event.metrics.filterValues { it != null },
+      event.properties.filterValues { it != null }.mapValues { it.value!! }.toMutableMap(),
+      event.metrics.filterValues { it != null }.mapValues { it.value!! }.toMutableMap(),
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/TelemetryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/TelemetryService.kt
@@ -1,0 +1,62 @@
+package uk.gov.justice.digital.hmpps.esupervisionapi.v2
+
+import com.microsoft.applicationinsights.TelemetryClient
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Profile
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Service
+import org.springframework.web.util.UriUtils
+import uk.gov.justice.digital.hmpps.esupervisionapi.utils.logger
+import java.nio.charset.Charset
+
+enum class TelemetryEvent(val label: String) {
+  IMAGE_RETENTION_JOB_RESULTS("ImageRetentionJobResults"),
+}
+
+interface TelemetryService {
+  fun trackEvent(event: Event)
+
+  data class Event(
+    val name: String,
+    val properties: Map<String, String?>,
+    val metrics: Map<String, Double?>,
+  )
+}
+
+@Profile("!local & !test")
+@Service
+class TelemetryServiceImpl(
+  private val telemetryClient: TelemetryClient = TelemetryClient(),
+) : TelemetryService {
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+  }
+
+  @Async
+  override fun trackEvent(event: TelemetryService.Event) {
+    log.debug(
+      "{} {} {}",
+      UriUtils.encode(event.name, Charset.defaultCharset()),
+      UriUtils.encode(event.properties.toString(), Charset.defaultCharset()),
+      UriUtils.encode(event.metrics.toString(), Charset.defaultCharset()),
+    )
+    telemetryClient.trackEvent(
+      event.name,
+      event.properties.filterValues { it != null },
+      event.metrics.filterValues { it != null },
+    )
+  }
+}
+
+@Profile("local | test")
+@Service
+class NoopTelemetryService : TelemetryService {
+  @Async
+  override fun trackEvent(event: TelemetryService.Event) {
+    LOG.debug("Telemetry event: {}", event)
+  }
+
+  companion object {
+    private val LOG = logger<NoopTelemetryService>()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/CheckinImageRetentionJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/CheckinImageRetentionJob.kt
@@ -12,6 +12,8 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.JobLog
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.JobLogRepository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckin
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinRepository
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.TelemetryEvent
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.TelemetryService
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.audit.EventAuditService
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ManualIdVerificationResult
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.infrastructure.storage.S3UploadService
@@ -40,6 +42,7 @@ class CheckinImageRetentionJob(
   private val jobLogRepository: JobLogRepository,
   private val transactionTemplate: TransactionTemplate,
   private val eventAuditService: EventAuditService,
+  private val telemetryService: TelemetryService,
   @Value("\${app.scheduling.checkin-image-retention.standard-retention-days:28}")
   private val standardRetentionDays: Long,
   @Value("\${app.scheduling.checkin-image-retention.concern-retention-days:2192}")
@@ -108,8 +111,19 @@ class CheckinImageRetentionJob(
       concernStats.failed,
       Duration.between(now, ended),
     )
+    telemetryService.trackEvent(
+      TelemetryService.Event(
+        name = TelemetryEvent.IMAGE_RETENTION_JOB_RESULTS.label,
+        properties = mapOf(),
+        metrics = mapOf(
+          "assessed" to (standardStats.assessed + concernStats.assessed).toDouble(),
+          "deleted" to (standardStats.deleted + concernStats.deleted).toDouble(),
+          "failed" to totalFailed.toDouble(),
+        ),
+      ),
+    )
     if (totalFailed > 0) {
-      LOGGER.error(
+      LOGGER.warn(
         "V2 Checkin Image Retention Job(id={}) had {} failed image deletion(s) - see preceding warnings",
         logEntry.id,
         totalFailed,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/CheckinImageRetentionJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/jobs/CheckinImageRetentionJobTest.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.esupervisionapi.v2.JobLogRepository
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.Offender
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckin
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.OffenderCheckinRepository
+import uk.gov.justice.digital.hmpps.esupervisionapi.v2.TelemetryService
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.audit.EventAuditService
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.CheckinInterval
 import uk.gov.justice.digital.hmpps.esupervisionapi.v2.domain.ContactPreference
@@ -47,6 +48,7 @@ class CheckinImageRetentionJobTest {
     }
   }
   private val eventAuditService: EventAuditService = mock()
+  private val telemetryService: TelemetryService = mock()
 
   private val job = CheckinImageRetentionJob(
     clock,
@@ -55,6 +57,7 @@ class CheckinImageRetentionJobTest {
     jobLogRepository,
     transactionTemplate,
     eventAuditService,
+    telemetryService,
     28L,
     2192L,
     100,


### PR DESCRIPTION
Adds a service that sends data to Application Insights. Additionally, to test it out we emit a custom event containing image retention job results. 