### PR TITLE
ESUP-1920 Use NOT_FOUND when no overalRisk

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/arns/ArnsApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/arns/ArnsApiClient.kt
@@ -67,7 +67,7 @@ data class ArnsWidget(
   val riskInCustody: RiskInSituation,
 ) {
   constructor() : this(
-    "NOT_FOUND",
+    null,
     null,
     RiskInSituation(),
     RiskInSituation(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/esupervisionapi/v2/offender/OffenderService.kt
@@ -64,7 +64,7 @@ class OffenderService(
       dateOfBirth = contactDetails.dateOfBirth,
       tierScore = tierDetails.tierScore,
       tierDetailsLink = "$tierUiBaseUri/case/$crn",
-      overallRisk = arnsWidget.overallRisk ?: "NONE",
+      overallRisk = arnsWidget.overallRisk ?: "NOT_FOUND",
     )
   }
 


### PR DESCRIPTION
ESUP-1920 Use NOT_FOUND when no overalRisk
The fix to use `NONE` in #346 should have used `NOT_FOUND` instead